### PR TITLE
[PR] [FEAT-F5] 淘宝资金页面

### DIFF
--- a/frontend/app/[section]/page.tsx
+++ b/frontend/app/[section]/page.tsx
@@ -3,6 +3,7 @@ import { AssetsPage } from "@/components/assets-page";
 import { ModuleOverview } from "@/components/module-overview";
 import { VendorsPage } from "@/components/vendors-page";
 import { XboxPage } from "@/components/xbox-page";
+import { TaobaoPage } from "@/components/taobao-page";
 import { sectionById, sectionIds } from "@/lib/navigation";
 
 type SectionPageProps = {
@@ -19,7 +20,8 @@ export default function SectionPage({ params }: SectionPageProps) {
       {section.id === "assets" ? <AssetsPage /> : null}
       {section.id === "vendors" ? <VendorsPage /> : null}
       {section.id === "xbox" ? <XboxPage /> : null}
-      {section.id !== "assets" && section.id !== "vendors" && section.id !== "xbox" ? (
+      {section.id === "taobao" ? <TaobaoPage /> : null}
+      {section.id !== "assets" && section.id !== "vendors" && section.id !== "xbox" && section.id !== "taobao" ? (
         <ModuleOverview section={section} />
       ) : null}
     </AppShell>

--- a/frontend/components/taobao-page.tsx
+++ b/frontend/components/taobao-page.tsx
@@ -1,0 +1,352 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowDownLeft, ArrowUpRight, Plus, RefreshCcw, ShoppingBag } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  createTaobaoAccount,
+  creditTaobaoSettled,
+  creditTaobaoUnsettled,
+  debitTaobaoSettled,
+  getTaobaoAccounts,
+  getTaobaoTransactions
+} from "@/lib/api";
+import { formatMoney, sumMinor } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import type { TaobaoAccount, TaobaoTransaction } from "@/types";
+
+type TaobaoAction = "unsettled-credit" | "settled-credit" | "settled-debit";
+
+function Input({
+  value,
+  onChange,
+  placeholder,
+  type = "text"
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  type?: string;
+}) {
+  return (
+    <input
+      className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder={placeholder}
+      type={type}
+      min={type === "number" ? "0" : undefined}
+      step={type === "number" ? "0.01" : undefined}
+    />
+  );
+}
+
+function SummaryCards({ accounts }: { accounts: TaobaoAccount[] }) {
+  const unsettled = sumMinor(accounts.map((account) => account.unsettledBalanceMinor));
+  const settled = sumMinor(accounts.map((account) => account.settledBalanceMinor));
+
+  return (
+    <div className="grid gap-3 md:grid-cols-3">
+      <Card>
+        <CardContent className="p-5">
+          <div className="text-sm text-muted-foreground">未结算</div>
+          <div className="mt-2 tabular-nums text-3xl font-semibold">{formatMoney(unsettled, "CNY")}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="p-5">
+          <div className="text-sm text-muted-foreground">已结算</div>
+          <div className="mt-2 tabular-nums text-3xl font-semibold">{formatMoney(settled, "CNY")}</div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardContent className="p-5">
+          <div className="text-sm text-muted-foreground">账户数</div>
+          <div className="mt-2 tabular-nums text-3xl font-semibold">{accounts.length}</div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function CreateAccountForm() {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [remark, setRemark] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!name.trim()) {
+        throw new Error("淘宝账户名称不能为空");
+      }
+      return createTaobaoAccount(name.trim(), remark.trim());
+    },
+    onSuccess: async () => {
+      setName("");
+      setRemark("");
+      setMessage("淘宝账户创建请求已提交");
+      await queryClient.invalidateQueries({ queryKey: ["taobao-accounts"] });
+    },
+    onError: (error) => setMessage(error instanceof Error ? error.message : "创建失败")
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>新增淘宝账户</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Input value={name} onChange={setName} placeholder="账户名称" />
+        <Input value={remark} onChange={setRemark} placeholder="备注" />
+        <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+          <Plus className="h-4 w-4" />
+          创建账户
+        </Button>
+        {message ? <div className="text-sm text-muted-foreground">{message}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function MovementForm({ accounts, selectedAccountId }: { accounts: TaobaoAccount[]; selectedAccountId: string }) {
+  const queryClient = useQueryClient();
+  const [accountId, setAccountId] = useState(selectedAccountId);
+  const [action, setAction] = useState<TaobaoAction>("unsettled-credit");
+  const [amount, setAmount] = useState("");
+  const [remark, setRemark] = useState("");
+  const [message, setMessage] = useState<string | null>(null);
+  const activeAccountId = accountId || selectedAccountId || accounts[0]?.id || "";
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      if (!activeAccountId) {
+        throw new Error("请选择淘宝账户");
+      }
+      if (!amount || Number(amount) <= 0) {
+        throw new Error("金额必须大于 0");
+      }
+      if (action === "unsettled-credit") {
+        return creditTaobaoUnsettled(activeAccountId, amount, remark);
+      }
+      if (action === "settled-credit") {
+        return creditTaobaoSettled(activeAccountId, amount, remark);
+      }
+      return debitTaobaoSettled(activeAccountId, amount, remark);
+    },
+    onSuccess: async () => {
+      setAmount("");
+      setRemark("");
+      setMessage("淘宝资金操作请求已提交");
+      await queryClient.invalidateQueries({ queryKey: ["taobao-accounts"] });
+      await queryClient.invalidateQueries({ queryKey: ["taobao-transactions"] });
+    },
+    onError: (error) => setMessage(error instanceof Error ? error.message : "操作失败")
+  });
+
+  if (accounts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>资金操作</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <select
+          className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+          value={activeAccountId}
+          onChange={(event) => setAccountId(event.target.value)}
+        >
+          {accounts.map((account) => (
+            <option key={account.id} value={account.id}>
+              {account.name}
+            </option>
+          ))}
+        </select>
+        <div className="grid gap-2 rounded-md border border-border p-1 md:grid-cols-3">
+          {[
+            ["unsettled-credit", "未结算入账"],
+            ["settled-credit", "已结算入账"],
+            ["settled-debit", "已结算出账"]
+          ].map(([id, label]) => (
+            <button
+              key={id}
+              className={cn(
+                "h-8 rounded text-sm font-medium text-muted-foreground",
+                action === id && "bg-muted text-foreground"
+              )}
+              type="button"
+              onClick={() => setAction(id as TaobaoAction)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        <Input value={amount} onChange={setAmount} placeholder="金额" type="number" />
+        <Input value={remark} onChange={setRemark} placeholder="备注" />
+        <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+          {action === "settled-debit" ? <ArrowUpRight className="h-4 w-4" /> : <ArrowDownLeft className="h-4 w-4" />}
+          提交操作
+        </Button>
+        {message ? <div className="text-sm text-muted-foreground">{message}</div> : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function AccountsTable({
+  accounts,
+  selectedAccountId,
+  onSelect
+}: {
+  accounts: TaobaoAccount[];
+  selectedAccountId: string;
+  onSelect: (accountId: string) => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>淘宝账户</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>账户</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead className="text-right">未结算</TableHead>
+              <TableHead className="text-right">已结算</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {accounts.map((account) => (
+              <TableRow
+                key={account.id}
+                className={cn("cursor-pointer", selectedAccountId === account.id && "bg-muted/70")}
+                onClick={() => onSelect(account.id)}
+              >
+                <TableCell className="font-medium">{account.name}</TableCell>
+                <TableCell className="text-muted-foreground">{account.remark || "-"}</TableCell>
+                <TableCell className="text-right tabular-nums font-semibold">
+                  {formatMoney(account.unsettledBalanceMinor, "CNY")}
+                </TableCell>
+                <TableCell className="text-right tabular-nums font-semibold">
+                  {formatMoney(account.settledBalanceMinor, "CNY")}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function TransactionsTable({ transactions }: { transactions: TaobaoTransaction[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>交易流水</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>时间</TableHead>
+              <TableHead>钱包范围</TableHead>
+              <TableHead>方向</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead className="text-right">金额</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {transactions.map((transaction) => (
+              <TableRow
+                key={transaction.id}
+                className={transaction.direction === "in" ? "border-l-2 border-l-emerald-500" : "border-l-2 border-l-red-500"}
+              >
+                <TableCell className="text-muted-foreground">
+                  {transaction.createdAt ? new Date(transaction.createdAt).toLocaleString("zh-CN") : "-"}
+                </TableCell>
+                <TableCell>
+                  <Badge tone={transaction.walletScope === "unsettled" ? "transfer" : "neutral"}>
+                    {transaction.walletScope === "unsettled" ? "未结算" : "已结算"}
+                  </Badge>
+                </TableCell>
+                <TableCell>
+                  <Badge tone={transaction.direction === "in" ? "success" : "danger"}>
+                    {transaction.direction === "in" ? "入账" : "出账"}
+                  </Badge>
+                </TableCell>
+                <TableCell className="text-muted-foreground">{transaction.remark || "-"}</TableCell>
+                <TableCell className="text-right tabular-nums font-semibold">
+                  {formatMoney(
+                    transaction.direction === "in" ? transaction.amountMinor : -transaction.amountMinor,
+                    "CNY",
+                    { accounting: transaction.direction === "out", signed: transaction.direction === "in" }
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function TaobaoPage() {
+  const [selectedAccountId, setSelectedAccountId] = useState("");
+  const { data: accounts = [], isFetching, refetch } = useQuery({
+    queryKey: ["taobao-accounts"],
+    queryFn: getTaobaoAccounts
+  });
+  const selectedAccount = accounts.find((account) => account.id === selectedAccountId) ?? accounts[0];
+  const { data: transactions = [] } = useQuery({
+    queryKey: ["taobao-transactions", selectedAccount?.id],
+    queryFn: () => getTaobaoTransactions(selectedAccount as TaobaoAccount),
+    enabled: Boolean(selectedAccount)
+  });
+  const transactionCount = useMemo(() => transactions.length, [transactions]);
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-normal">淘宝资金</h2>
+          <p className="mt-1 text-sm text-muted-foreground">淘宝未结算、已结算钱包和资金流水。</p>
+        </div>
+        <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className="h-4 w-4" />
+          刷新
+        </Button>
+      </div>
+
+      <SummaryCards accounts={accounts} />
+      <div className="grid gap-3 xl:grid-cols-[0.8fr_1.2fr]">
+        <CreateAccountForm />
+        <MovementForm accounts={accounts} selectedAccountId={selectedAccount?.id ?? ""} />
+      </div>
+      <div className="grid gap-3 xl:grid-cols-[1.1fr_0.9fr]">
+        <AccountsTable accounts={accounts} selectedAccountId={selectedAccount?.id ?? ""} onSelect={setSelectedAccountId} />
+        <Card>
+          <CardContent className="flex items-center justify-between gap-4 p-5">
+            <div>
+              <div className="text-sm text-muted-foreground">当前账户流水数</div>
+              <div className="mt-2 tabular-nums text-3xl font-semibold">{transactionCount}</div>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+              <ShoppingBag className="h-5 w-5" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+      <TransactionsTable transactions={transactions} />
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -12,7 +12,9 @@ import type {
   XboxAccount,
   XboxCountry,
   XboxSummary,
-  XboxTransaction
+  XboxTransaction,
+  TaobaoAccount,
+  TaobaoTransaction
 } from "@/types";
 
 type AssetWalletResponse = {
@@ -108,6 +110,35 @@ type XboxTransactionResponse = {
   local_amount?: string | number;
   localAmount?: string | number;
   type: "recharge" | "consume";
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type TaobaoAccountResponse = {
+  id: string | number;
+  name: string;
+  unsettled_wallet_id?: string | number;
+  unsettledWalletId?: string | number;
+  settled_wallet_id?: string | number;
+  settledWalletId?: string | number;
+  unsettled_balance?: string | number;
+  unsettledBalance?: string | number;
+  settled_balance?: string | number;
+  settledBalance?: string | number;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type TaobaoTransactionResponse = {
+  id: string | number;
+  wallet_id?: string | number;
+  walletId?: string | number;
+  wallet_scope?: "unsettled" | "settled";
+  walletScope?: "unsettled" | "settled";
+  amount: string | number;
+  direction: "in" | "out";
   remark?: string | null;
   created_at?: string;
   createdAt?: string;
@@ -390,4 +421,67 @@ export function consumeXboxAccount(accountId: string, localAmount: string, remar
     local_amount: localAmount,
     remark
   });
+}
+
+function normalizeTaobaoAccount(account: TaobaoAccountResponse): TaobaoAccount {
+  return {
+    id: String(account.id),
+    name: account.name,
+    unsettledWalletId: String(account.unsettled_wallet_id ?? account.unsettledWalletId ?? ""),
+    settledWalletId: String(account.settled_wallet_id ?? account.settledWalletId ?? ""),
+    unsettledBalanceMinor: decimalToMinor(account.unsettled_balance ?? account.unsettledBalance ?? 0, "CNY"),
+    settledBalanceMinor: decimalToMinor(account.settled_balance ?? account.settledBalance ?? 0, "CNY"),
+    remark: account.remark,
+    createdAt: account.created_at ?? account.createdAt
+  };
+}
+
+function normalizeTaobaoTransaction(transaction: TaobaoTransactionResponse): TaobaoTransaction {
+  return {
+    id: String(transaction.id),
+    walletId: String(transaction.wallet_id ?? transaction.walletId ?? ""),
+    walletScope: transaction.wallet_scope ?? transaction.walletScope ?? "settled",
+    amountMinor: decimalToMinor(transaction.amount, "CNY"),
+    direction: transaction.direction,
+    remark: transaction.remark,
+    createdAt: transaction.created_at ?? transaction.createdAt
+  };
+}
+
+export async function getTaobaoAccounts(): Promise<TaobaoAccount[]> {
+  try {
+    const accounts = await fetchJson<TaobaoAccountResponse[]>("/api/taobao/accounts");
+    return accounts.map(normalizeTaobaoAccount);
+  } catch {
+    const { mockTaobaoAccounts } = await import("@/lib/mock-data");
+    return mockTaobaoAccounts;
+  }
+}
+
+export async function getTaobaoTransactions(account: TaobaoAccount): Promise<TaobaoTransaction[]> {
+  try {
+    const transactions = await fetchJson<TaobaoTransactionResponse[]>(
+      `/api/taobao/accounts/${account.id}/transactions`
+    );
+    return transactions.map(normalizeTaobaoTransaction);
+  } catch {
+    const { mockTaobaoTransactions } = await import("@/lib/mock-data");
+    return mockTaobaoTransactions[account.id] ?? [];
+  }
+}
+
+export function createTaobaoAccount(name: string, remark: string) {
+  return postJson("/api/taobao/accounts", { name, remark });
+}
+
+export function creditTaobaoUnsettled(accountId: string, amount: string, remark: string) {
+  return postJson(`/api/taobao/accounts/${accountId}/unsettled/credit`, { amount, remark });
+}
+
+export function creditTaobaoSettled(accountId: string, amount: string, remark: string) {
+  return postJson(`/api/taobao/accounts/${accountId}/settled/credit`, { amount, remark });
+}
+
+export function debitTaobaoSettled(accountId: string, amount: string, remark: string) {
+  return postJson(`/api/taobao/accounts/${accountId}/settled/debit`, { amount, remark });
 }

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -4,6 +4,8 @@ import type {
   Vendor,
   VendorBill,
   WalletBalance,
+  TaobaoAccount,
+  TaobaoTransaction,
   XboxAccount,
   XboxSummary,
   XboxTransaction
@@ -253,6 +255,51 @@ export const mockXboxTransactions: Record<string, XboxTransaction[]> = {
       remark: "英国区充值",
       createdAt: "2026-04-22T09:00:00.000Z",
       currency: "GBP"
+    }
+  ]
+};
+
+export const mockTaobaoAccounts: TaobaoAccount[] = [
+  {
+    id: "taobao-1",
+    name: "淘宝主店",
+    unsettledWalletId: "taobao-unsettled",
+    settledWalletId: "taobao-settled",
+    unsettledBalanceMinor: 93_400_00,
+    settledBalanceMinor: 41_250_00,
+    remark: "默认淘宝账户",
+    createdAt: "2026-04-14T03:00:00.000Z"
+  }
+];
+
+export const mockTaobaoTransactions: Record<string, TaobaoTransaction[]> = {
+  "taobao-1": [
+    {
+      id: "taobao-tx-1",
+      walletId: "taobao-unsettled",
+      walletScope: "unsettled",
+      amountMinor: 23_000_00,
+      direction: "in",
+      remark: "未结算订单",
+      createdAt: "2026-04-21T05:00:00.000Z"
+    },
+    {
+      id: "taobao-tx-2",
+      walletId: "taobao-settled",
+      walletScope: "settled",
+      amountMinor: 18_500_00,
+      direction: "in",
+      remark: "已结算订单",
+      createdAt: "2026-04-24T09:00:00.000Z"
+    },
+    {
+      id: "taobao-tx-3",
+      walletId: "taobao-settled",
+      walletScope: "settled",
+      amountMinor: 5_000_00,
+      direction: "out",
+      remark: "提现",
+      createdAt: "2026-04-25T10:00:00.000Z"
     }
   ]
 };

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -86,6 +86,27 @@ export type XboxSummary = {
   ukLocalBalanceMinor: number;
 };
 
+export type TaobaoAccount = {
+  id: string;
+  name: string;
+  unsettledWalletId: string;
+  settledWalletId: string;
+  unsettledBalanceMinor: number;
+  settledBalanceMinor: number;
+  remark?: string | null;
+  createdAt?: string;
+};
+
+export type TaobaoTransaction = {
+  id: string;
+  walletId: string;
+  walletScope: "unsettled" | "settled";
+  amountMinor: number;
+  direction: "in" | "out";
+  remark?: string | null;
+  createdAt?: string;
+};
+
 export type ModuleSection = {
   id: string;
   title: string;


### PR DESCRIPTION
## 关联 Issue
Closes #20

## 依赖
- 依赖 XBOX 页面 PR #24，当前 PR base 为 `feature/issue-19`

## 改动说明
- 新增 /taobao 专用淘宝资金页面
- 展示未结算、已结算、账户数摘要
- 展示淘宝账户列表及未结算 / 已结算余额
- 新增淘宝账户创建表单，对接 POST /api/taobao/accounts
- 新增资金操作表单，支持未结算入账、已结算入账、已结算出账
- 新增交易流水表，展示 unsettled / settled scope 与 in / out 方向
- API 不可用时使用 mock 淘宝账户和流水用于前端验收

## 自测情况
- [x] cd frontend && npm run build
- [x] cd frontend && npm run typecheck
- [x] python3 -m pytest -q
- [x] git diff --check
- [x] 本地 http://localhost:3001/taobao 返回 200

## 注意
- 继续沿用 Next.js 14，没有擅自升级主版本。
- 本机 3000 上仍有旧 dev 进程不可由当前 shell kill，验收请使用 3001。