### PR TITLE
fix(agent): support Python 3.9 and custom cloudflared path

### DIFF
--- a/agent/.env.backend.example
+++ b/agent/.env.backend.example
@@ -3,6 +3,8 @@ WEBHOOK_SECRET=your_webhook_secret_here
 AGENT_LABEL=backend
 # gh CLI 完整路径，默认 "gh"；若 which gh 返回非标准路径则填入
 # GH_PATH=/Users/yourname/bin/gh
+# cloudflared 完整路径，默认 "cloudflared"；若 which cloudflared 找不到则填入
+# CLOUDFLARED_PATH=/Users/yourname/bin/cloudflared
 
 # ===== 事件驱动激活命令 =====
 # 收到 GitHub 事件后，agent 会执行这条命令启动 AI 编程助手开干

--- a/agent/.env.frontend.example
+++ b/agent/.env.frontend.example
@@ -3,6 +3,8 @@ WEBHOOK_SECRET=your_webhook_secret_here
 AGENT_LABEL=frontend
 # gh CLI 完整路径，默认 "gh"；若 which gh 返回非标准路径则填入
 # GH_PATH=/Users/yourname/bin/gh
+# cloudflared 完整路径，默认 "cloudflared"；若 which cloudflared 找不到则填入
+# CLOUDFLARED_PATH=/Users/yourname/bin/cloudflared
 
 # ===== 事件驱动激活命令 =====
 # 收到 GitHub 事件后，agent 会执行这条命令启动 AI 编程助手开干

--- a/agent/main.py
+++ b/agent/main.py
@@ -24,6 +24,7 @@ import os
 import shlex
 import subprocess
 import sys
+from typing import Optional
 
 from fastapi import FastAPI, Request, HTTPException, BackgroundTasks
 
@@ -84,7 +85,7 @@ def utf8_env() -> dict:
     }
 
 
-def edit_issue_label(issue_number: int, remove: str | None, add: str):
+def edit_issue_label(issue_number: int, remove: Optional[str], add: str):
     args = [GH, "issue", "edit", str(issue_number), "--repo", REPO, "--add-label", add]
     if remove:
         args += ["--remove-label", remove]

--- a/agent/start_backend.sh
+++ b/agent/start_backend.sh
@@ -21,6 +21,8 @@ set -a
 source "$ENV_FILE"
 set +a
 
+CLOUDFLARED="${CLOUDFLARED_PATH:-cloudflared}"
+
 export LANG="${LANG:-en_US.UTF-8}"
 export LC_ALL="${LC_ALL:-en_US.UTF-8}"
 export PYTHONUTF8="${PYTHONUTF8:-1}"
@@ -38,4 +40,4 @@ echo "Backend Agent 已启动 PID: $AGENT_PID, port: $PORT"
 
 echo ""
 echo "=== Cloudflare Tunnel 公网地址 ==="
-cloudflared tunnel --url "$TUNNEL_URL"
+"$CLOUDFLARED" tunnel --url "$TUNNEL_URL"

--- a/agent/start_frontend.sh
+++ b/agent/start_frontend.sh
@@ -21,6 +21,8 @@ set -a
 source "$ENV_FILE"
 set +a
 
+CLOUDFLARED="${CLOUDFLARED_PATH:-cloudflared}"
+
 export LANG="${LANG:-en_US.UTF-8}"
 export LC_ALL="${LC_ALL:-en_US.UTF-8}"
 export PYTHONUTF8="${PYTHONUTF8:-1}"
@@ -38,4 +40,4 @@ echo "Frontend Agent 已启动 PID: $AGENT_PID, port: $PORT"
 
 echo ""
 echo "=== Cloudflare Tunnel 公网地址 ==="
-cloudflared tunnel --url "$TUNNEL_URL"
+"$CLOUDFLARED" tunnel --url "$TUNNEL_URL"


### PR DESCRIPTION
## 说明
- 修复 Mac 默认 Python 3.9 启动 agent 时不支持 `str | None` 导致 uvicorn 崩溃的问题
- start_backend/start_frontend 支持 `CLOUDFLARED_PATH`，避免非交互启动时找不到 cloudflared
- 给两个启动脚本补执行权限
- .env 示例补充 `CLOUDFLARED_PATH`

## 验证
- `python3 -m py_compile agent/main.py agent/github_helper.py`
- `bash -n agent/start_backend.sh agent/start_frontend.sh`
- `git diff --check`
- 本机 backend agent 已在 8091 启动，/health 返回 ok
