### PR TITLE
[PR] [FEAT] 资产钱包三层结构：支付宝/微信/币安子账号体系

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 from typing import Iterator
 
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 
@@ -43,6 +43,24 @@ def init_db() -> None:
     from src.models import taobao  # noqa: F401
 
     Base.metadata.create_all(bind=engine)
+    _ensure_wallet_is_group_column()
+
+
+def _ensure_wallet_is_group_column() -> None:
+    """Add the wallet group marker to existing SQLite dev databases."""
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+
+    inspector = inspect(engine)
+    if "wallets" not in inspector.get_table_names():
+        return
+
+    column_names = {column["name"] for column in inspector.get_columns("wallets")}
+    if "is_group" in column_names:
+        return
+
+    with engine.begin() as connection:
+        connection.execute(text("ALTER TABLE wallets ADD COLUMN is_group BOOLEAN NOT NULL DEFAULT 0"))
 
 
 def get_db() -> Iterator[Session]:

--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Numeric, String, func, select
+from sqlalchemy import Boolean, DateTime, ForeignKey, Numeric, String, func, select
 from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from src.database import Base
@@ -42,6 +42,7 @@ class Wallet(Base):
     type: Mapped[WalletType] = mapped_column(String(32), nullable=False)
     currency: Mapped[Currency] = mapped_column(String(16), nullable=False)
     balance: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False, default=Decimal("0"))
+    is_group: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="0")
     parent_id: Mapped[Optional[int]] = mapped_column(ForeignKey("wallets.id"), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -99,11 +100,14 @@ def create_wallet(
     currency: Currency | str,
     parent_id: int | None = None,
     opening_balance: Decimal | int | float | str = Decimal("0"),
+    is_group: bool = False,
 ) -> Wallet:
     """Create a wallet or sub-wallet and flush it into the current session."""
     balance = Decimal(str(opening_balance))
     if balance < 0:
         raise ValueError("opening_balance cannot be negative")
+    if is_group:
+        balance = Decimal("0")
     if parent_id is not None:
         get_wallet(session, parent_id)
 
@@ -113,6 +117,7 @@ def create_wallet(
         currency=Currency(currency),
         parent_id=parent_id,
         balance=balance,
+        is_group=is_group,
     )
     session.add(wallet)
     session.flush()

--- a/src/routers/assets.py
+++ b/src/routers/assets.py
@@ -19,6 +19,7 @@ router = APIRouter(prefix="/wallets/assets", tags=["asset-wallets"])
 
 class SubWalletCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
+    is_group: bool = False
 
 
 class WalletMovementRequest(BaseModel):
@@ -32,12 +33,10 @@ class WalletOut(BaseModel):
     type: str
     currency: str
     balance: Decimal
+    is_group: bool
     parent_id: Optional[int]
     created_at: str
-
-
-class AssetWalletOut(WalletOut):
-    children: list[WalletOut] = []
+    children: list["WalletOut"] = Field(default_factory=list)
 
 
 class TransactionOut(BaseModel):
@@ -55,15 +54,27 @@ def _value(value):
     return value
 
 
-def serialize_wallet(wallet: Wallet) -> WalletOut:
+def _computed_balance(wallet: Wallet, children_by_parent: dict[int, list[Wallet]]) -> Decimal:
+    if not wallet.is_group:
+        return wallet.balance
+    return sum(
+        (_computed_balance(child, children_by_parent) for child in children_by_parent.get(wallet.id, [])),
+        Decimal("0"),
+    )
+
+
+def serialize_wallet(wallet: Wallet, children_by_parent: dict[int, list[Wallet]] | None = None) -> WalletOut:
+    child_wallets = children_by_parent.get(wallet.id, []) if children_by_parent is not None else []
     return WalletOut(
         id=wallet.id,
         name=wallet.name,
         type=_value(wallet.type),
         currency=_value(wallet.currency),
-        balance=wallet.balance,
+        balance=_computed_balance(wallet, children_by_parent) if children_by_parent is not None else wallet.balance,
+        is_group=bool(wallet.is_group),
         parent_id=wallet.parent_id,
         created_at=wallet.created_at.isoformat() if wallet.created_at else "",
+        children=[serialize_wallet(child, children_by_parent) for child in child_wallets],
     )
 
 
@@ -87,25 +98,29 @@ def get_asset_wallet_or_404(session: Session, wallet_id: int) -> Wallet:
     return wallet
 
 
-@router.get("", response_model=list[AssetWalletOut])
-def list_assets(db: Session = Depends(get_db)) -> list[AssetWalletOut]:
+def get_postable_asset_wallet_or_404(session: Session, wallet_id: int) -> Wallet:
+    wallet = get_asset_wallet_or_404(session, wallet_id)
+    if wallet.is_group:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="分组钱包不可直接记账，请操作叶子钱包",
+        )
+    return wallet
+
+
+@router.get("", response_model=list[WalletOut])
+def list_assets(db: Session = Depends(get_db)) -> list[WalletOut]:
     wallets = list_asset_wallets(db)
-    children_by_parent: dict[int, list[WalletOut]] = {}
+    children_by_parent: dict[int, list[Wallet]] = {}
     roots: list[Wallet] = []
 
     for wallet in wallets:
         if wallet.parent_id is None:
             roots.append(wallet)
         else:
-            children_by_parent.setdefault(wallet.parent_id, []).append(serialize_wallet(wallet))
+            children_by_parent.setdefault(wallet.parent_id, []).append(wallet)
 
-    return [
-        AssetWalletOut(
-            **serialize_wallet(root).model_dump(),
-            children=children_by_parent.get(root.id, []),
-        )
-        for root in roots
-    ]
+    return [serialize_wallet(root, children_by_parent) for root in roots]
 
 
 @router.post("/{wallet_id}/sub", response_model=WalletOut, status_code=status.HTTP_201_CREATED)
@@ -115,7 +130,7 @@ def create_sub_wallet(
     db: Session = Depends(get_db),
 ) -> WalletOut:
     parent = get_asset_wallet_or_404(db, wallet_id)
-    sub_wallet = create_asset_sub_wallet(db, parent, request.name)
+    sub_wallet = create_asset_sub_wallet(db, parent, request.name, is_group=request.is_group)
     db.commit()
     db.refresh(sub_wallet)
     return serialize_wallet(sub_wallet)
@@ -127,7 +142,7 @@ def credit_asset_wallet(
     request: WalletMovementRequest,
     db: Session = Depends(get_db),
 ) -> TransactionOut:
-    get_asset_wallet_or_404(db, wallet_id)
+    get_postable_asset_wallet_or_404(db, wallet_id)
     transaction = credit(db, wallet_id, request.amount, request.remark)
     db.commit()
     db.refresh(transaction)
@@ -140,7 +155,7 @@ def debit_asset_wallet(
     request: WalletMovementRequest,
     db: Session = Depends(get_db),
 ) -> TransactionOut:
-    get_asset_wallet_or_404(db, wallet_id)
+    get_postable_asset_wallet_or_404(db, wallet_id)
     try:
         transaction = debit(db, wallet_id, request.amount, request.remark)
     except ValueError as exc:

--- a/src/services/assets.py
+++ b/src/services/assets.py
@@ -12,36 +12,86 @@ from src.models.wallet import Currency, Wallet, WalletType, create_wallet
 ASSET_TYPES = {WalletType.ASSET_RMB.value, WalletType.ASSET_USDT.value}
 DEFAULT_ASSET_WALLETS = (
     {
-        "name": "RMB Main",
+        "name": "RMB钱包",
         "wallet_type": WalletType.ASSET_RMB,
         "currency": Currency.CNY,
+        "groups": (
+            {
+                "name": "支付宝钱包",
+                "children": ("丙火网络支付宝", "TOM支付宝", "BOSS支付宝"),
+            },
+            {
+                "name": "微信钱包",
+                "children": ("跳舞姬微信",),
+            },
+        ),
     },
     {
-        "name": "USDT Main",
+        "name": "USDT钱包",
         "wallet_type": WalletType.ASSET_USDT,
         "currency": Currency.USDT,
+        "children": ("FREEMAN币安", "张总币安"),
     },
 )
 
 
 def ensure_default_asset_wallets(session: Session) -> None:
-    """Create RMB and USDT root asset wallets if they do not already exist."""
+    """Create or migrate the default asset wallet tree idempotently."""
     for config in DEFAULT_ASSET_WALLETS:
-        exists = session.scalar(
+        root = session.scalar(
             select(Wallet).where(
                 Wallet.type == config["wallet_type"].value,
                 Wallet.currency == config["currency"].value,
                 Wallet.parent_id.is_(None),
             )
         )
-        if exists is None:
-            create_wallet(
+        if root is None:
+            root = create_wallet(
                 session,
                 name=config["name"],
                 wallet_type=config["wallet_type"],
                 currency=config["currency"],
+                is_group=True,
             )
+        else:
+            root.name = config["name"]
+            root.is_group = True
+            root.balance = Decimal("0")
+
+        for group_config in config.get("groups", ()):
+            group = ensure_sub_wallet(session, root, group_config["name"], is_group=True)
+            group.balance = Decimal("0")
+            for child_name in group_config["children"]:
+                ensure_sub_wallet(session, group, child_name, is_group=False)
+
+        for child_name in config.get("children", ()):
+            ensure_sub_wallet(session, root, child_name, is_group=False)
     session.flush()
+
+
+def ensure_sub_wallet(session: Session, parent: Wallet, name: str, is_group: bool = False) -> Wallet:
+    """Create a named child wallet under a parent if it does not exist."""
+    existing = session.scalar(
+        select(Wallet).where(
+            Wallet.parent_id == parent.id,
+            Wallet.name == name,
+        )
+    )
+    if existing is not None:
+        existing.is_group = is_group
+        if is_group:
+            existing.balance = Decimal("0")
+        return existing
+
+    return create_wallet(
+        session,
+        name=name,
+        wallet_type=parent.type.value if isinstance(parent.type, WalletType) else parent.type,
+        currency=parent.currency.value if isinstance(parent.currency, Currency) else parent.currency,
+        parent_id=parent.id,
+        opening_balance=Decimal("0"),
+        is_group=is_group,
+    )
 
 
 def is_asset_wallet(wallet: Wallet) -> bool:
@@ -59,14 +109,7 @@ def list_asset_wallets(session: Session) -> list[Wallet]:
     )
 
 
-def create_asset_sub_wallet(session: Session, parent: Wallet, name: str) -> Wallet:
+def create_asset_sub_wallet(session: Session, parent: Wallet, name: str, is_group: bool = False) -> Wallet:
     if not is_asset_wallet(parent):
         raise ValueError("parent wallet is not an asset wallet")
-    return create_wallet(
-        session,
-        name=name,
-        wallet_type=parent.type.value if isinstance(parent.type, WalletType) else parent.type,
-        currency=parent.currency.value if isinstance(parent.currency, Currency) else parent.currency,
-        parent_id=parent.id,
-        opening_balance=Decimal("0"),
-    )
+    return ensure_sub_wallet(session, parent, name, is_group=is_group)

--- a/tests/test_assets_api.py
+++ b/tests/test_assets_api.py
@@ -2,9 +2,11 @@ from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 from src import database
 from src.main import app
+from src.models.wallet import Currency, Wallet, WalletType, create_wallet
 from src.services.assets import ensure_default_asset_wallets
 
 
@@ -21,15 +23,83 @@ def client(tmp_path):
     return TestClient(app)
 
 
+def _find_wallet(wallets, name):
+    for wallet in wallets:
+        if wallet["name"] == name:
+            return wallet
+        found = _find_wallet(wallet.get("children", []), name)
+        if found:
+            return found
+    return None
+
+
 def test_default_asset_wallets_are_listed(client):
     response = client.get("/wallets/assets")
 
     assert response.status_code == 200, response.text
     wallets = response.json()
     names = {wallet["name"] for wallet in wallets}
-    assert {"RMB Main", "USDT Main"}.issubset(names)
+    assert {"RMB钱包", "USDT钱包"}.issubset(names)
     assert {wallet["currency"] for wallet in wallets} == {"CNY", "USDT"}
     assert all(wallet["parent_id"] is None for wallet in wallets)
+    assert all(wallet["is_group"] for wallet in wallets)
+
+    rmb = next(wallet for wallet in wallets if wallet["name"] == "RMB钱包")
+    alipay = next(wallet for wallet in rmb["children"] if wallet["name"] == "支付宝钱包")
+    wechat = next(wallet for wallet in rmb["children"] if wallet["name"] == "微信钱包")
+    assert alipay["is_group"] is True
+    assert wechat["is_group"] is True
+    assert [wallet["name"] for wallet in alipay["children"]] == [
+        "丙火网络支付宝",
+        "TOM支付宝",
+        "BOSS支付宝",
+    ]
+    assert [wallet["name"] for wallet in wechat["children"]] == ["跳舞姬微信"]
+
+    usdt = next(wallet for wallet in wallets if wallet["name"] == "USDT钱包")
+    assert [wallet["name"] for wallet in usdt["children"]] == ["FREEMAN币安", "张总币安"]
+    assert all(not wallet["is_group"] for wallet in usdt["children"])
+
+
+def test_existing_roots_are_migrated_without_duplicates(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'migration.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        rmb = create_wallet(
+            db,
+            name="RMB Main",
+            wallet_type=WalletType.ASSET_RMB,
+            currency=Currency.CNY,
+            opening_balance="10",
+        )
+        usdt = create_wallet(
+            db,
+            name="USDT Main",
+            wallet_type=WalletType.ASSET_USDT,
+            currency=Currency.USDT,
+            opening_balance="5",
+        )
+        db.commit()
+
+        ensure_default_asset_wallets(db)
+        ensure_default_asset_wallets(db)
+        db.commit()
+
+        roots = list(
+            db.scalars(
+                select(Wallet)
+                .where(Wallet.parent_id.is_(None), Wallet.type.in_(("ASSET_RMB", "ASSET_USDT")))
+                .order_by(Wallet.id)
+            )
+        )
+        assert [wallet.id for wallet in roots] == [rmb.id, usdt.id]
+        assert [wallet.name for wallet in roots] == ["RMB钱包", "USDT钱包"]
+        assert all(wallet.is_group for wallet in roots)
+        assert all(wallet.balance == Decimal("0.000000") for wallet in roots)
+        assert len(list(db.scalars(select(Wallet).where(Wallet.name == "支付宝钱包")))) == 1
+    finally:
+        db.close()
 
 
 def test_create_sub_wallet_inherits_type_and_currency(client):
@@ -43,30 +113,47 @@ def test_create_sub_wallet_inherits_type_and_currency(client):
     assert sub_wallet["type"] == root["type"]
     assert sub_wallet["currency"] == root["currency"]
     assert sub_wallet["parent_id"] == root["id"]
+    assert sub_wallet["is_group"] is False
 
     wallets = client.get("/wallets/assets").json()
-    updated_root = next(wallet for wallet in wallets if wallet["id"] == root["id"])
-    assert updated_root["children"][0]["name"] == "Operations"
+    assert _find_wallet(wallets, "Operations") is not None
 
 
-def test_credit_debit_and_transactions(client):
+def test_create_sub_wallet_can_create_group(client):
     root = client.get("/wallets/assets").json()[0]
 
     response = client.post(
-        f"/wallets/assets/{root['id']}/credit",
+        f"/wallets/assets/{root['id']}/sub",
+        json={"name": "新分组", "is_group": True},
+    )
+
+    assert response.status_code == 201, response.text
+    group = response.json()
+    assert group["name"] == "新分组"
+    assert group["is_group"] is True
+    assert Decimal(group["balance"]) == Decimal("0.000000")
+
+
+def test_credit_debit_and_transactions(client):
+    wallets = client.get("/wallets/assets").json()
+    leaf = _find_wallet(wallets, "丙火网络支付宝")
+    assert leaf is not None
+
+    response = client.post(
+        f"/wallets/assets/{leaf['id']}/credit",
         json={"amount": "100.50", "remark": "initial deposit"},
     )
     assert response.status_code == 201, response.text
     assert response.json()["direction"] == "in"
 
     response = client.post(
-        f"/wallets/assets/{root['id']}/debit",
+        f"/wallets/assets/{leaf['id']}/debit",
         json={"amount": "40.25", "remark": "payment"},
     )
     assert response.status_code == 201, response.text
     assert response.json()["direction"] == "out"
 
-    transactions = client.get(f"/wallets/assets/{root['id']}/transactions").json()
+    transactions = client.get(f"/wallets/assets/{leaf['id']}/transactions").json()
     assert [item["direction"] for item in transactions] == ["in", "out"]
     assert [Decimal(item["amount"]) for item in transactions] == [
         Decimal("100.500000"),
@@ -74,15 +161,35 @@ def test_credit_debit_and_transactions(client):
     ]
 
     refreshed = client.get("/wallets/assets").json()
-    wallet = next(item for item in refreshed if item["id"] == root["id"])
+    rmb = _find_wallet(refreshed, "RMB钱包")
+    alipay = _find_wallet(refreshed, "支付宝钱包")
+    wallet = _find_wallet(refreshed, "丙火网络支付宝")
+    assert Decimal(rmb["balance"]) == Decimal("60.250000")
+    assert Decimal(alipay["balance"]) == Decimal("60.250000")
     assert Decimal(wallet["balance"]) == Decimal("60.250000")
 
 
-def test_debit_rejects_insufficient_balance(client):
-    root = client.get("/wallets/assets").json()[0]
+def test_group_wallet_rejects_direct_credit(client):
+    wallets = client.get("/wallets/assets").json()
+    group = _find_wallet(wallets, "支付宝钱包")
+    assert group is not None
 
     response = client.post(
-        f"/wallets/assets/{root['id']}/debit",
+        f"/wallets/assets/{group['id']}/credit",
+        json={"amount": "1", "remark": "invalid"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "分组钱包不可直接记账，请操作叶子钱包"
+
+
+def test_debit_rejects_insufficient_balance(client):
+    wallets = client.get("/wallets/assets").json()
+    leaf = _find_wallet(wallets, "FREEMAN币安")
+    assert leaf is not None
+
+    response = client.post(
+        f"/wallets/assets/{leaf['id']}/debit",
         json={"amount": "1", "remark": "too much"},
     )
 


### PR DESCRIPTION
## 关联 Issue
Closes #28

## 改动说明
- Wallet 新增 `is_group` 字段，分组钱包只做汇总展示，不直接记账。
- 资产钱包默认结构升级为三层：RMB钱包 -> 支付宝钱包/微信钱包 -> 叶子钱包；USDT钱包 -> 币安叶子钱包。
- `GET /wallets/assets` 返回递归 `children`，分组/顶级余额实时汇总所有后代叶子钱包。
- `credit` / `debit` 禁止操作 `is_group=True` 钱包，返回 400：`分组钱包不可直接记账，请操作叶子钱包`。
- `POST /wallets/assets/{wallet_id}/sub` 支持 `is_group` 参数，默认 `false`。
- SQLite 已有开发库通过 `ALTER TABLE wallets ADD COLUMN is_group ...` 自动补列；新库由 `create_all` 直接创建字段。

## 自测情况
- [x] `python3 -m pytest -q` -> 26 passed
- [x] `python3 -m compileall -q src tests`
- [x] `git diff --check`

## Base 说明
本 PR base 为 `feature/issue-8`，因为 #28 依赖之前链式 backend 资产钱包 API；当前 `main` 尚未包含 `src/services/assets.py` / `src/routers/assets.py`。

---
> 请 Claude PM 审查
