### PR TITLE
[PR] [FEAT] 淘宝账户管理

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -40,6 +40,7 @@ def init_db() -> None:
     from src.models import wallet  # noqa: F401
     from src.models import vendor  # noqa: F401
     from src.models import xbox  # noqa: F401
+    from src.models import taobao  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
 

--- a/src/main.py
+++ b/src/main.py
@@ -9,6 +9,7 @@ from src import database
 from src.routers.assets import router as assets_router
 from src.routers.vendors import router as vendors_router
 from src.routers.xbox import router as xbox_router
+from src.routers.taobao import router as taobao_router
 from src.services.assets import ensure_default_asset_wallets
 
 
@@ -28,6 +29,7 @@ app = FastAPI(title="Finance System API", lifespan=lifespan)
 app.include_router(assets_router)
 app.include_router(vendors_router)
 app.include_router(xbox_router)
+app.include_router(taobao_router)
 
 
 @app.get("/health")

--- a/src/models/taobao.py
+++ b/src/models/taobao.py
@@ -1,0 +1,29 @@
+"""Taobao account ORM model."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.database import Base
+from src.models.wallet import Wallet
+
+
+class TaobaoAccount(Base):
+    __tablename__ = "taobao_accounts"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
+    unsettled_wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id"), nullable=False)
+    settled_wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id"), nullable=False)
+    remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    unsettled_wallet: Mapped[Wallet] = relationship(foreign_keys=[unsettled_wallet_id])
+    settled_wallet: Mapped[Wallet] = relationship(foreign_keys=[settled_wallet_id])

--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -1,0 +1,190 @@
+"""Taobao account API routes."""
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.taobao import TaobaoAccount
+from src.models.wallet import Currency, WalletTransaction, WalletType, credit, create_wallet, debit
+
+
+router = APIRouter(prefix="/taobao", tags=["taobao"])
+
+
+class TaobaoAccountCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=120)
+    remark: Optional[str] = None
+
+
+class TaobaoAccountOut(BaseModel):
+    id: int
+    name: str
+    unsettled_wallet_id: int
+    settled_wallet_id: int
+    unsettled_balance: Decimal
+    settled_balance: Decimal
+    remark: Optional[str]
+    created_at: str
+
+
+class TaobaoMovementRequest(BaseModel):
+    amount: Decimal = Field(..., gt=0)
+    remark: Optional[str] = None
+
+
+class TaobaoTransactionOut(BaseModel):
+    id: int
+    wallet_id: int
+    wallet_scope: str
+    amount: Decimal
+    direction: str
+    remark: Optional[str]
+    created_at: str
+
+
+def _value(value):
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def serialize_account(account: TaobaoAccount) -> TaobaoAccountOut:
+    return TaobaoAccountOut(
+        id=account.id,
+        name=account.name,
+        unsettled_wallet_id=account.unsettled_wallet_id,
+        settled_wallet_id=account.settled_wallet_id,
+        unsettled_balance=account.unsettled_wallet.balance,
+        settled_balance=account.settled_wallet.balance,
+        remark=account.remark,
+        created_at=account.created_at.isoformat() if account.created_at else "",
+    )
+
+
+def serialize_transaction(account: TaobaoAccount, transaction: WalletTransaction) -> TaobaoTransactionOut:
+    scope = "unsettled" if transaction.wallet_id == account.unsettled_wallet_id else "settled"
+    return TaobaoTransactionOut(
+        id=transaction.id,
+        wallet_id=transaction.wallet_id,
+        wallet_scope=scope,
+        amount=transaction.amount,
+        direction=_value(transaction.direction),
+        remark=transaction.remark,
+        created_at=transaction.created_at.isoformat() if transaction.created_at else "",
+    )
+
+
+def get_account_or_404(session: Session, account_id: int) -> TaobaoAccount:
+    account = session.get(TaobaoAccount, account_id)
+    if account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="淘宝账户不存在")
+    return account
+
+
+@router.post("/accounts", response_model=TaobaoAccountOut, status_code=status.HTTP_201_CREATED)
+def create_account(request: TaobaoAccountCreate, db: Session = Depends(get_db)) -> TaobaoAccountOut:
+    unsettled_wallet = create_wallet(
+        db,
+        name=f"{request.name} 未结算",
+        wallet_type=WalletType.TAOBAO,
+        currency=Currency.CNY,
+    )
+    settled_wallet = create_wallet(
+        db,
+        name=f"{request.name} 已结算",
+        wallet_type=WalletType.TAOBAO,
+        currency=Currency.CNY,
+    )
+    account = TaobaoAccount(
+        name=request.name,
+        unsettled_wallet_id=unsettled_wallet.id,
+        settled_wallet_id=settled_wallet.id,
+        remark=request.remark,
+    )
+    db.add(account)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="淘宝账户名称已存在") from exc
+    db.refresh(account)
+    return serialize_account(account)
+
+
+@router.get("/accounts", response_model=list[TaobaoAccountOut])
+def list_accounts(db: Session = Depends(get_db)) -> list[TaobaoAccountOut]:
+    accounts = db.scalars(select(TaobaoAccount).order_by(TaobaoAccount.id)).all()
+    return [serialize_account(account) for account in accounts]
+
+
+@router.post(
+    "/accounts/{account_id}/unsettled/credit",
+    response_model=TaobaoTransactionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def credit_unsettled(
+    account_id: int,
+    request: TaobaoMovementRequest,
+    db: Session = Depends(get_db),
+) -> TaobaoTransactionOut:
+    account = get_account_or_404(db, account_id)
+    transaction = credit(db, account.unsettled_wallet_id, request.amount, request.remark)
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(account, transaction)
+
+
+@router.post(
+    "/accounts/{account_id}/settled/credit",
+    response_model=TaobaoTransactionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def credit_settled(
+    account_id: int,
+    request: TaobaoMovementRequest,
+    db: Session = Depends(get_db),
+) -> TaobaoTransactionOut:
+    account = get_account_or_404(db, account_id)
+    transaction = credit(db, account.settled_wallet_id, request.amount, request.remark)
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(account, transaction)
+
+
+@router.post(
+    "/accounts/{account_id}/settled/debit",
+    response_model=TaobaoTransactionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def debit_settled(
+    account_id: int,
+    request: TaobaoMovementRequest,
+    db: Session = Depends(get_db),
+) -> TaobaoTransactionOut:
+    account = get_account_or_404(db, account_id)
+    try:
+        transaction = debit(db, account.settled_wallet_id, request.amount, request.remark)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(account, transaction)
+
+
+@router.get("/accounts/{account_id}/transactions", response_model=list[TaobaoTransactionOut])
+def list_transactions(account_id: int, db: Session = Depends(get_db)) -> list[TaobaoTransactionOut]:
+    account = get_account_or_404(db, account_id)
+    transactions = db.scalars(
+        select(WalletTransaction)
+        .where(WalletTransaction.wallet_id.in_([account.unsettled_wallet_id, account.settled_wallet_id]))
+        .order_by(WalletTransaction.id)
+    ).all()
+    return [serialize_transaction(account, transaction) for transaction in transactions]

--- a/tests/test_taobao_api.py
+++ b/tests/test_taobao_api.py
@@ -1,0 +1,86 @@
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'taobao.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def create_account(client):
+    response = client.post("/taobao/accounts", json={"name": "Taobao A", "remark": "store"})
+    assert response.status_code == 201, response.text
+    return response.json()
+
+
+def test_create_account_creates_two_wallets(client):
+    account = create_account(client)
+
+    assert account["unsettled_wallet_id"] != account["settled_wallet_id"]
+    assert Decimal(account["unsettled_balance"]) == Decimal("0.000000")
+    assert Decimal(account["settled_balance"]) == Decimal("0.000000")
+
+    response = client.get("/taobao/accounts")
+    assert response.status_code == 200, response.text
+    assert response.json()[0]["name"] == "Taobao A"
+
+
+def test_taobao_credit_debit_and_transactions(client):
+    account = create_account(client)
+
+    unsettled = client.post(
+        f"/taobao/accounts/{account['id']}/unsettled/credit",
+        json={"amount": "120.00", "remark": "unsettled order"},
+    )
+    settled_credit = client.post(
+        f"/taobao/accounts/{account['id']}/settled/credit",
+        json={"amount": "80.00", "remark": "settled order"},
+    )
+    settled_debit = client.post(
+        f"/taobao/accounts/{account['id']}/settled/debit",
+        json={"amount": "30.00", "remark": "withdraw"},
+    )
+
+    assert unsettled.status_code == 201, unsettled.text
+    assert unsettled.json()["wallet_scope"] == "unsettled"
+    assert settled_credit.status_code == 201, settled_credit.text
+    assert settled_credit.json()["wallet_scope"] == "settled"
+    assert settled_debit.status_code == 201, settled_debit.text
+    assert settled_debit.json()["direction"] == "out"
+
+    transactions = client.get(f"/taobao/accounts/{account['id']}/transactions")
+    assert transactions.status_code == 200, transactions.text
+    assert [item["wallet_scope"] for item in transactions.json()] == [
+        "unsettled",
+        "settled",
+        "settled",
+    ]
+
+    refreshed = client.get("/taobao/accounts").json()[0]
+    assert Decimal(refreshed["unsettled_balance"]) == Decimal("120.000000")
+    assert Decimal(refreshed["settled_balance"]) == Decimal("50.000000")
+
+
+def test_settled_debit_rejects_insufficient_balance(client):
+    account = create_account(client)
+
+    response = client.post(
+        f"/taobao/accounts/{account['id']}/settled/debit",
+        json={"amount": "1.00"},
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
## 关联 Issue
Closes #7

## 依赖
- 依赖 XBOX/API 链路 PR #12，当前 PR base 为 `feature/issue-6`

## 改动说明
- 新增 TaobaoAccount ORM 模型
- 创建淘宝账户时自动创建未结算 / 已结算两个 CNY 钱包，type=TAOBAO
- 支持未结算入账、已结算入账、已结算出账
- 支持余额不足校验
- 支持账户列表展示两个钱包余额
- 支持合并查询淘宝账户两类钱包流水
- 新增测试覆盖开户、钱包创建、入账、出账、流水和余额不足

## 自测情况
- [x] python3 -m pytest -q
- [x] python3 -m compileall -q src tests
- [x] git diff --check
- [x] 满足 Issue 中的验收标准

---
> 请 Claude PM 审查