### PR TITLE
[PR] [FEAT] 资产钱包 API

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 SQLAlchemy==2.0.36
+fastapi==0.115.0
+httpx==0.27.2
 pytest==8.3.3
+uvicorn==0.30.6

--- a/src/database.py
+++ b/src/database.py
@@ -25,6 +25,15 @@ engine = create_engine(DATABASE_URL, connect_args=_connect_args(DATABASE_URL))
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 
 
+def configure_database(database_url: str) -> None:
+    """Reconfigure the database connection, mainly for isolated tests."""
+    global DATABASE_URL, SessionLocal, engine
+
+    DATABASE_URL = database_url
+    engine = create_engine(DATABASE_URL, connect_args=_connect_args(DATABASE_URL))
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+
 def init_db() -> None:
     """Create all database tables used by the finance system."""
     # Import models so their metadata is registered before create_all runs.

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,31 @@
+"""Finance system API application."""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from src import database
+from src.routers.assets import router as assets_router
+from src.services.assets import ensure_default_asset_wallets
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    yield
+
+
+app = FastAPI(title="Finance System API", lifespan=lifespan)
+app.include_router(assets_router)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI routers."""

--- a/src/routers/assets.py
+++ b/src/routers/assets.py
@@ -1,0 +1,159 @@
+"""Asset wallet API routes."""
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.wallet import Wallet, credit, debit, list_transactions
+from src.services.assets import create_asset_sub_wallet, is_asset_wallet, list_asset_wallets
+
+
+router = APIRouter(prefix="/wallets/assets", tags=["asset-wallets"])
+
+
+class SubWalletCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+
+
+class WalletMovementRequest(BaseModel):
+    amount: Decimal = Field(..., gt=0)
+    remark: Optional[str] = Field(None, max_length=500)
+
+
+class WalletOut(BaseModel):
+    id: int
+    name: str
+    type: str
+    currency: str
+    balance: Decimal
+    parent_id: Optional[int]
+    created_at: str
+
+
+class AssetWalletOut(WalletOut):
+    children: list[WalletOut] = []
+
+
+class TransactionOut(BaseModel):
+    id: int
+    wallet_id: int
+    amount: Decimal
+    direction: str
+    remark: Optional[str]
+    created_at: str
+
+
+def _value(value):
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def serialize_wallet(wallet: Wallet) -> WalletOut:
+    return WalletOut(
+        id=wallet.id,
+        name=wallet.name,
+        type=_value(wallet.type),
+        currency=_value(wallet.currency),
+        balance=wallet.balance,
+        parent_id=wallet.parent_id,
+        created_at=wallet.created_at.isoformat() if wallet.created_at else "",
+    )
+
+
+def serialize_transaction(transaction) -> TransactionOut:
+    return TransactionOut(
+        id=transaction.id,
+        wallet_id=transaction.wallet_id,
+        amount=transaction.amount,
+        direction=_value(transaction.direction),
+        remark=transaction.remark,
+        created_at=transaction.created_at.isoformat() if transaction.created_at else "",
+    )
+
+
+def get_asset_wallet_or_404(session: Session, wallet_id: int) -> Wallet:
+    wallet = session.get(Wallet, wallet_id)
+    if wallet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="资产钱包不存在")
+    if not is_asset_wallet(wallet):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="该钱包不是资产钱包")
+    return wallet
+
+
+@router.get("", response_model=list[AssetWalletOut])
+def list_assets(db: Session = Depends(get_db)) -> list[AssetWalletOut]:
+    wallets = list_asset_wallets(db)
+    children_by_parent: dict[int, list[WalletOut]] = {}
+    roots: list[Wallet] = []
+
+    for wallet in wallets:
+        if wallet.parent_id is None:
+            roots.append(wallet)
+        else:
+            children_by_parent.setdefault(wallet.parent_id, []).append(serialize_wallet(wallet))
+
+    return [
+        AssetWalletOut(
+            **serialize_wallet(root).model_dump(),
+            children=children_by_parent.get(root.id, []),
+        )
+        for root in roots
+    ]
+
+
+@router.post("/{wallet_id}/sub", response_model=WalletOut, status_code=status.HTTP_201_CREATED)
+def create_sub_wallet(
+    wallet_id: int,
+    request: SubWalletCreate,
+    db: Session = Depends(get_db),
+) -> WalletOut:
+    parent = get_asset_wallet_or_404(db, wallet_id)
+    sub_wallet = create_asset_sub_wallet(db, parent, request.name)
+    db.commit()
+    db.refresh(sub_wallet)
+    return serialize_wallet(sub_wallet)
+
+
+@router.post("/{wallet_id}/credit", response_model=TransactionOut, status_code=status.HTTP_201_CREATED)
+def credit_asset_wallet(
+    wallet_id: int,
+    request: WalletMovementRequest,
+    db: Session = Depends(get_db),
+) -> TransactionOut:
+    get_asset_wallet_or_404(db, wallet_id)
+    transaction = credit(db, wallet_id, request.amount, request.remark)
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(transaction)
+
+
+@router.post("/{wallet_id}/debit", response_model=TransactionOut, status_code=status.HTTP_201_CREATED)
+def debit_asset_wallet(
+    wallet_id: int,
+    request: WalletMovementRequest,
+    db: Session = Depends(get_db),
+) -> TransactionOut:
+    get_asset_wallet_or_404(db, wallet_id)
+    try:
+        transaction = debit(db, wallet_id, request.amount, request.remark)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(transaction)
+
+
+@router.get("/{wallet_id}/transactions", response_model=list[TransactionOut])
+def get_asset_wallet_transactions(
+    wallet_id: int,
+    db: Session = Depends(get_db),
+) -> list[TransactionOut]:
+    get_asset_wallet_or_404(db, wallet_id)
+    return [serialize_transaction(transaction) for transaction in list_transactions(db, wallet_id)]

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,1 @@
+"""Business service helpers."""

--- a/src/services/assets.py
+++ b/src/services/assets.py
@@ -1,0 +1,72 @@
+"""Asset wallet service functions."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import Currency, Wallet, WalletType, create_wallet
+
+
+ASSET_TYPES = {WalletType.ASSET_RMB.value, WalletType.ASSET_USDT.value}
+DEFAULT_ASSET_WALLETS = (
+    {
+        "name": "RMB Main",
+        "wallet_type": WalletType.ASSET_RMB,
+        "currency": Currency.CNY,
+    },
+    {
+        "name": "USDT Main",
+        "wallet_type": WalletType.ASSET_USDT,
+        "currency": Currency.USDT,
+    },
+)
+
+
+def ensure_default_asset_wallets(session: Session) -> None:
+    """Create RMB and USDT root asset wallets if they do not already exist."""
+    for config in DEFAULT_ASSET_WALLETS:
+        exists = session.scalar(
+            select(Wallet).where(
+                Wallet.type == config["wallet_type"].value,
+                Wallet.currency == config["currency"].value,
+                Wallet.parent_id.is_(None),
+            )
+        )
+        if exists is None:
+            create_wallet(
+                session,
+                name=config["name"],
+                wallet_type=config["wallet_type"],
+                currency=config["currency"],
+            )
+    session.flush()
+
+
+def is_asset_wallet(wallet: Wallet) -> bool:
+    wallet_type = wallet.type.value if isinstance(wallet.type, WalletType) else wallet.type
+    return wallet_type in ASSET_TYPES
+
+
+def list_asset_wallets(session: Session) -> list[Wallet]:
+    return list(
+        session.scalars(
+            select(Wallet)
+            .where(Wallet.type.in_(ASSET_TYPES))
+            .order_by(Wallet.parent_id.is_not(None), Wallet.id)
+        )
+    )
+
+
+def create_asset_sub_wallet(session: Session, parent: Wallet, name: str) -> Wallet:
+    if not is_asset_wallet(parent):
+        raise ValueError("parent wallet is not an asset wallet")
+    return create_wallet(
+        session,
+        name=name,
+        wallet_type=parent.type.value if isinstance(parent.type, WalletType) else parent.type,
+        currency=parent.currency.value if isinstance(parent.currency, Currency) else parent.currency,
+        parent_id=parent.id,
+        opening_balance=Decimal("0"),
+    )

--- a/tests/test_assets_api.py
+++ b/tests/test_assets_api.py
@@ -1,0 +1,90 @@
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'assets.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def test_default_asset_wallets_are_listed(client):
+    response = client.get("/wallets/assets")
+
+    assert response.status_code == 200, response.text
+    wallets = response.json()
+    names = {wallet["name"] for wallet in wallets}
+    assert {"RMB Main", "USDT Main"}.issubset(names)
+    assert {wallet["currency"] for wallet in wallets} == {"CNY", "USDT"}
+    assert all(wallet["parent_id"] is None for wallet in wallets)
+
+
+def test_create_sub_wallet_inherits_type_and_currency(client):
+    root = client.get("/wallets/assets").json()[0]
+
+    response = client.post(f"/wallets/assets/{root['id']}/sub", json={"name": "Operations"})
+
+    assert response.status_code == 201, response.text
+    sub_wallet = response.json()
+    assert sub_wallet["name"] == "Operations"
+    assert sub_wallet["type"] == root["type"]
+    assert sub_wallet["currency"] == root["currency"]
+    assert sub_wallet["parent_id"] == root["id"]
+
+    wallets = client.get("/wallets/assets").json()
+    updated_root = next(wallet for wallet in wallets if wallet["id"] == root["id"])
+    assert updated_root["children"][0]["name"] == "Operations"
+
+
+def test_credit_debit_and_transactions(client):
+    root = client.get("/wallets/assets").json()[0]
+
+    response = client.post(
+        f"/wallets/assets/{root['id']}/credit",
+        json={"amount": "100.50", "remark": "initial deposit"},
+    )
+    assert response.status_code == 201, response.text
+    assert response.json()["direction"] == "in"
+
+    response = client.post(
+        f"/wallets/assets/{root['id']}/debit",
+        json={"amount": "40.25", "remark": "payment"},
+    )
+    assert response.status_code == 201, response.text
+    assert response.json()["direction"] == "out"
+
+    transactions = client.get(f"/wallets/assets/{root['id']}/transactions").json()
+    assert [item["direction"] for item in transactions] == ["in", "out"]
+    assert [Decimal(item["amount"]) for item in transactions] == [
+        Decimal("100.500000"),
+        Decimal("40.250000"),
+    ]
+
+    refreshed = client.get("/wallets/assets").json()
+    wallet = next(item for item in refreshed if item["id"] == root["id"])
+    assert Decimal(wallet["balance"]) == Decimal("60.250000")
+
+
+def test_debit_rejects_insufficient_balance(client):
+    root = client.get("/wallets/assets").json()[0]
+
+    response = client.post(
+        f"/wallets/assets/{root['id']}/debit",
+        json={"amount": "1", "remark": "too much"},
+    )
+
+    assert response.status_code == 400
+    assert "insufficient" in response.json()["detail"]


### PR DESCRIPTION
## 关联 Issue
Closes #4

## 依赖
- 依赖钱包基础模型 PR #9，当前 PR base 为 `feature/issue-3`

## 改动说明
- 新增 FastAPI 应用入口 `src/main.py`
- 新增资产钱包路由 `src/routers/assets.py`
- 启动时自动初始化 RMB Main(CNY) 和 USDT Main(USDT) 主资产钱包
- 支持创建资产子钱包，并继承父钱包 type/currency
- 支持资产钱包 credit / debit / transactions API
- debit 会校验余额不足并返回 400
- 新增测试覆盖默认主钱包、子钱包、入账、出账、流水和余额不足

## 自测情况
- [x] python3 -m pytest -q
- [x] python3 -m compileall -q src tests
- [x] git diff --check
- [x] 满足 Issue 中的验收标准

---
> 请 Claude PM 审查