### PR TITLE
[PR] [FEAT] 供应商往来账

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -38,6 +38,7 @@ def init_db() -> None:
     """Create all database tables used by the finance system."""
     # Import models so their metadata is registered before create_all runs.
     from src.models import wallet  # noqa: F401
+    from src.models import vendor  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
 

--- a/src/main.py
+++ b/src/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 
 from src import database
 from src.routers.assets import router as assets_router
+from src.routers.vendors import router as vendors_router
 from src.services.assets import ensure_default_asset_wallets
 
 
@@ -24,6 +25,7 @@ async def lifespan(_: FastAPI):
 
 app = FastAPI(title="Finance System API", lifespan=lifespan)
 app.include_router(assets_router)
+app.include_router(vendors_router)
 
 
 @app.get("/health")

--- a/src/models/vendor.py
+++ b/src/models/vendor.py
@@ -1,0 +1,63 @@
+"""Vendor and vendor bill ORM models."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.database import Base
+
+
+class VendorBillDirection(str, Enum):
+    PAYABLE = "payable"
+    RECEIVABLE = "receivable"
+
+
+class VendorBillStatus(str, Enum):
+    PENDING = "pending"
+    SETTLED = "settled"
+
+
+class Vendor(Base):
+    __tablename__ = "vendors"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    bills: Mapped[list["VendorBill"]] = relationship(
+        back_populates="vendor",
+        cascade="all, delete-orphan",
+    )
+
+
+class VendorBill(Base):
+    __tablename__ = "vendor_bills"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    vendor_id: Mapped[int] = mapped_column(ForeignKey("vendors.id"), nullable=False, index=True)
+    direction: Mapped[VendorBillDirection] = mapped_column(String(16), nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    status: Mapped[VendorBillStatus] = mapped_column(
+        String(16),
+        nullable=False,
+        default=VendorBillStatus.PENDING.value,
+    )
+    due_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    vendor: Mapped[Vendor] = relationship(back_populates="bills")

--- a/src/routers/vendors.py
+++ b/src/routers/vendors.py
@@ -1,0 +1,162 @@
+"""Vendor payable and receivable API routes."""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.vendor import Vendor, VendorBill, VendorBillDirection, VendorBillStatus
+
+
+router = APIRouter(prefix="/vendors", tags=["vendors"])
+
+
+class VendorCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    remark: Optional[str] = None
+
+
+class VendorOut(BaseModel):
+    id: int
+    name: str
+    remark: Optional[str]
+    created_at: str
+
+
+class VendorBillCreate(BaseModel):
+    direction: VendorBillDirection
+    amount: Decimal = Field(..., gt=0)
+    due_date: Optional[date] = None
+    remark: Optional[str] = None
+
+
+class VendorBillOut(BaseModel):
+    id: int
+    vendor_id: int
+    direction: str
+    amount: Decimal
+    status: str
+    due_date: Optional[str]
+    remark: Optional[str]
+    created_at: str
+
+
+class VendorSummaryOut(BaseModel):
+    payable: Decimal
+    receivable: Decimal
+    net: Decimal
+
+
+def _value(value):
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def serialize_vendor(vendor: Vendor) -> VendorOut:
+    return VendorOut(
+        id=vendor.id,
+        name=vendor.name,
+        remark=vendor.remark,
+        created_at=vendor.created_at.isoformat() if vendor.created_at else "",
+    )
+
+
+def serialize_bill(bill: VendorBill) -> VendorBillOut:
+    return VendorBillOut(
+        id=bill.id,
+        vendor_id=bill.vendor_id,
+        direction=_value(bill.direction),
+        amount=bill.amount,
+        status=_value(bill.status),
+        due_date=bill.due_date.isoformat() if bill.due_date else None,
+        remark=bill.remark,
+        created_at=bill.created_at.isoformat() if bill.created_at else "",
+    )
+
+
+def get_vendor_or_404(session: Session, vendor_id: int) -> Vendor:
+    vendor = session.get(Vendor, vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="供应商不存在")
+    return vendor
+
+
+@router.post("", response_model=VendorOut, status_code=status.HTTP_201_CREATED)
+def create_vendor(request: VendorCreate, db: Session = Depends(get_db)) -> VendorOut:
+    vendor = Vendor(name=request.name, remark=request.remark)
+    db.add(vendor)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="供应商名称已存在") from exc
+    db.refresh(vendor)
+    return serialize_vendor(vendor)
+
+
+@router.get("", response_model=list[VendorOut])
+def list_vendors(db: Session = Depends(get_db)) -> list[VendorOut]:
+    vendors = db.scalars(select(Vendor).order_by(Vendor.id)).all()
+    return [serialize_vendor(vendor) for vendor in vendors]
+
+
+@router.post("/{vendor_id}/bills", response_model=VendorBillOut, status_code=status.HTTP_201_CREATED)
+def create_vendor_bill(
+    vendor_id: int,
+    request: VendorBillCreate,
+    db: Session = Depends(get_db),
+) -> VendorBillOut:
+    get_vendor_or_404(db, vendor_id)
+    bill = VendorBill(
+        vendor_id=vendor_id,
+        direction=request.direction.value,
+        amount=request.amount,
+        due_date=request.due_date,
+        remark=request.remark,
+    )
+    db.add(bill)
+    db.commit()
+    db.refresh(bill)
+    return serialize_bill(bill)
+
+
+@router.get("/{vendor_id}/bills", response_model=list[VendorBillOut])
+def list_vendor_bills(vendor_id: int, db: Session = Depends(get_db)) -> list[VendorBillOut]:
+    get_vendor_or_404(db, vendor_id)
+    bills = db.scalars(
+        select(VendorBill).where(VendorBill.vendor_id == vendor_id).order_by(VendorBill.id)
+    ).all()
+    return [serialize_bill(bill) for bill in bills]
+
+
+@router.patch("/bills/{bill_id}/settle", response_model=VendorBillOut)
+def settle_vendor_bill(bill_id: int, db: Session = Depends(get_db)) -> VendorBillOut:
+    bill = db.get(VendorBill, bill_id)
+    if bill is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="账单不存在")
+    bill.status = VendorBillStatus.SETTLED.value
+    db.commit()
+    db.refresh(bill)
+    return serialize_bill(bill)
+
+
+@router.get("/summary", response_model=VendorSummaryOut)
+def vendor_summary(db: Session = Depends(get_db)) -> VendorSummaryOut:
+    rows = db.execute(
+        select(VendorBill.direction, func.coalesce(func.sum(VendorBill.amount), 0))
+        .where(VendorBill.status == VendorBillStatus.PENDING.value)
+        .group_by(VendorBill.direction)
+    ).all()
+    totals = {direction: Decimal(str(amount)) for direction, amount in rows}
+    payable = totals.get(VendorBillDirection.PAYABLE.value, Decimal("0"))
+    receivable = totals.get(VendorBillDirection.RECEIVABLE.value, Decimal("0"))
+    return VendorSummaryOut(payable=payable, receivable=receivable, net=receivable - payable)

--- a/tests/test_vendors_api.py
+++ b/tests/test_vendors_api.py
@@ -1,0 +1,97 @@
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'vendors.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def create_vendor(client, name="Vendor A"):
+    response = client.post("/vendors", json={"name": name, "remark": "trusted"})
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_create_and_list_vendors(client):
+    vendor = create_vendor(client)
+
+    response = client.get("/vendors")
+
+    assert response.status_code == 200, response.text
+    assert response.json()[0]["id"] == vendor["id"]
+    assert response.json()[0]["name"] == "Vendor A"
+
+
+def test_vendor_name_must_be_unique(client):
+    create_vendor(client)
+
+    response = client.post("/vendors", json={"name": "Vendor A"})
+
+    assert response.status_code == 409
+
+
+def test_create_list_and_settle_vendor_bills(client):
+    vendor = create_vendor(client)
+
+    payable = client.post(
+        f"/vendors/{vendor['id']}/bills",
+        json={
+            "direction": "payable",
+            "amount": "100.00",
+            "due_date": "2026-05-01",
+            "remark": "we owe vendor",
+        },
+    )
+    receivable = client.post(
+        f"/vendors/{vendor['id']}/bills",
+        json={"direction": "receivable", "amount": "30.00", "remark": "vendor owes us"},
+    )
+    assert payable.status_code == 201, payable.text
+    assert receivable.status_code == 201, receivable.text
+
+    bills = client.get(f"/vendors/{vendor['id']}/bills")
+    assert bills.status_code == 200, bills.text
+    assert [bill["direction"] for bill in bills.json()] == ["payable", "receivable"]
+
+    settled = client.patch(f"/vendors/bills/{payable.json()['id']}/settle")
+    assert settled.status_code == 200, settled.text
+    assert settled.json()["status"] == "settled"
+
+
+def test_summary_counts_only_pending_bills(client):
+    vendor = create_vendor(client)
+    payable = client.post(
+        f"/vendors/{vendor['id']}/bills",
+        json={"direction": "payable", "amount": "100.00"},
+    ).json()
+    client.post(
+        f"/vendors/{vendor['id']}/bills",
+        json={"direction": "receivable", "amount": "40.00"},
+    )
+
+    summary = client.get("/vendors/summary")
+    assert summary.status_code == 200, summary.text
+    assert Decimal(summary.json()["payable"]) == Decimal("100.000000")
+    assert Decimal(summary.json()["receivable"]) == Decimal("40.000000")
+    assert Decimal(summary.json()["net"]) == Decimal("-60.000000")
+
+    client.patch(f"/vendors/bills/{payable['id']}/settle")
+    summary = client.get("/vendors/summary")
+    assert Decimal(summary.json()["payable"]) == Decimal("0")
+    assert Decimal(summary.json()["receivable"]) == Decimal("40.000000")
+    assert Decimal(summary.json()["net"]) == Decimal("40.000000")


### PR DESCRIPTION
## 关联 Issue
Closes #5

## 依赖
- 依赖资产/API 基础 PR #10，当前 PR base 为 `feature/issue-4`

## 改动说明
- 新增 Vendor / VendorBill ORM 模型
- 支持 payable / receivable 两类供应商账单
- 支持 pending / settled 状态
- 新增供应商创建、列表接口
- 新增供应商账单创建、列表、结清接口
- 新增 `/vendors/summary` 汇总 pending 应付、应收、净额
- 新增测试覆盖供应商唯一性、账单、结清和汇总

## 自测情况
- [x] python3 -m pytest -q
- [x] python3 -m compileall -q src tests
- [x] git diff --check
- [x] 满足 Issue 中的验收标准

---
> 请 Claude PM 审查