### PR TITLE
[PR] [FEAT] 台湾钱包管理

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,9 @@ from src.routers.assets import router as assets_router
 from src.routers.vendors import router as vendors_router
 from src.routers.xbox import router as xbox_router
 from src.routers.taobao import router as taobao_router
+from src.routers.taiwan import router as taiwan_router
 from src.services.assets import ensure_default_asset_wallets
+from src.services.taiwan import ensure_default_taiwan_wallets
 
 
 @asynccontextmanager
@@ -19,6 +21,7 @@ async def lifespan(_: FastAPI):
     db = database.SessionLocal()
     try:
         ensure_default_asset_wallets(db)
+        ensure_default_taiwan_wallets(db)
         db.commit()
     finally:
         db.close()
@@ -30,6 +33,7 @@ app.include_router(assets_router)
 app.include_router(vendors_router)
 app.include_router(xbox_router)
 app.include_router(taobao_router)
+app.include_router(taiwan_router)
 
 
 @app.get("/health")

--- a/src/routers/taiwan.py
+++ b/src/routers/taiwan.py
@@ -1,0 +1,148 @@
+"""Taiwan TWD wallet API routes."""
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.wallet import Wallet, WalletTransaction, credit, debit, list_transactions
+from src.services.taiwan import is_taiwan_wallet, list_taiwan_wallets
+
+
+router = APIRouter(prefix="/taiwan", tags=["taiwan"])
+
+
+class TaiwanWalletOut(BaseModel):
+    id: int
+    name: str
+    type: str
+    currency: str
+    balance: Decimal
+    created_at: str
+
+
+class TaiwanMovementRequest(BaseModel):
+    amount: Decimal = Field(..., gt=0)
+    remark: Optional[str] = None
+
+
+class TaiwanTransactionOut(BaseModel):
+    id: int
+    wallet_id: int
+    amount: Decimal
+    direction: str
+    remark: Optional[str]
+    created_at: str
+
+
+class TaiwanSummaryOut(BaseModel):
+    total_balance: Decimal
+    wallet_count: int
+
+
+def _value(value):
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def serialize_wallet(wallet: Wallet) -> TaiwanWalletOut:
+    return TaiwanWalletOut(
+        id=wallet.id,
+        name=wallet.name,
+        type=_value(wallet.type),
+        currency=_value(wallet.currency),
+        balance=wallet.balance,
+        created_at=wallet.created_at.isoformat() if wallet.created_at else "",
+    )
+
+
+def serialize_transaction(transaction: WalletTransaction) -> TaiwanTransactionOut:
+    return TaiwanTransactionOut(
+        id=transaction.id,
+        wallet_id=transaction.wallet_id,
+        amount=transaction.amount,
+        direction=_value(transaction.direction),
+        remark=transaction.remark,
+        created_at=transaction.created_at.isoformat() if transaction.created_at else "",
+    )
+
+
+def get_taiwan_wallet_or_404(session: Session, wallet_id: int) -> Wallet:
+    wallet = session.get(Wallet, wallet_id)
+    if wallet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="台湾钱包不存在")
+    if not is_taiwan_wallet(wallet):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="该钱包不是台湾 TWD 钱包")
+    return wallet
+
+
+@router.get("/wallets", response_model=list[TaiwanWalletOut])
+def get_wallets(db: Session = Depends(get_db)) -> list[TaiwanWalletOut]:
+    return [serialize_wallet(wallet) for wallet in list_taiwan_wallets(db)]
+
+
+@router.post(
+    "/wallets/{wallet_id}/credit",
+    response_model=TaiwanTransactionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def credit_wallet(
+    wallet_id: int,
+    request: TaiwanMovementRequest,
+    db: Session = Depends(get_db),
+) -> TaiwanTransactionOut:
+    get_taiwan_wallet_or_404(db, wallet_id)
+    transaction = credit(db, wallet_id, request.amount, request.remark)
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(transaction)
+
+
+@router.post(
+    "/wallets/{wallet_id}/debit",
+    response_model=TaiwanTransactionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def debit_wallet(
+    wallet_id: int,
+    request: TaiwanMovementRequest,
+    db: Session = Depends(get_db),
+) -> TaiwanTransactionOut:
+    get_taiwan_wallet_or_404(db, wallet_id)
+    try:
+        transaction = debit(db, wallet_id, request.amount, request.remark)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(transaction)
+    return serialize_transaction(transaction)
+
+
+@router.get("/wallets/{wallet_id}/transactions", response_model=list[TaiwanTransactionOut])
+def get_transactions(wallet_id: int, db: Session = Depends(get_db)) -> list[TaiwanTransactionOut]:
+    get_taiwan_wallet_or_404(db, wallet_id)
+    return [serialize_transaction(transaction) for transaction in list_transactions(db, wallet_id)]
+
+
+@router.get("/summary", response_model=TaiwanSummaryOut)
+def get_summary(db: Session = Depends(get_db)) -> TaiwanSummaryOut:
+    total = db.scalar(
+        select(func.coalesce(func.sum(Wallet.balance), 0)).where(
+            Wallet.type == "TAIWAN",
+            Wallet.currency == "TWD",
+        )
+    )
+    wallet_count = db.scalar(
+        select(func.count()).select_from(Wallet).where(
+            Wallet.type == "TAIWAN",
+            Wallet.currency == "TWD",
+        )
+    )
+    return TaiwanSummaryOut(total_balance=Decimal(str(total)), wallet_count=int(wallet_count or 0))

--- a/src/services/taiwan.py
+++ b/src/services/taiwan.py
@@ -1,0 +1,50 @@
+"""Taiwan wallet service functions."""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import Currency, Wallet, WalletType, create_wallet
+
+
+DEFAULT_TAIWAN_WALLET_NAMES = ("8591 收入", "提现", "待处理")
+
+
+def ensure_default_taiwan_wallets(session: Session) -> None:
+    """Create the default Taiwan TWD wallets if they do not already exist."""
+    for name in DEFAULT_TAIWAN_WALLET_NAMES:
+        exists = session.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.TAIWAN.value,
+                Wallet.currency == Currency.TWD.value,
+                Wallet.name == name,
+                Wallet.parent_id.is_(None),
+            )
+        )
+        if exists is None:
+            create_wallet(
+                session,
+                name=name,
+                wallet_type=WalletType.TAIWAN,
+                currency=Currency.TWD,
+                opening_balance=Decimal("0"),
+            )
+    session.flush()
+
+
+def is_taiwan_wallet(wallet: Wallet) -> bool:
+    wallet_type = wallet.type.value if isinstance(wallet.type, WalletType) else wallet.type
+    currency = wallet.currency.value if isinstance(wallet.currency, Currency) else wallet.currency
+    return wallet_type == WalletType.TAIWAN.value and currency == Currency.TWD.value
+
+
+def list_taiwan_wallets(session: Session) -> list[Wallet]:
+    return list(
+        session.scalars(
+            select(Wallet)
+            .where(Wallet.type == WalletType.TAIWAN.value, Wallet.currency == Currency.TWD.value)
+            .order_by(Wallet.id)
+        )
+    )

--- a/src/services/taiwan.py
+++ b/src/services/taiwan.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from src.models.wallet import Currency, Wallet, WalletType, create_wallet
 
 
-DEFAULT_TAIWAN_WALLET_NAMES = ("8591 收入", "提现", "待处理")
+DEFAULT_TAIWAN_WALLET_NAMES = ("8591余额", "银行卡", "超商代收金流余额")
 
 
 def ensure_default_taiwan_wallets(session: Session) -> None:

--- a/tests/test_taiwan_api.py
+++ b/tests/test_taiwan_api.py
@@ -28,7 +28,7 @@ def test_default_taiwan_wallets_are_listed(client):
 
     assert response.status_code == 200, response.text
     wallets = response.json()
-    assert {wallet["name"] for wallet in wallets} == {"8591 收入", "提现", "待处理"}
+    assert {wallet["name"] for wallet in wallets} == {"8591余额", "银行卡", "超商代收金流余额"}
     assert {wallet["type"] for wallet in wallets} == {"TAIWAN"}
     assert {wallet["currency"] for wallet in wallets} == {"TWD"}
 

--- a/tests/test_taiwan_api.py
+++ b/tests/test_taiwan_api.py
@@ -1,0 +1,70 @@
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.services.assets import ensure_default_asset_wallets
+from src.services.taiwan import ensure_default_taiwan_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'taiwan.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        ensure_default_taiwan_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def test_default_taiwan_wallets_are_listed(client):
+    response = client.get("/taiwan/wallets")
+
+    assert response.status_code == 200, response.text
+    wallets = response.json()
+    assert {wallet["name"] for wallet in wallets} == {"8591 收入", "提现", "待处理"}
+    assert {wallet["type"] for wallet in wallets} == {"TAIWAN"}
+    assert {wallet["currency"] for wallet in wallets} == {"TWD"}
+
+
+def test_credit_debit_transactions_and_summary(client):
+    wallet = client.get("/taiwan/wallets").json()[0]
+
+    credit = client.post(
+        f"/taiwan/wallets/{wallet['id']}/credit",
+        json={"amount": "500.00", "remark": "8591 income"},
+    )
+    debit = client.post(
+        f"/taiwan/wallets/{wallet['id']}/debit",
+        json={"amount": "120.00", "remark": "withdrawal"},
+    )
+    assert credit.status_code == 201, credit.text
+    assert credit.json()["direction"] == "in"
+    assert debit.status_code == 201, debit.text
+    assert debit.json()["direction"] == "out"
+
+    transactions = client.get(f"/taiwan/wallets/{wallet['id']}/transactions")
+    assert transactions.status_code == 200, transactions.text
+    assert [item["direction"] for item in transactions.json()] == ["in", "out"]
+
+    summary = client.get("/taiwan/summary")
+    assert summary.status_code == 200, summary.text
+    assert Decimal(summary.json()["total_balance"]) == Decimal("380.000000")
+    assert summary.json()["wallet_count"] == 3
+
+
+def test_debit_rejects_insufficient_balance(client):
+    wallet = client.get("/taiwan/wallets").json()[0]
+
+    response = client.post(
+        f"/taiwan/wallets/{wallet['id']}/debit",
+        json={"amount": "1.00"},
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
## 关联 Issue
Closes #8

## 依赖
- 依赖淘宝/API 链路 PR #13，当前 PR base 为 `feature/issue-7`

## 改动说明
- 新增台湾 TWD 钱包服务和 API
- 启动时自动初始化 3 个默认台湾钱包：8591 收入、提现、待处理
- 支持台湾钱包列表、入账、出账、流水查询
- 支持余额不足校验
- 新增 `/taiwan/summary` 汇总台湾钱包总余额和钱包数量
- 新增测试覆盖默认钱包、入账、出账、流水、汇总和余额不足

## 自测情况
- [x] python3 -m pytest -q
- [x] python3 -m compileall -q src tests
- [x] git diff --check
- [x] 满足 Issue 中的验收标准

---
> 请 Claude PM 审查