### PR TITLE
[PR] [FEAT-F3] 供应商往来页面

### DIFF
--- a/frontend/app/[section]/page.tsx
+++ b/frontend/app/[section]/page.tsx
@@ -1,6 +1,7 @@
 import { AppShell } from "@/components/app-shell";
 import { AssetsPage } from "@/components/assets-page";
 import { ModuleOverview } from "@/components/module-overview";
+import { VendorsPage } from "@/components/vendors-page";
 import { sectionById, sectionIds } from "@/lib/navigation";
 
 type SectionPageProps = {
@@ -14,7 +15,9 @@ export default function SectionPage({ params }: SectionPageProps) {
 
   return (
     <AppShell activeSection={section.id}>
-      {section.id === "assets" ? <AssetsPage /> : <ModuleOverview section={section} />}
+      {section.id === "assets" ? <AssetsPage /> : null}
+      {section.id === "vendors" ? <VendorsPage /> : null}
+      {section.id !== "assets" && section.id !== "vendors" ? <ModuleOverview section={section} /> : null}
     </AppShell>
   );
 }

--- a/frontend/components/vendors-page.tsx
+++ b/frontend/components/vendors-page.tsx
@@ -1,0 +1,392 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowDownLeft, ArrowLeftRight, ArrowUpRight, CheckCircle2, Plus, RefreshCcw } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  createVendor,
+  createVendorBill,
+  getDashboardData,
+  getVendorBills,
+  getVendors,
+  settleVendorBill
+} from "@/lib/api";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import type { Vendor, VendorBill } from "@/types";
+
+type BillDirection = "payable" | "receivable";
+
+function Input({
+  value,
+  onChange,
+  placeholder,
+  type = "text"
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  type?: string;
+}) {
+  return (
+    <input
+      className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      type={type}
+      min={type === "number" ? "0" : undefined}
+      step={type === "number" ? "0.01" : undefined}
+    />
+  );
+}
+
+function VendorSummaryCards() {
+  const { data } = useQuery({
+    queryKey: ["dashboard"],
+    queryFn: getDashboardData
+  });
+  const summary = data?.vendorSummary;
+  const items = [
+    {
+      label: "应收",
+      value: summary?.receivableMinor ?? 0,
+      tone: "success" as const,
+      icon: ArrowDownLeft
+    },
+    {
+      label: "应付",
+      value: -(summary?.payableMinor ?? 0),
+      tone: "danger" as const,
+      icon: ArrowUpRight
+    },
+    {
+      label: "净额",
+      value: summary?.netMinor ?? 0,
+      tone: "transfer" as const,
+      icon: ArrowLeftRight
+    }
+  ];
+
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      {items.map((item) => {
+        const Icon = item.icon;
+        return (
+          <Card key={item.label}>
+            <CardContent className="flex items-center justify-between gap-4 p-5">
+              <div>
+                <div className="text-sm text-muted-foreground">{item.label}</div>
+                <div className="mt-2 tabular-nums text-3xl font-semibold">
+                  {formatMoney(item.value, "CNY", {
+                    accounting: item.value < 0,
+                    signed: item.value > 0
+                  })}
+                </div>
+              </div>
+              <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+                <Icon className="h-5 w-5" />
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+function VendorCreateForm() {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [remark, setRemark] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!name.trim()) {
+        throw new Error("供应商名称不能为空");
+      }
+      return createVendor(name.trim(), remark.trim());
+    },
+    onSuccess: async () => {
+      setName("");
+      setRemark("");
+      setMessage("供应商创建请求已提交");
+      await queryClient.invalidateQueries({ queryKey: ["vendors"] });
+    },
+    onError: (error) => setMessage(error instanceof Error ? error.message : "创建失败")
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>新增供应商</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Input value={name} onChange={setName} placeholder="供应商名称" />
+        <Input value={remark} onChange={setRemark} placeholder="备注" />
+        <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+          <Plus className="h-4 w-4" />
+          创建供应商
+        </Button>
+        {message ? <div className="text-sm text-muted-foreground">{message}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function VendorBillForm({ vendors, selectedVendorId }: { vendors: Vendor[]; selectedVendorId: string }) {
+  const queryClient = useQueryClient();
+  const [vendorId, setVendorId] = useState(selectedVendorId);
+  const [direction, setDirection] = useState<BillDirection>("payable");
+  const [amount, setAmount] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [remark, setRemark] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const activeVendorId = vendorId || selectedVendorId || vendors[0]?.id || "";
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!activeVendorId) {
+        throw new Error("请选择供应商");
+      }
+      if (!amount || Number(amount) <= 0) {
+        throw new Error("金额必须大于 0");
+      }
+      return createVendorBill(activeVendorId, direction, amount, dueDate, remark);
+    },
+    onSuccess: async () => {
+      setAmount("");
+      setDueDate("");
+      setRemark("");
+      setMessage("账单创建请求已提交");
+      await queryClient.invalidateQueries({ queryKey: ["vendor-bills"] });
+      await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+    },
+    onError: (error) => setMessage(error instanceof Error ? error.message : "创建失败")
+  });
+
+  if (vendors.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>新增账单</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <select
+          className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+          value={activeVendorId}
+          onChange={(event) => setVendorId(event.target.value)}
+        >
+          {vendors.map((vendor) => (
+            <option key={vendor.id} value={vendor.id}>
+              {vendor.name}
+            </option>
+          ))}
+        </select>
+        <div className="grid grid-cols-2 rounded-md border border-border p-1">
+          {(["payable", "receivable"] as BillDirection[]).map((item) => (
+            <button
+              key={item}
+              className={cn(
+                "h-8 rounded text-sm font-medium text-muted-foreground",
+                direction === item && "bg-muted text-foreground"
+              )}
+              type="button"
+              onClick={() => setDirection(item)}
+            >
+              {item === "payable" ? "应付" : "应收"}
+            </button>
+          ))}
+        </div>
+        <div className="grid gap-3 md:grid-cols-2">
+          <Input value={amount} onChange={setAmount} placeholder="金额" type="number" />
+          <Input value={dueDate} onChange={setDueDate} placeholder="到期日" type="date" />
+        </div>
+        <Input value={remark} onChange={setRemark} placeholder="备注" />
+        <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+          <Plus className="h-4 w-4" />
+          创建账单
+        </Button>
+        {message ? <div className="text-sm text-muted-foreground">{message}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function VendorTable({
+  vendors,
+  selectedVendorId,
+  onSelect
+}: {
+  vendors: Vendor[];
+  selectedVendorId: string;
+  onSelect: (vendorId: string) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>供应商列表</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>供应商</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead>创建时间</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {vendors.map((vendor) => (
+              <TableRow
+                key={vendor.id}
+                className={cn("cursor-pointer", selectedVendorId === vendor.id && "bg-muted/70")}
+                onClick={() => onSelect(vendor.id)}
+              >
+                <TableCell className="font-medium">{vendor.name}</TableCell>
+                <TableCell className="text-muted-foreground">{vendor.remark || "-"}</TableCell>
+                <TableCell className="text-muted-foreground">
+                  {vendor.createdAt ? new Date(vendor.createdAt).toLocaleDateString("zh-CN") : "-"}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BillTable({ bills }: { bills: VendorBill[] }) {
+  const queryClient = useQueryClient();
+  const settleMutation = useMutation({
+    mutationFn: settleVendorBill,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["vendor-bills"] });
+      await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+    }
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>账单明细</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>供应商</TableHead>
+              <TableHead>方向</TableHead>
+              <TableHead>状态</TableHead>
+              <TableHead>到期日</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead className="text-right">金额</TableHead>
+              <TableHead className="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bills.map((bill) => (
+              <TableRow
+                key={bill.id}
+                className={bill.direction === "receivable" ? "border-l-2 border-l-emerald-500" : "border-l-2 border-l-red-500"}
+              >
+                <TableCell className="font-medium">{bill.vendorName}</TableCell>
+                <TableCell>
+                  <Badge tone={bill.direction === "receivable" ? "success" : "danger"}>
+                    {bill.direction === "receivable" ? "应收" : "应付"}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge tone={bill.status === "settled" ? "neutral" : "transfer"}>
+                    {bill.status === "settled" ? "已结清" : "待处理"}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground">{bill.dueDate || "-"}</TableCell>
+                <TableCell className="text-muted-foreground">{bill.remark || "-"}</TableCell>
+                <TableCell className="text-right tabular-nums font-semibold">
+                  {formatMoney(
+                    bill.direction === "receivable" ? bill.amountMinor : -bill.amountMinor,
+                    "CNY",
+                    { accounting: bill.direction === "payable", signed: bill.direction === "receivable" }
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => settleMutation.mutate(bill.id)}
+                    disabled={bill.status === "settled" || settleMutation.isPending}
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    结清
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+            {bills.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="py-8 text-center text-muted-foreground">
+                  当前供应商暂无账单
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function VendorsPage() {
+  const [selectedVendorId, setSelectedVendorId] = useState("");
+  const { data: vendors = [], isFetching, refetch } = useQuery({
+    queryKey: ["vendors"],
+    queryFn: getVendors
+  });
+  const selectedVendor = vendors.find((vendor) => vendor.id === selectedVendorId) ?? vendors[0];
+  const { data: bills = [] } = useQuery({
+    queryKey: ["vendor-bills", selectedVendor?.id],
+    queryFn: () => getVendorBills(selectedVendor as Vendor),
+    enabled: Boolean(selectedVendor)
+  });
+  const pendingBills = useMemo(() => bills.filter((bill) => bill.status === "pending"), [bills]);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-normal">供应商往来</h2>
+          <p className="mt-1 text-sm text-muted-foreground">供应商应付、应收、待处理账单和结清状态。</p>
+        </div>
+        <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className="h-4 w-4" />
+          刷新
+        </Button>
+      </div>
+
+      <VendorSummaryCards />
+      <div className="grid gap-3 xl:grid-cols-[0.8fr_1.2fr]">
+        <VendorCreateForm />
+        <VendorBillForm vendors={vendors} selectedVendorId={selectedVendor?.id ?? ""} />
+      </div>
+      <div className="grid gap-3 xl:grid-cols-[0.9fr_1.1fr]">
+        <VendorTable vendors={vendors} selectedVendorId={selectedVendor?.id ?? ""} onSelect={setSelectedVendorId} />
+        <Card>
+          <CardContent className="p-5">
+            <div className="text-sm text-muted-foreground">当前待处理账单</div>
+            <div className="mt-2 tabular-nums text-3xl font-semibold">{pendingBills.length}</div>
+          </CardContent>
+        </Card>
+      </div>
+      <BillTable bills={bills} />
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -4,6 +4,8 @@ import type {
   AssetTransaction,
   Currency,
   DashboardData,
+  Vendor,
+  VendorBill,
   VendorSummary,
   WalletBalance,
   WalletType
@@ -40,6 +42,30 @@ type AssetTransactionResponse = {
   created_at?: string;
   createdAt?: string;
   currency?: Currency;
+};
+
+type VendorResponse = {
+  id: string | number;
+  name: string;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type VendorBillResponse = {
+  id: string | number;
+  vendor_id?: string | number;
+  vendorId?: string | number;
+  vendor_name?: string;
+  vendorName?: string;
+  direction: "payable" | "receivable";
+  amount: string | number;
+  status: "pending" | "settled";
+  due_date?: string | null;
+  dueDate?: string | null;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
 };
 
 async function fetchJson<T>(path: string): Promise<T> {
@@ -156,4 +182,81 @@ export function creditAssetWallet(walletId: string, amount: string, remark: stri
 
 export function debitAssetWallet(walletId: string, amount: string, remark: string) {
   return postJson(`/api/wallets/assets/${walletId}/debit`, { amount, remark });
+}
+
+function normalizeVendor(vendor: VendorResponse): Vendor {
+  return {
+    id: String(vendor.id),
+    name: vendor.name,
+    remark: vendor.remark,
+    createdAt: vendor.created_at ?? vendor.createdAt
+  };
+}
+
+function normalizeVendorBill(bill: VendorBillResponse, vendor: Vendor): VendorBill {
+  return {
+    id: String(bill.id),
+    vendorId: String(bill.vendor_id ?? bill.vendorId ?? vendor.id),
+    vendorName: bill.vendor_name ?? bill.vendorName ?? vendor.name,
+    direction: bill.direction,
+    amountMinor: decimalToMinor(bill.amount, "CNY"),
+    status: bill.status,
+    dueDate: bill.due_date ?? bill.dueDate,
+    remark: bill.remark,
+    createdAt: bill.created_at ?? bill.createdAt,
+    currency: "CNY"
+  };
+}
+
+export async function getVendors(): Promise<Vendor[]> {
+  try {
+    const vendors = await fetchJson<VendorResponse[]>("/api/vendors");
+    return vendors.map(normalizeVendor);
+  } catch {
+    const { mockVendors } = await import("@/lib/mock-data");
+    return mockVendors;
+  }
+}
+
+export async function getVendorBills(vendor: Vendor): Promise<VendorBill[]> {
+  try {
+    const bills = await fetchJson<VendorBillResponse[]>(`/api/vendors/${vendor.id}/bills`);
+    return bills.map((bill) => normalizeVendorBill(bill, vendor));
+  } catch {
+    const { mockVendorBills } = await import("@/lib/mock-data");
+    return mockVendorBills[vendor.id] ?? [];
+  }
+}
+
+export function createVendor(name: string, remark: string) {
+  return postJson("/api/vendors", { name, remark });
+}
+
+export function createVendorBill(
+  vendorId: string,
+  direction: "payable" | "receivable",
+  amount: string,
+  dueDate: string,
+  remark: string
+) {
+  return postJson(`/api/vendors/${vendorId}/bills`, {
+    direction,
+    amount,
+    due_date: dueDate || undefined,
+    remark
+  });
+}
+
+export function settleVendorBill(billId: string) {
+  return fetch(`/api/vendors/bills/${billId}/settle`, {
+    method: "PATCH",
+    headers: {
+      accept: "application/json"
+    }
+  }).then((response) => {
+    if (!response.ok) {
+      throw new Error(`settle returned ${response.status}`);
+    }
+    return response.json();
+  });
 }

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import type { AssetTransaction, DashboardData, WalletBalance } from "@/types";
+import type { AssetTransaction, DashboardData, Vendor, VendorBill, WalletBalance } from "@/types";
 
 export const mockWallets: WalletBalance[] = [
   {
@@ -116,6 +116,64 @@ export const mockAssetTransactions: Record<string, AssetTransaction[]> = {
       remark: "链上充值",
       createdAt: "2026-04-23T11:10:00.000Z",
       currency: "USDT"
+    }
+  ]
+};
+
+export const mockVendors: Vendor[] = [
+  {
+    id: "vendor-1",
+    name: "华东渠道商",
+    remark: "月结供应商",
+    createdAt: "2026-04-10T02:00:00.000Z"
+  },
+  {
+    id: "vendor-2",
+    name: "跨境结算服务",
+    remark: "USDT 相关费用",
+    createdAt: "2026-04-18T06:30:00.000Z"
+  }
+];
+
+export const mockVendorBills: Record<string, VendorBill[]> = {
+  "vendor-1": [
+    {
+      id: "bill-1",
+      vendorId: "vendor-1",
+      vendorName: "华东渠道商",
+      direction: "payable",
+      amountMinor: 128_500_00,
+      status: "pending",
+      dueDate: "2026-05-05",
+      remark: "采购款",
+      createdAt: "2026-04-21T04:00:00.000Z",
+      currency: "CNY"
+    },
+    {
+      id: "bill-2",
+      vendorId: "vendor-1",
+      vendorName: "华东渠道商",
+      direction: "receivable",
+      amountMinor: 86_300_00,
+      status: "settled",
+      dueDate: "2026-04-25",
+      remark: "返利",
+      createdAt: "2026-04-15T05:00:00.000Z",
+      currency: "CNY"
+    }
+  ],
+  "vendor-2": [
+    {
+      id: "bill-3",
+      vendorId: "vendor-2",
+      vendorName: "跨境结算服务",
+      direction: "receivable",
+      amountMinor: 208_720_00,
+      status: "pending",
+      dueDate: "2026-05-12",
+      remark: "服务垫款",
+      createdAt: "2026-04-24T03:00:00.000Z",
+      currency: "CNY"
     }
   ]
 };

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -34,6 +34,26 @@ export type AssetTransaction = {
   currency: Currency;
 };
 
+export type Vendor = {
+  id: string;
+  name: string;
+  remark?: string | null;
+  createdAt?: string;
+};
+
+export type VendorBill = {
+  id: string;
+  vendorId: string;
+  vendorName: string;
+  direction: "payable" | "receivable";
+  amountMinor: number;
+  status: "pending" | "settled";
+  dueDate?: string | null;
+  remark?: string | null;
+  createdAt?: string;
+  currency: "CNY";
+};
+
 export type ModuleSection = {
   id: string;
   title: string;


### PR DESCRIPTION
## 关联 Issue
Closes #18

## 依赖
- 依赖前端资产页 PR #22，当前 PR base 为 `feature/issue-17`

## 改动说明
- 新增 /vendors 专用供应商往来页面
- 展示应收、应付、净额摘要卡片
- 展示供应商列表，支持选择供应商查看账单
- 新增供应商创建表单，对接 POST /api/vendors
- 新增账单创建表单，对接 POST /api/vendors/{vendor_id}/bills
- 新增账单明细表，支持 payable / receivable 方向、pending / settled 状态和结清操作
- 结清操作对接 PATCH /api/vendors/bills/{bill_id}/settle
- API 不可用时使用 mock 供应商和账单数据用于前端验收

## 自测情况
- [x] cd frontend && npm run typecheck
- [x] cd frontend && npm run build
- [x] python3 -m pytest -q
- [x] git diff --check
- [x] 本地 http://localhost:3001/vendors 返回 200

## 注意
- 继续沿用 Next.js 14，没有擅自升级主版本。
- 本机 3000 上仍有旧 dev 进程不可由当前 shell kill，验收请使用 3001。