### PR TITLE
[PR] [FEAT-F4] XBOX 账户页面

### DIFF
--- a/frontend/app/[section]/page.tsx
+++ b/frontend/app/[section]/page.tsx
@@ -2,6 +2,7 @@ import { AppShell } from "@/components/app-shell";
 import { AssetsPage } from "@/components/assets-page";
 import { ModuleOverview } from "@/components/module-overview";
 import { VendorsPage } from "@/components/vendors-page";
+import { XboxPage } from "@/components/xbox-page";
 import { sectionById, sectionIds } from "@/lib/navigation";
 
 type SectionPageProps = {
@@ -17,7 +18,10 @@ export default function SectionPage({ params }: SectionPageProps) {
     <AppShell activeSection={section.id}>
       {section.id === "assets" ? <AssetsPage /> : null}
       {section.id === "vendors" ? <VendorsPage /> : null}
-      {section.id !== "assets" && section.id !== "vendors" ? <ModuleOverview section={section} /> : null}
+      {section.id === "xbox" ? <XboxPage /> : null}
+      {section.id !== "assets" && section.id !== "vendors" && section.id !== "xbox" ? (
+        <ModuleOverview section={section} />
+      ) : null}
     </AppShell>
   );
 }

--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowDownLeft, ArrowUpRight, Gamepad2, Plus, RefreshCcw } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  consumeXboxAccount,
+  createXboxAccount,
+  getXboxAccounts,
+  getXboxSummary,
+  getXboxTransactions,
+  rechargeXboxAccount
+} from "@/lib/api";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import type { XboxAccount, XboxCountry, XboxTransaction } from "@/types";
+
+type XboxAction = "recharge" | "consume";
+
+function Input({
+  value,
+  onChange,
+  placeholder,
+  type = "text"
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  type?: string;
+}) {
+  return (
+    <input
+      className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      type={type}
+      min={type === "number" ? "0" : undefined}
+      step={type === "number" ? "0.01" : undefined}
+    />
+  );
+}
+
+function XboxSummaryCards({ country }: { country: XboxCountry }) {
+  const { data } = useQuery({
+    queryKey: ["xbox-summary"],
+    queryFn: getXboxSummary
+  });
+  const localCurrency = country === "US" ? "USD" : "GBP";
+  const rmbCost = country === "US" ? data?.usRmbCostMinor ?? 0 : data?.ukRmbCostMinor ?? 0;
+  const localBalance = country === "US" ? data?.usLocalBalanceMinor ?? 0 : data?.ukLocalBalanceMinor ?? 0;
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      <Card>
+        <CardContent className="p-5">
+          <div className="text-sm text-muted-foreground">{country} 累计 RMB 成本</div>
+          <div className="mt-2 tabular-nums text-3xl font-semibold">{formatMoney(rmbCost, "CNY")}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="p-5">
+          <div className="text-sm text-muted-foreground">{country} 本地余额</div>
+          <div className="mt-2 tabular-nums text-3xl font-semibold">
+            {formatMoney(localBalance, localCurrency)}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function XboxAccountForm() {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [country, setCountry] = useState<XboxCountry>("US");
+  const [remark, setRemark] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!name.trim()) {
+        throw new Error("账户名称不能为空");
+      }
+      return createXboxAccount(name.trim(), country, remark.trim());
+    },
+    onSuccess: async () => {
+      setName("");
+      setRemark("");
+      setMessage("XBOX 账户创建请求已提交");
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+    },
+    onError: (error) => setMessage(error instanceof Error ? error.message : "创建失败")
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>新增 XBOX 账户</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Input value={name} onChange={setName} placeholder="账户名称" />
+        <select
+          className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+          value={country}
+          onChange={(event) => setCountry(event.target.value as XboxCountry)}
+        >
+          <option value="US">美国 USD</option>
+          <option value="UK">英国 GBP</option>
+        </select>
+        <Input value={remark} onChange={setRemark} placeholder="备注" />
+        <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+          <Plus className="h-4 w-4" />
+          创建账户
+        </Button>
+        {message ? <div className="text-sm text-muted-foreground">{message}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function XboxMovementForm({ accounts, selectedAccountId }: { accounts: XboxAccount[]; selectedAccountId: string }) {
+  const queryClient = useQueryClient();
+  const [accountId, setAccountId] = useState(selectedAccountId);
+  const [action, setAction] = useState<XboxAction>("recharge");
+  const [rmbAmount, setRmbAmount] = useState("");
+  const [localAmount, setLocalAmount] = useState("");
+  const [remark, setRemark] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const activeAccountId = accountId || selectedAccountId || accounts[0]?.id || "";
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!activeAccountId) {
+        throw new Error("请选择 XBOX 账户");
+      }
+      if (!localAmount || Number(localAmount) <= 0) {
+        throw new Error("本地金额必须大于 0");
+      }
+      if (action === "recharge") {
+        if (!rmbAmount || Number(rmbAmount) <= 0) {
+          throw new Error("RMB 成本必须大于 0");
+        }
+        return rechargeXboxAccount(activeAccountId, rmbAmount, localAmount);
+      }
+      return consumeXboxAccount(activeAccountId, localAmount, remark);
+    },
+    onSuccess: async () => {
+      setRmbAmount("");
+      setLocalAmount("");
+      setRemark("");
+      setMessage("XBOX 操作请求已提交");
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-summary"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-transactions"] });
+    },
+    onError: (error) => setMessage(error instanceof Error ? error.message : "操作失败")
+  });
+
+  if (accounts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>充值 / 消费</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <select
+          className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+          value={activeAccountId}
+          onChange={(event) => setAccountId(event.target.value)}
+        >
+          {accounts.map((account) => (
+            <option key={account.id} value={account.id}>
+              {account.name} / {account.currency}
+            </option>
+          ))}
+        </select>
+        <div className="grid grid-cols-2 rounded-md border border-border p-1">
+          {(["recharge", "consume"] as XboxAction[]).map((item) => (
+            <button
+              key={item}
+              className={cn(
+                "h-8 rounded text-sm font-medium text-muted-foreground",
+                action === item && "bg-muted text-foreground"
+              )}
+              type="button"
+              onClick={() => setAction(item)}
+            >
+              {item === "recharge" ? "充值" : "消费"}
+            </button>
+          ))}
+        </div>
+        {action === "recharge" ? (
+          <Input value={rmbAmount} onChange={setRmbAmount} placeholder="RMB 成本" type="number" />
+        ) : null}
+        <Input value={localAmount} onChange={setLocalAmount} placeholder="本地金额" type="number" />
+        <Input value={remark} onChange={setRemark} placeholder="备注" />
+        <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+          {action === "recharge" ? <ArrowDownLeft className="h-4 w-4" /> : <ArrowUpRight className="h-4 w-4" />}
+          提交{action === "recharge" ? "充值" : "消费"}
+        </Button>
+        {message ? <div className="text-sm text-muted-foreground">{message}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function XboxAccountsTable({
+  accounts,
+  selectedAccountId,
+  onSelect
+}: {
+  accounts: XboxAccount[];
+  selectedAccountId: string;
+  onSelect: (accountId: string) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>账户列表</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>账户</TableHead>
+              <TableHead>地区</TableHead>
+              <TableHead className="text-right">RMB 成本</TableHead>
+              <TableHead className="text-right">本地余额</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {accounts.map((account) => (
+              <TableRow
+                key={account.id}
+                className={cn("cursor-pointer", selectedAccountId === account.id && "bg-muted/70")}
+                onClick={() => onSelect(account.id)}
+              >
+                <TableCell className="font-medium">{account.name}</TableCell>
+                <TableCell>
+                  <Badge tone="transfer">{account.country === "US" ? "美国 USD" : "英国 GBP"}</Badge>
+                </TableCell>
+                <TableCell className="text-right tabular-nums font-semibold">
+                  {formatMoney(account.rmbCostMinor, "CNY")}
+                </TableCell>
+                <TableCell className="text-right tabular-nums font-semibold">
+                  {formatMoney(account.localBalanceMinor, account.currency)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function XboxTransactionsTable({ transactions }: { transactions: XboxTransaction[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>交易流水</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>时间</TableHead>
+              <TableHead>类型</TableHead>
+              <TableHead>账户</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead className="text-right">RMB 成本</TableHead>
+              <TableHead className="text-right">本地金额</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {transactions.map((transaction) => (
+              <TableRow
+                key={transaction.id}
+                className={transaction.type === "recharge" ? "border-l-2 border-l-emerald-500" : "border-l-2 border-l-red-500"}
+              >
+                <TableCell className="text-muted-foreground">
+                  {transaction.createdAt ? new Date(transaction.createdAt).toLocaleString("zh-CN") : "-"}
+                </TableCell>
+                <TableCell>
+                  <Badge tone={transaction.type === "recharge" ? "success" : "danger"}>
+                    {transaction.type === "recharge" ? "充值" : "消费"}
+                  </Badge>
+                </TableCell>
+                <TableCell>{transaction.accountName}</TableCell>
+                <TableCell className="text-muted-foreground">{transaction.remark || "-"}</TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {transaction.rmbAmountMinor ? formatMoney(transaction.rmbAmountMinor, "CNY") : "-"}
+                </TableCell>
+                <TableCell className="text-right tabular-nums font-semibold">
+                  {formatMoney(
+                    transaction.type === "recharge" ? transaction.localAmountMinor : -transaction.localAmountMinor,
+                    transaction.currency,
+                    { accounting: transaction.type === "consume", signed: transaction.type === "recharge" }
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+            {transactions.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                  当前账户暂无流水
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function XboxPage() {
+  const [country, setCountry] = useState<XboxCountry>("US");
+  const [selectedAccountId, setSelectedAccountId] = useState("");
+  const { data: accounts = [], isFetching, refetch } = useQuery({
+    queryKey: ["xbox-accounts"],
+    queryFn: getXboxAccounts
+  });
+  const scopedAccounts = useMemo(() => accounts.filter((account) => account.country === country), [accounts, country]);
+  const selectedAccount = scopedAccounts.find((account) => account.id === selectedAccountId) ?? scopedAccounts[0];
+  const { data: transactions = [] } = useQuery({
+    queryKey: ["xbox-transactions", selectedAccount?.id],
+    queryFn: () => getXboxTransactions(selectedAccount as XboxAccount),
+    enabled: Boolean(selectedAccount)
+  });
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-normal">XBOX 账户</h2>
+          <p className="mt-1 text-sm text-muted-foreground">美国 USD、英国 GBP 账户的 RMB 成本、本地余额和流水。</p>
+        </div>
+        <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className="h-4 w-4" />
+          刷新
+        </Button>
+      </div>
+
+      <div className="grid gap-2 rounded-lg border border-border bg-card p-2 md:grid-cols-2">
+        {(["US", "UK"] as XboxCountry[]).map((item) => (
+          <button
+            key={item}
+            className={cn("rounded-md px-4 py-3 text-left hover:bg-muted", country === item && "bg-muted")}
+            type="button"
+            onClick={() => {
+              setCountry(item);
+              setSelectedAccountId("");
+            }}
+          >
+            <div className="flex items-center gap-2 font-semibold">
+              <Gamepad2 className="h-4 w-4" />
+              {item === "US" ? "美国 USD" : "英国 GBP"}
+            </div>
+            <div className="mt-1 text-sm text-muted-foreground">账户余额、RMB 成本和交易流水</div>
+          </button>
+        ))}
+      </div>
+
+      <XboxSummaryCards country={country} />
+      <div className="grid gap-3 xl:grid-cols-[0.8fr_1.2fr]">
+        <XboxAccountForm />
+        <XboxMovementForm accounts={scopedAccounts} selectedAccountId={selectedAccount?.id ?? ""} />
+      </div>
+      <XboxAccountsTable
+        accounts={scopedAccounts}
+        selectedAccountId={selectedAccount?.id ?? ""}
+        onSelect={setSelectedAccountId}
+      />
+      <XboxTransactionsTable transactions={transactions} />
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -8,7 +8,11 @@ import type {
   VendorBill,
   VendorSummary,
   WalletBalance,
-  WalletType
+  WalletType,
+  XboxAccount,
+  XboxCountry,
+  XboxSummary,
+  XboxTransaction
 } from "@/types";
 
 type AssetWalletResponse = {
@@ -63,6 +67,47 @@ type VendorBillResponse = {
   status: "pending" | "settled";
   due_date?: string | null;
   dueDate?: string | null;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type XboxAccountResponse = {
+  id: string | number;
+  name: string;
+  country: XboxCountry;
+  currency: "USD" | "GBP";
+  rmb_cost?: string | number;
+  rmbCost?: string | number;
+  local_balance?: string | number;
+  localBalance?: string | number;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type XboxSummaryResponse = {
+  us_rmb_cost?: string | number;
+  usRmbCost?: string | number;
+  us_local_balance?: string | number;
+  usLocalBalance?: string | number;
+  uk_rmb_cost?: string | number;
+  ukRmbCost?: string | number;
+  uk_local_balance?: string | number;
+  ukLocalBalance?: string | number;
+};
+
+type XboxTransactionResponse = {
+  id: string | number;
+  account_id?: string | number;
+  accountId?: string | number;
+  account_name?: string;
+  accountName?: string;
+  rmb_amount?: string | number;
+  rmbAmount?: string | number;
+  local_amount?: string | number;
+  localAmount?: string | number;
+  type: "recharge" | "consume";
   remark?: string | null;
   created_at?: string;
   createdAt?: string;
@@ -258,5 +303,91 @@ export function settleVendorBill(billId: string) {
       throw new Error(`settle returned ${response.status}`);
     }
     return response.json();
+  });
+}
+
+function normalizeXboxAccount(account: XboxAccountResponse): XboxAccount {
+  return {
+    id: String(account.id),
+    name: account.name,
+    country: account.country,
+    currency: account.currency,
+    rmbCostMinor: decimalToMinor(account.rmb_cost ?? account.rmbCost ?? 0, "CNY"),
+    localBalanceMinor: decimalToMinor(account.local_balance ?? account.localBalance ?? 0, account.currency),
+    remark: account.remark,
+    createdAt: account.created_at ?? account.createdAt
+  };
+}
+
+function normalizeXboxSummary(summary: XboxSummaryResponse): XboxSummary {
+  return {
+    usRmbCostMinor: decimalToMinor(summary.us_rmb_cost ?? summary.usRmbCost ?? 0, "CNY"),
+    usLocalBalanceMinor: decimalToMinor(summary.us_local_balance ?? summary.usLocalBalance ?? 0, "USD"),
+    ukRmbCostMinor: decimalToMinor(summary.uk_rmb_cost ?? summary.ukRmbCost ?? 0, "CNY"),
+    ukLocalBalanceMinor: decimalToMinor(summary.uk_local_balance ?? summary.ukLocalBalance ?? 0, "GBP")
+  };
+}
+
+function normalizeXboxTransaction(transaction: XboxTransactionResponse, account: XboxAccount): XboxTransaction {
+  return {
+    id: String(transaction.id),
+    accountId: String(transaction.account_id ?? transaction.accountId ?? account.id),
+    accountName: transaction.account_name ?? transaction.accountName ?? account.name,
+    rmbAmountMinor: decimalToMinor(transaction.rmb_amount ?? transaction.rmbAmount ?? 0, "CNY"),
+    localAmountMinor: decimalToMinor(transaction.local_amount ?? transaction.localAmount ?? 0, account.currency),
+    type: transaction.type,
+    remark: transaction.remark,
+    createdAt: transaction.created_at ?? transaction.createdAt,
+    currency: account.currency
+  };
+}
+
+export async function getXboxAccounts(): Promise<XboxAccount[]> {
+  try {
+    const accounts = await fetchJson<XboxAccountResponse[]>("/api/xbox/accounts");
+    return accounts.map(normalizeXboxAccount);
+  } catch {
+    const { mockXboxAccounts } = await import("@/lib/mock-data");
+    return mockXboxAccounts;
+  }
+}
+
+export async function getXboxSummary(): Promise<XboxSummary> {
+  try {
+    const summary = await fetchJson<XboxSummaryResponse>("/api/xbox/summary");
+    return normalizeXboxSummary(summary);
+  } catch {
+    const { mockXboxSummary } = await import("@/lib/mock-data");
+    return mockXboxSummary;
+  }
+}
+
+export async function getXboxTransactions(account: XboxAccount): Promise<XboxTransaction[]> {
+  try {
+    const transactions = await fetchJson<XboxTransactionResponse[]>(
+      `/api/xbox/accounts/${account.id}/transactions`
+    );
+    return transactions.map((transaction) => normalizeXboxTransaction(transaction, account));
+  } catch {
+    const { mockXboxTransactions } = await import("@/lib/mock-data");
+    return mockXboxTransactions[account.id] ?? [];
+  }
+}
+
+export function createXboxAccount(name: string, country: XboxCountry, remark: string) {
+  return postJson("/api/xbox/accounts", { name, country, remark });
+}
+
+export function rechargeXboxAccount(accountId: string, rmbAmount: string, localAmount: string) {
+  return postJson(`/api/xbox/accounts/${accountId}/recharge`, {
+    rmb_amount: rmbAmount,
+    local_amount: localAmount
+  });
+}
+
+export function consumeXboxAccount(accountId: string, localAmount: string, remark: string) {
+  return postJson(`/api/xbox/accounts/${accountId}/consume`, {
+    local_amount: localAmount,
+    remark
   });
 }

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -1,4 +1,13 @@
-import type { AssetTransaction, DashboardData, Vendor, VendorBill, WalletBalance } from "@/types";
+import type {
+  AssetTransaction,
+  DashboardData,
+  Vendor,
+  VendorBill,
+  WalletBalance,
+  XboxAccount,
+  XboxSummary,
+  XboxTransaction
+} from "@/types";
 
 export const mockWallets: WalletBalance[] = [
   {
@@ -174,6 +183,76 @@ export const mockVendorBills: Record<string, VendorBill[]> = {
       remark: "服务垫款",
       createdAt: "2026-04-24T03:00:00.000Z",
       currency: "CNY"
+    }
+  ]
+};
+
+export const mockXboxAccounts: XboxAccount[] = [
+  {
+    id: "xbox-us-1",
+    name: "US Game Pass",
+    country: "US",
+    currency: "USD",
+    rmbCostMinor: 48_600_00,
+    localBalanceMinor: 7_850_00,
+    remark: "美国区主账户",
+    createdAt: "2026-04-12T02:00:00.000Z"
+  },
+  {
+    id: "xbox-uk-1",
+    name: "UK Store",
+    country: "UK",
+    currency: "GBP",
+    rmbCostMinor: 39_200_00,
+    localBalanceMinor: 5_430_00,
+    remark: "英国区主账户",
+    createdAt: "2026-04-16T02:00:00.000Z"
+  }
+];
+
+export const mockXboxSummary: XboxSummary = {
+  usRmbCostMinor: 48_600_00,
+  usLocalBalanceMinor: 7_850_00,
+  ukRmbCostMinor: 39_200_00,
+  ukLocalBalanceMinor: 5_430_00
+};
+
+export const mockXboxTransactions: Record<string, XboxTransaction[]> = {
+  "xbox-us-1": [
+    {
+      id: "xbox-tx-1",
+      accountId: "xbox-us-1",
+      accountName: "US Game Pass",
+      rmbAmountMinor: 15_000_00,
+      localAmountMinor: 2_000_00,
+      type: "recharge",
+      remark: "礼品卡充值",
+      createdAt: "2026-04-20T04:30:00.000Z",
+      currency: "USD"
+    },
+    {
+      id: "xbox-tx-2",
+      accountId: "xbox-us-1",
+      accountName: "US Game Pass",
+      rmbAmountMinor: 0,
+      localAmountMinor: 320_00,
+      type: "consume",
+      remark: "订阅扣费",
+      createdAt: "2026-04-24T08:30:00.000Z",
+      currency: "USD"
+    }
+  ],
+  "xbox-uk-1": [
+    {
+      id: "xbox-tx-3",
+      accountId: "xbox-uk-1",
+      accountName: "UK Store",
+      rmbAmountMinor: 12_000_00,
+      localAmountMinor: 1_300_00,
+      type: "recharge",
+      remark: "英国区充值",
+      createdAt: "2026-04-22T09:00:00.000Z",
+      currency: "GBP"
     }
   ]
 };

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -54,6 +54,38 @@ export type VendorBill = {
   currency: "CNY";
 };
 
+export type XboxCountry = "US" | "UK";
+
+export type XboxAccount = {
+  id: string;
+  name: string;
+  country: XboxCountry;
+  currency: "USD" | "GBP";
+  rmbCostMinor: number;
+  localBalanceMinor: number;
+  remark?: string | null;
+  createdAt?: string;
+};
+
+export type XboxTransaction = {
+  id: string;
+  accountId: string;
+  accountName: string;
+  rmbAmountMinor: number;
+  localAmountMinor: number;
+  type: "recharge" | "consume";
+  remark?: string | null;
+  createdAt?: string;
+  currency: "USD" | "GBP";
+};
+
+export type XboxSummary = {
+  usRmbCostMinor: number;
+  usLocalBalanceMinor: number;
+  ukRmbCostMinor: number;
+  ukLocalBalanceMinor: number;
+};
+
 export type ModuleSection = {
   id: string;
   title: string;


### PR DESCRIPTION
## 关联 Issue
Closes #19

## 依赖
- 依赖供应商页面 PR #23，当前 PR base 为 `feature/issue-18`

## 改动说明
- 新增 /xbox 专用 XBOX 账户页面
- 支持美国 USD / 英国 GBP Tab 切换
- 展示各地区 RMB 成本与本地余额摘要
- 展示账户列表：地区、RMB 成本、本地余额
- 新增 XBOX 账户创建表单，对接 POST /api/xbox/accounts
- 新增充值 / 消费表单，对接 /recharge 与 /consume
- 新增交易流水表，区分 recharge / consume
- API 不可用时使用 mock XBOX 账户、摘要和流水用于前端验收

## 自测情况
- [x] cd frontend && npm run build
- [x] cd frontend && npm run typecheck
- [x] python3 -m pytest -q
- [x] git diff --check
- [x] 本地 http://localhost:3001/xbox 返回 200

## 注意
- 继续沿用 Next.js 14，没有擅自升级主版本。
- 本机 3000 上仍有旧 dev 进程不可由当前 shell kill，验收请使用 3001。