### PR TITLE
[PR] [FEAT] 钱包基础数据模型

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.env
+*.log
+*.pid
+*.db
+*.sqlite
+*.sqlite3
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+.venv/
+venv/
+.DS_Store

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+SQLAlchemy==2.0.36
+pytest==8.3.3

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Finance system source package."""

--- a/src/database.py
+++ b/src/database.py
@@ -1,0 +1,42 @@
+"""Database configuration and initialization helpers."""
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
+
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./finance.db")
+
+
+class Base(DeclarativeBase):
+    """Base class for SQLAlchemy ORM models."""
+
+
+def _connect_args(database_url: str) -> dict:
+    if database_url.startswith("sqlite"):
+        return {"check_same_thread": False}
+    return {}
+
+
+engine = create_engine(DATABASE_URL, connect_args=_connect_args(DATABASE_URL))
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
+def init_db() -> None:
+    """Create all database tables used by the finance system."""
+    # Import models so their metadata is registered before create_all runs.
+    from src.models import wallet  # noqa: F401
+
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db() -> Iterator[Session]:
+    """Yield a database session for future FastAPI dependencies."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,1 @@
+"""SQLAlchemy ORM models."""

--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -1,0 +1,176 @@
+"""Wallet models and balance movement helpers."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, func, select
+from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
+
+from src.database import Base
+
+
+class WalletType(str, Enum):
+    ASSET_RMB = "ASSET_RMB"
+    ASSET_USDT = "ASSET_USDT"
+    VENDOR = "VENDOR"
+    XBOX = "XBOX"
+    TAOBAO = "TAOBAO"
+    TAIWAN = "TAIWAN"
+
+
+class Currency(str, Enum):
+    CNY = "CNY"
+    USDT = "USDT"
+    USD = "USD"
+    GBP = "GBP"
+    TWD = "TWD"
+
+
+class TransactionDirection(str, Enum):
+    IN = "in"
+    OUT = "out"
+
+
+class Wallet(Base):
+    __tablename__ = "wallets"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    type: Mapped[WalletType] = mapped_column(String(32), nullable=False)
+    currency: Mapped[Currency] = mapped_column(String(16), nullable=False)
+    balance: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False, default=Decimal("0"))
+    parent_id: Mapped[Optional[int]] = mapped_column(ForeignKey("wallets.id"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    parent: Mapped[Optional["Wallet"]] = relationship(
+        remote_side=[id],
+        back_populates="children",
+    )
+    children: Mapped[list["Wallet"]] = relationship(back_populates="parent")
+    transactions: Mapped[list["WalletTransaction"]] = relationship(
+        back_populates="wallet",
+        cascade="all, delete-orphan",
+    )
+
+
+class WalletTransaction(Base):
+    __tablename__ = "wallet_transactions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id"), nullable=False, index=True)
+    amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    direction: Mapped[TransactionDirection] = mapped_column(String(8), nullable=False)
+    remark: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    wallet: Mapped[Wallet] = relationship(back_populates="transactions")
+
+
+def _to_decimal(amount: Decimal | int | float | str) -> Decimal:
+    value = Decimal(str(amount))
+    if value <= 0:
+        raise ValueError("amount must be greater than zero")
+    return value
+
+
+def get_wallet(session: Session, wallet_id: int) -> Wallet:
+    wallet = session.get(Wallet, wallet_id)
+    if wallet is None:
+        raise ValueError(f"wallet {wallet_id} does not exist")
+    return wallet
+
+
+def create_wallet(
+    session: Session,
+    *,
+    name: str,
+    wallet_type: WalletType | str,
+    currency: Currency | str,
+    parent_id: int | None = None,
+    opening_balance: Decimal | int | float | str = Decimal("0"),
+) -> Wallet:
+    """Create a wallet or sub-wallet and flush it into the current session."""
+    balance = Decimal(str(opening_balance))
+    if balance < 0:
+        raise ValueError("opening_balance cannot be negative")
+    if parent_id is not None:
+        get_wallet(session, parent_id)
+
+    wallet = Wallet(
+        name=name,
+        type=WalletType(wallet_type),
+        currency=Currency(currency),
+        parent_id=parent_id,
+        balance=balance,
+    )
+    session.add(wallet)
+    session.flush()
+    return wallet
+
+
+def credit(
+    session: Session,
+    wallet_id: int,
+    amount: Decimal | int | float | str,
+    remark: str | None = None,
+) -> WalletTransaction:
+    """Increase a wallet balance and create an inbound transaction record."""
+    value = _to_decimal(amount)
+    wallet = get_wallet(session, wallet_id)
+    wallet.balance = Decimal(wallet.balance) + value
+
+    transaction = WalletTransaction(
+        wallet_id=wallet_id,
+        amount=value,
+        direction=TransactionDirection.IN,
+        remark=remark,
+    )
+    session.add(transaction)
+    session.flush()
+    return transaction
+
+
+def debit(
+    session: Session,
+    wallet_id: int,
+    amount: Decimal | int | float | str,
+    remark: str | None = None,
+) -> WalletTransaction:
+    """Decrease a wallet balance and create an outbound transaction record."""
+    value = _to_decimal(amount)
+    wallet = get_wallet(session, wallet_id)
+    if Decimal(wallet.balance) < value:
+        raise ValueError("insufficient wallet balance")
+
+    wallet.balance = Decimal(wallet.balance) - value
+    transaction = WalletTransaction(
+        wallet_id=wallet_id,
+        amount=value,
+        direction=TransactionDirection.OUT,
+        remark=remark,
+    )
+    session.add(transaction)
+    session.flush()
+    return transaction
+
+
+def list_transactions(session: Session, wallet_id: int) -> list[WalletTransaction]:
+    get_wallet(session, wallet_id)
+    return list(
+        session.scalars(
+            select(WalletTransaction)
+            .where(WalletTransaction.wallet_id == wallet_id)
+            .order_by(WalletTransaction.id)
+        )
+    )

--- a/tests/test_wallet.py
+++ b/tests/test_wallet.py
@@ -1,0 +1,106 @@
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import create_engine, inspect
+from sqlalchemy.orm import sessionmaker
+
+from src.database import Base
+from src.models.wallet import (
+    Currency,
+    TransactionDirection,
+    Wallet,
+    WalletTransaction,
+    WalletType,
+    create_wallet,
+    credit,
+    debit,
+    list_transactions,
+)
+
+
+@pytest.fixture()
+def session():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = session_factory()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def test_wallet_tables_are_registered():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+
+    tables = set(inspect(engine).get_table_names())
+    assert {"wallets", "wallet_transactions"}.issubset(tables)
+
+
+def test_create_parent_and_sub_wallet(session):
+    parent = create_wallet(
+        session,
+        name="RMB Main",
+        wallet_type=WalletType.ASSET_RMB,
+        currency=Currency.CNY,
+    )
+    child = create_wallet(
+        session,
+        name="RMB Sub",
+        wallet_type="ASSET_RMB",
+        currency="CNY",
+        parent_id=parent.id,
+    )
+    session.commit()
+
+    saved_child = session.get(Wallet, child.id)
+    assert saved_child.parent_id == parent.id
+    assert saved_child.parent.name == "RMB Main"
+    assert saved_child.balance == Decimal("0.000000")
+
+
+def test_credit_and_debit_create_transactions(session):
+    wallet = create_wallet(
+        session,
+        name="USDT Main",
+        wallet_type=WalletType.ASSET_USDT,
+        currency=Currency.USDT,
+    )
+
+    incoming = credit(session, wallet.id, "150.25", "initial deposit")
+    outgoing = debit(session, wallet.id, Decimal("20.25"), "vendor payout")
+    session.commit()
+
+    saved_wallet = session.get(Wallet, wallet.id)
+    assert saved_wallet.balance == Decimal("130.000000")
+    assert incoming.direction == TransactionDirection.IN
+    assert outgoing.direction == TransactionDirection.OUT
+
+    transactions = list_transactions(session, wallet.id)
+    assert [item.amount for item in transactions] == [Decimal("150.250000"), Decimal("20.250000")]
+    assert session.query(WalletTransaction).count() == 2
+
+
+def test_debit_rejects_insufficient_balance(session):
+    wallet = create_wallet(
+        session,
+        name="Taiwan Wallet",
+        wallet_type=WalletType.TAIWAN,
+        currency=Currency.TWD,
+    )
+
+    with pytest.raises(ValueError, match="insufficient"):
+        debit(session, wallet.id, 1)
+
+
+def test_amount_must_be_positive(session):
+    wallet = create_wallet(
+        session,
+        name="Vendor Wallet",
+        wallet_type=WalletType.VENDOR,
+        currency=Currency.CNY,
+    )
+
+    with pytest.raises(ValueError, match="greater than zero"):
+        credit(session, wallet.id, 0)


### PR DESCRIPTION
## 关联 Issue
Closes #3

## 改动说明
- 新增 SQLAlchemy + SQLite 数据库基础层 `src/database.py`
- 新增 Wallet / WalletTransaction ORM 模型
- 支持钱包 type: ASSET_RMB / ASSET_USDT / VENDOR / XBOX / TAOBAO / TAIWAN
- 支持 currency: CNY / USDT / USD / GBP / TWD
- 支持 parent_id 父子钱包关系
- 新增 credit / debit / create_wallet / list_transactions 工具函数
- 新增测试覆盖表创建、父子钱包、入账、出账、余额校验和非法金额

## 自测情况
- [x] python3 -m pytest -q
- [x] python3 -m compileall -q src tests
- [x] git diff --check
- [x] 满足 Issue 中的验收标准

---
> 请 Claude PM 审查