### PR TITLE
[PR] [FEAT] XBOX 账户管理

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -39,6 +39,7 @@ def init_db() -> None:
     # Import models so their metadata is registered before create_all runs.
     from src.models import wallet  # noqa: F401
     from src.models import vendor  # noqa: F401
+    from src.models import xbox  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
 

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from src import database
 from src.routers.assets import router as assets_router
 from src.routers.vendors import router as vendors_router
+from src.routers.xbox import router as xbox_router
 from src.services.assets import ensure_default_asset_wallets
 
 
@@ -26,6 +27,7 @@ async def lifespan(_: FastAPI):
 app = FastAPI(title="Finance System API", lifespan=lifespan)
 app.include_router(assets_router)
 app.include_router(vendors_router)
+app.include_router(xbox_router)
 
 
 @app.get("/health")

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -1,0 +1,71 @@
+"""XBOX account and transaction ORM models."""
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.database import Base
+
+
+class XboxCountry(str, Enum):
+    US = "US"
+    UK = "UK"
+
+
+class XboxCurrency(str, Enum):
+    USD = "USD"
+    GBP = "GBP"
+
+
+class XboxTransactionType(str, Enum):
+    RECHARGE = "recharge"
+    CONSUME = "consume"
+
+
+class XboxAccount(Base):
+    __tablename__ = "xbox_accounts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    country: Mapped[XboxCountry] = mapped_column(String(8), nullable=False)
+    currency: Mapped[XboxCurrency] = mapped_column(String(8), nullable=False)
+    rmb_cost: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False, default=Decimal("0"))
+    local_balance: Mapped[Decimal] = mapped_column(
+        Numeric(18, 6),
+        nullable=False,
+        default=Decimal("0"),
+    )
+    remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    transactions: Mapped[list["XboxTransaction"]] = relationship(
+        back_populates="account",
+        cascade="all, delete-orphan",
+    )
+
+
+class XboxTransaction(Base):
+    __tablename__ = "xbox_transactions"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(ForeignKey("xbox_accounts.id"), nullable=False, index=True)
+    rmb_amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False, default=Decimal("0"))
+    local_amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    type: Mapped[XboxTransactionType] = mapped_column(String(16), nullable=False)
+    remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    account: Mapped[XboxAccount] = relationship(back_populates="transactions")

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -1,0 +1,231 @@
+"""XBOX account API routes."""
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.xbox import (
+    XboxAccount,
+    XboxCountry,
+    XboxCurrency,
+    XboxTransaction,
+    XboxTransactionType,
+)
+
+
+router = APIRouter(prefix="/xbox", tags=["xbox"])
+
+
+COUNTRY_CURRENCY = {
+    XboxCountry.US: XboxCurrency.USD,
+    XboxCountry.UK: XboxCurrency.GBP,
+}
+
+
+class XboxAccountCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    country: XboxCountry
+    remark: Optional[str] = None
+
+
+class XboxAccountOut(BaseModel):
+    id: int
+    name: str
+    country: str
+    currency: str
+    rmb_cost: Decimal
+    local_balance: Decimal
+    remark: Optional[str]
+    created_at: str
+
+
+class XboxRechargeRequest(BaseModel):
+    rmb_amount: Decimal = Field(..., gt=0)
+    local_amount: Decimal = Field(..., gt=0)
+    remark: Optional[str] = None
+
+
+class XboxConsumeRequest(BaseModel):
+    local_amount: Decimal = Field(..., gt=0)
+    remark: Optional[str] = None
+
+
+class XboxTransactionOut(BaseModel):
+    id: int
+    account_id: int
+    rmb_amount: Decimal
+    local_amount: Decimal
+    type: str
+    remark: Optional[str]
+    created_at: str
+
+
+class XboxCurrencySummary(BaseModel):
+    rmb_cost: Decimal
+    local_balance: Decimal
+
+
+class XboxSummaryOut(BaseModel):
+    USD: XboxCurrencySummary
+    GBP: XboxCurrencySummary
+
+
+def _value(value):
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def serialize_account(account: XboxAccount) -> XboxAccountOut:
+    return XboxAccountOut(
+        id=account.id,
+        name=account.name,
+        country=_value(account.country),
+        currency=_value(account.currency),
+        rmb_cost=account.rmb_cost,
+        local_balance=account.local_balance,
+        remark=account.remark,
+        created_at=account.created_at.isoformat() if account.created_at else "",
+    )
+
+
+def serialize_transaction(transaction: XboxTransaction) -> XboxTransactionOut:
+    return XboxTransactionOut(
+        id=transaction.id,
+        account_id=transaction.account_id,
+        rmb_amount=transaction.rmb_amount,
+        local_amount=transaction.local_amount,
+        type=_value(transaction.type),
+        remark=transaction.remark,
+        created_at=transaction.created_at.isoformat() if transaction.created_at else "",
+    )
+
+
+def get_account_or_404(session: Session, account_id: int) -> XboxAccount:
+    account = session.get(XboxAccount, account_id)
+    if account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="XBOX 账号不存在")
+    return account
+
+
+@router.post("/accounts", response_model=XboxAccountOut, status_code=status.HTTP_201_CREATED)
+def create_account(request: XboxAccountCreate, db: Session = Depends(get_db)) -> XboxAccountOut:
+    account = XboxAccount(
+        name=request.name,
+        country=request.country.value,
+        currency=COUNTRY_CURRENCY[request.country].value,
+        remark=request.remark,
+    )
+    db.add(account)
+    db.commit()
+    db.refresh(account)
+    return serialize_account(account)
+
+
+@router.get("/accounts", response_model=list[XboxAccountOut])
+def list_accounts(
+    country: Optional[XboxCountry] = Query(None),
+    db: Session = Depends(get_db),
+) -> list[XboxAccountOut]:
+    statement = select(XboxAccount).order_by(XboxAccount.id)
+    if country is not None:
+        statement = statement.where(XboxAccount.country == country.value)
+    accounts = db.scalars(statement).all()
+    return [serialize_account(account) for account in accounts]
+
+
+@router.post(
+    "/accounts/{account_id}/recharge",
+    response_model=XboxTransactionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def recharge_account(
+    account_id: int,
+    request: XboxRechargeRequest,
+    db: Session = Depends(get_db),
+) -> XboxTransactionOut:
+    account = get_account_or_404(db, account_id)
+    account.rmb_cost = Decimal(account.rmb_cost) + request.rmb_amount
+    account.local_balance = Decimal(account.local_balance) + request.local_amount
+    transaction = XboxTransaction(
+        account_id=account.id,
+        rmb_amount=request.rmb_amount,
+        local_amount=request.local_amount,
+        type=XboxTransactionType.RECHARGE.value,
+        remark=request.remark,
+    )
+    db.add(transaction)
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(transaction)
+
+
+@router.post(
+    "/accounts/{account_id}/consume",
+    response_model=XboxTransactionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def consume_account(
+    account_id: int,
+    request: XboxConsumeRequest,
+    db: Session = Depends(get_db),
+) -> XboxTransactionOut:
+    account = get_account_or_404(db, account_id)
+    if Decimal(account.local_balance) < request.local_amount:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="当地币余额不足")
+    account.local_balance = Decimal(account.local_balance) - request.local_amount
+    transaction = XboxTransaction(
+        account_id=account.id,
+        rmb_amount=Decimal("0"),
+        local_amount=request.local_amount,
+        type=XboxTransactionType.CONSUME.value,
+        remark=request.remark,
+    )
+    db.add(transaction)
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(transaction)
+
+
+@router.get("/accounts/{account_id}/transactions", response_model=list[XboxTransactionOut])
+def list_account_transactions(
+    account_id: int,
+    db: Session = Depends(get_db),
+) -> list[XboxTransactionOut]:
+    get_account_or_404(db, account_id)
+    transactions = db.scalars(
+        select(XboxTransaction)
+        .where(XboxTransaction.account_id == account_id)
+        .order_by(XboxTransaction.id)
+    ).all()
+    return [serialize_transaction(transaction) for transaction in transactions]
+
+
+@router.get("/summary", response_model=XboxSummaryOut)
+def xbox_summary(db: Session = Depends(get_db)) -> XboxSummaryOut:
+    rows = db.execute(
+        select(
+            XboxAccount.currency,
+            func.coalesce(func.sum(XboxAccount.rmb_cost), 0),
+            func.coalesce(func.sum(XboxAccount.local_balance), 0),
+        ).group_by(XboxAccount.currency)
+    ).all()
+    totals = {
+        currency: XboxCurrencySummary(
+            rmb_cost=Decimal(str(rmb_cost)),
+            local_balance=Decimal(str(local_balance)),
+        )
+        for currency, rmb_cost, local_balance in rows
+    }
+    empty = XboxCurrencySummary(rmb_cost=Decimal("0"), local_balance=Decimal("0"))
+    return XboxSummaryOut(
+        USD=totals.get(XboxCurrency.USD.value, empty),
+        GBP=totals.get(XboxCurrency.GBP.value, empty),
+    )

--- a/tests/test_xbox_api.py
+++ b/tests/test_xbox_api.py
@@ -1,0 +1,98 @@
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'xbox.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def create_account(client, name="US Account", country="US"):
+    response = client.post("/xbox/accounts", json={"name": name, "country": country})
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_create_and_filter_accounts(client):
+    us_account = create_account(client, "US Account", "US")
+    uk_account = create_account(client, "UK Account", "UK")
+
+    assert us_account["currency"] == "USD"
+    assert uk_account["currency"] == "GBP"
+
+    response = client.get("/xbox/accounts", params={"country": "US"})
+    assert response.status_code == 200, response.text
+    assert [account["name"] for account in response.json()] == ["US Account"]
+
+
+def test_recharge_consume_and_transactions(client):
+    account = create_account(client)
+
+    recharge = client.post(
+        f"/xbox/accounts/{account['id']}/recharge",
+        json={"rmb_amount": "700.00", "local_amount": "100.00", "remark": "USD top-up"},
+    )
+    assert recharge.status_code == 201, recharge.text
+    assert recharge.json()["type"] == "recharge"
+
+    consume = client.post(
+        f"/xbox/accounts/{account['id']}/consume",
+        json={"local_amount": "35.50", "remark": "game purchase"},
+    )
+    assert consume.status_code == 201, consume.text
+    assert consume.json()["type"] == "consume"
+    assert Decimal(consume.json()["rmb_amount"]) == Decimal("0.000000")
+
+    transactions = client.get(f"/xbox/accounts/{account['id']}/transactions")
+    assert transactions.status_code == 200, transactions.text
+    assert [item["type"] for item in transactions.json()] == ["recharge", "consume"]
+
+    refreshed = client.get("/xbox/accounts", params={"country": "US"}).json()[0]
+    assert Decimal(refreshed["rmb_cost"]) == Decimal("700.000000")
+    assert Decimal(refreshed["local_balance"]) == Decimal("64.500000")
+
+
+def test_consume_rejects_insufficient_local_balance(client):
+    account = create_account(client)
+
+    response = client.post(
+        f"/xbox/accounts/{account['id']}/consume",
+        json={"local_amount": "1.00"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_summary_groups_usd_and_gbp(client):
+    us_account = create_account(client, "US Account", "US")
+    uk_account = create_account(client, "UK Account", "UK")
+    client.post(
+        f"/xbox/accounts/{us_account['id']}/recharge",
+        json={"rmb_amount": "700.00", "local_amount": "100.00"},
+    )
+    client.post(
+        f"/xbox/accounts/{uk_account['id']}/recharge",
+        json={"rmb_amount": "900.00", "local_amount": "80.00"},
+    )
+
+    summary = client.get("/xbox/summary")
+
+    assert summary.status_code == 200, summary.text
+    assert Decimal(summary.json()["USD"]["rmb_cost"]) == Decimal("700.000000")
+    assert Decimal(summary.json()["USD"]["local_balance"]) == Decimal("100.000000")
+    assert Decimal(summary.json()["GBP"]["rmb_cost"]) == Decimal("900.000000")
+    assert Decimal(summary.json()["GBP"]["local_balance"]) == Decimal("80.000000")


### PR DESCRIPTION
## 关联 Issue
Closes #6

## 依赖
- 依赖供应商/API 链路 PR #11，当前 PR base 为 `feature/issue-5`

## 改动说明
- 新增 XboxAccount / XboxTransaction ORM 模型
- 支持 US/UK 账号，并自动映射 USD/GBP 币种
- 支持账号列表按 country 过滤
- 支持 recharge：增加 RMB 成本和当地币余额
- 支持 consume：扣减当地币余额并记录流水
- 支持余额不足校验
- 新增 `/xbox/summary` 汇总 USD/GBP 的 RMB 成本和当地币余额
- 新增测试覆盖创建、过滤、充值、消费、流水、余额不足和汇总

## 自测情况
- [x] python3 -m pytest -q
- [x] python3 -m compileall -q src tests
- [x] git diff --check
- [x] 满足 Issue 中的验收标准

---
> 请 Claude PM 审查