### PR TITLE
[PR] [FEAT-F8] 资产页子钱包编辑/删除 UI

### DIFF
--- a/frontend/components/assets-page.tsx
+++ b/frontend/components/assets-page.tsx
@@ -8,7 +8,9 @@ import {
   ChevronRight,
   FolderPlus,
   List,
-  RefreshCcw
+  Pencil,
+  RefreshCcw,
+  Trash2
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -19,8 +21,10 @@ import {
   createAssetSubWallet,
   creditAssetWallet,
   debitAssetWallet,
+  deleteAssetWallet,
   getAssetTransactions,
-  getAssetWallets
+  getAssetWallets,
+  patchAssetWallet
 } from "@/lib/api";
 import { formatMoney, sumMinor } from "@/lib/money";
 import { cn } from "@/lib/utils";
@@ -60,17 +64,8 @@ function collectGroupIds(wallets: WalletBalance[]): string[] {
   ]);
 }
 
-function findWalletById(wallets: WalletBalance[], walletId: string): WalletBalance | undefined {
-  for (const wallet of wallets) {
-    if (wallet.id === walletId) {
-      return wallet;
-    }
-    const childMatch = findWalletById(wallet.children ?? [], walletId);
-    if (childMatch) {
-      return childMatch;
-    }
-  }
-  return undefined;
+function isTopLevelWallet(wallet: WalletBalance): boolean {
+  return !wallet.parentId && wallet.isGroup;
 }
 
 function AssetSummaryCards({ wallets, currency }: { wallets: WalletBalance[]; currency: Currency }) {
@@ -280,6 +275,147 @@ function AssetActions({
   );
 }
 
+function EditWalletModal({
+  wallet,
+  onClose
+}: {
+  wallet: WalletBalance;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState(wallet.name);
+  const [remark, setRemark] = useState(wallet.remark ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!name.trim()) {
+        throw new Error("钱包名不能为空");
+      }
+      const payload: { name?: string; remark?: string | null } = {};
+      if (name.trim() !== wallet.name) {
+        payload.name = name.trim();
+      }
+      const nextRemark = remark.trim() === "" ? null : remark;
+      if (nextRemark !== (wallet.remark ?? null)) {
+        payload.remark = nextRemark;
+      }
+      if (Object.keys(payload).length === 0) {
+        return null;
+      }
+      return patchAssetWallet(wallet.id, payload);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["assets"] });
+      await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "保存失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>编辑钱包</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">钱包名</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="钱包名"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "保存中..." : "保存"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function DeleteWalletModal({
+  wallet,
+  onClose
+}: {
+  wallet: WalletBalance;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => deleteAssetWallet(wallet.id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["assets"] });
+      await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "删除失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>删除钱包</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="text-sm">
+            确认删除「{wallet.name}」？删除后流水保留，钱包不再显示。
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => mutation.mutate()}
+              disabled={mutation.isPending}
+            >
+              <Trash2 className="h-4 w-4" />
+              {mutation.isPending ? "删除中..." : "确认删除"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 function AssetTree({
   wallets,
   expandedIds,
@@ -287,7 +423,9 @@ function AssetTree({
   onToggle,
   onSelectLeaf,
   onSelectGroup,
-  onShowTransactions
+  onShowTransactions,
+  onEdit,
+  onDelete
 }: {
   wallets: WalletBalance[];
   expandedIds: Set<string>;
@@ -296,10 +434,13 @@ function AssetTree({
   onSelectLeaf: (walletId: string, mode?: MovementMode) => void;
   onSelectGroup: (walletId: string) => void;
   onShowTransactions: (walletId: string) => void;
+  onEdit: (wallet: WalletBalance) => void;
+  onDelete: (wallet: WalletBalance) => void;
 }) {
   const renderNode = (wallet: WalletBalance, depth: number) => {
     const hasChildren = Boolean(wallet.children?.length);
     const expanded = expandedIds.has(wallet.id);
+    const topLevel = isTopLevelWallet(wallet);
 
     return (
       <div key={wallet.id} className="space-y-2">
@@ -329,6 +470,9 @@ function AssetTree({
                   {wallet.isGroup ? <Badge>汇总</Badge> : <Badge tone="transfer">叶子</Badge>}
                 </div>
                 <div className="mt-1 text-xs text-muted-foreground">{wallet.currency}</div>
+                {wallet.remark ? (
+                  <div className="mt-1 text-xs text-muted-foreground">{wallet.remark}</div>
+                ) : null}
               </div>
             </div>
 
@@ -361,6 +505,16 @@ function AssetTree({
                       流水
                     </Button>
                   </>
+                )}
+                <Button variant="outline" size="sm" onClick={() => onEdit(wallet)}>
+                  <Pencil className="h-4 w-4" aria-hidden="true" />
+                  编辑
+                </Button>
+                {topLevel ? null : (
+                  <Button variant="ghost" size="sm" onClick={() => onDelete(wallet)}>
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                    删除
+                  </Button>
                 )}
               </div>
             </div>
@@ -444,6 +598,8 @@ export function AssetsPage() {
   const [selectedGroupId, setSelectedGroupId] = useState("");
   const [movementMode, setMovementMode] = useState<MovementMode>("credit");
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [editTarget, setEditTarget] = useState<WalletBalance | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<WalletBalance | null>(null);
   const { data: wallets = [], isFetching, refetch } = useQuery({
     queryKey: ["assets"],
     queryFn: getAssetWallets
@@ -541,6 +697,8 @@ export function AssetsPage() {
           setSelectedWalletId(walletId);
           document.getElementById("asset-transactions")?.scrollIntoView({ behavior: "smooth", block: "start" });
         }}
+        onEdit={setEditTarget}
+        onDelete={setDeleteTarget}
       />
       <AssetActions
         leafWallets={leafWallets}
@@ -553,6 +711,12 @@ export function AssetsPage() {
         onSelectGroup={setSelectedGroupId}
       />
       <AssetTransactionTable transactions={transactions} />
+      {editTarget ? (
+        <EditWalletModal wallet={editTarget} onClose={() => setEditTarget(null)} />
+      ) : null}
+      {deleteTarget ? (
+        <DeleteWalletModal wallet={deleteTarget} onClose={() => setDeleteTarget(null)} />
+      ) : null}
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -20,6 +20,9 @@ type AssetWalletResponse = {
   children?: AssetWalletResponse[];
   parent_id?: string | number | null;
   parentId?: string | number | null;
+  remark?: string | null;
+  deleted_at?: string | null;
+  deletedAt?: string | null;
 };
 
 type VendorSummaryResponse = {
@@ -70,6 +73,8 @@ function normalizeWallet(wallet: AssetWalletResponse, parentId?: string | null):
     parentId:
       parentId ??
       (wallet.parent_id === undefined ? wallet.parentId?.toString() ?? null : wallet.parent_id?.toString() ?? null),
+    remark: wallet.remark ?? null,
+    deletedAt: wallet.deleted_at ?? wallet.deletedAt ?? null,
     children: wallet.children?.map((child) => normalizeWallet(child, String(wallet.id))) ?? []
   };
 }
@@ -166,6 +171,45 @@ async function postJson(path: string, body: unknown) {
 
 export function createAssetSubWallet(walletId: string, name: string) {
   return postJson(`/api/wallets/assets/${walletId}/sub`, { name, is_group: false });
+}
+
+async function sendJson(path: string, method: "PATCH" | "DELETE", body?: unknown) {
+  const response = await fetch(path, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json"
+    },
+    body: body === undefined ? undefined : JSON.stringify(body)
+  });
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    let message = `${path} returned ${response.status}`;
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as { detail?: string; message?: string; error?: string };
+        message = parsed.detail ?? parsed.message ?? parsed.error ?? text;
+      } catch {
+        message = text;
+      }
+    }
+    throw new Error(message);
+  }
+
+  return text ? JSON.parse(text) : null;
+}
+
+export function patchAssetWallet(
+  walletId: string,
+  payload: { name?: string; remark?: string | null }
+) {
+  return sendJson(`/api/wallets/assets/${walletId}`, "PATCH", payload);
+}
+
+export function deleteAssetWallet(walletId: string) {
+  return sendJson(`/api/wallets/assets/${walletId}`, "DELETE");
 }
 
 export function creditAssetWallet(walletId: string, amount: string, remark: string) {

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -8,6 +8,8 @@ export const mockWallets: WalletBalance[] = [
     currency: "CNY",
     balanceMinor: 628_450_00,
     isGroup: true,
+    remark: null,
+    deletedAt: null,
     children: [
       {
         id: "asset-cny-alipay",
@@ -17,6 +19,8 @@ export const mockWallets: WalletBalance[] = [
         balanceMinor: 508_450_00,
         isGroup: true,
         parentId: "asset-cny-root",
+        remark: null,
+        deletedAt: null,
         children: [
           {
             id: "asset-cny-bh",
@@ -25,7 +29,9 @@ export const mockWallets: WalletBalance[] = [
             currency: "CNY",
             balanceMinor: 228_150_00,
             isGroup: false,
-            parentId: "asset-cny-alipay"
+            parentId: "asset-cny-alipay",
+            remark: null,
+            deletedAt: null
           },
           {
             id: "asset-cny-tom",
@@ -34,7 +40,9 @@ export const mockWallets: WalletBalance[] = [
             currency: "CNY",
             balanceMinor: 164_300_00,
             isGroup: false,
-            parentId: "asset-cny-alipay"
+            parentId: "asset-cny-alipay",
+            remark: null,
+            deletedAt: null
           },
           {
             id: "asset-cny-boss",
@@ -43,7 +51,9 @@ export const mockWallets: WalletBalance[] = [
             currency: "CNY",
             balanceMinor: 116_000_00,
             isGroup: false,
-            parentId: "asset-cny-alipay"
+            parentId: "asset-cny-alipay",
+            remark: null,
+            deletedAt: null
           }
         ]
       },
@@ -55,6 +65,8 @@ export const mockWallets: WalletBalance[] = [
         balanceMinor: 120_000_00,
         isGroup: true,
         parentId: "asset-cny-root",
+        remark: null,
+        deletedAt: null,
         children: [
           {
             id: "asset-cny-dancer",
@@ -63,7 +75,9 @@ export const mockWallets: WalletBalance[] = [
             currency: "CNY",
             balanceMinor: 120_000_00,
             isGroup: false,
-            parentId: "asset-cny-wechat"
+            parentId: "asset-cny-wechat",
+            remark: null,
+            deletedAt: null
           }
         ]
       }
@@ -76,6 +90,8 @@ export const mockWallets: WalletBalance[] = [
     currency: "USDT",
     balanceMinor: 184_250_000000,
     isGroup: true,
+    remark: null,
+    deletedAt: null,
     children: [
       {
         id: "asset-usdt-freeman",
@@ -84,7 +100,9 @@ export const mockWallets: WalletBalance[] = [
         currency: "USDT",
         balanceMinor: 96_500_000000,
         isGroup: false,
-        parentId: "asset-usdt-root"
+        parentId: "asset-usdt-root",
+        remark: null,
+        deletedAt: null
       },
       {
         id: "asset-usdt-zhang",
@@ -93,7 +111,9 @@ export const mockWallets: WalletBalance[] = [
         currency: "USDT",
         balanceMinor: 87_750_000000,
         isGroup: false,
-        parentId: "asset-usdt-root"
+        parentId: "asset-usdt-root",
+        remark: null,
+        deletedAt: null
       }
     ]
   },
@@ -103,7 +123,9 @@ export const mockWallets: WalletBalance[] = [
     type: "VENDOR",
     currency: "CNY",
     balanceMinor: 76_320_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   },
   {
     id: "xbox-us",
@@ -111,7 +133,9 @@ export const mockWallets: WalletBalance[] = [
     type: "XBOX",
     currency: "USD",
     balanceMinor: 12_840_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   },
   {
     id: "xbox-uk",
@@ -119,7 +143,9 @@ export const mockWallets: WalletBalance[] = [
     type: "XBOX",
     currency: "GBP",
     balanceMinor: 8_620_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   },
   {
     id: "taobao-unsettled",
@@ -127,7 +153,9 @@ export const mockWallets: WalletBalance[] = [
     type: "TAOBAO",
     currency: "CNY",
     balanceMinor: 93_400_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   },
   {
     id: "taobao-settled",
@@ -135,7 +163,9 @@ export const mockWallets: WalletBalance[] = [
     type: "TAOBAO",
     currency: "CNY",
     balanceMinor: 41_250_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   },
   {
     id: "taiwan-8591",
@@ -143,7 +173,9 @@ export const mockWallets: WalletBalance[] = [
     type: "TAIWAN",
     currency: "TWD",
     balanceMinor: 385_000_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   },
   {
     id: "taiwan-bank",
@@ -151,7 +183,9 @@ export const mockWallets: WalletBalance[] = [
     type: "TAIWAN",
     currency: "TWD",
     balanceMinor: 128_500_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   },
   {
     id: "taiwan-store",
@@ -159,7 +193,9 @@ export const mockWallets: WalletBalance[] = [
     type: "TAIWAN",
     currency: "TWD",
     balanceMinor: 62_800_00,
-    isGroup: false
+    isGroup: false,
+    remark: null,
+    deletedAt: null
   }
 ];
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -11,6 +11,8 @@ export type WalletBalance = {
   isGroup: boolean;
   children?: WalletBalance[];
   parentId?: string | null;
+  remark: string | null;
+  deletedAt: string | null;
 };
 
 export type VendorSummary = {


### PR DESCRIPTION
## 关联 Issue
Closes #38

## 改动说明
- `types.ts`：`WalletBalance` 新增 `remark: string | null` 与 `deletedAt: string | null` 字段
- `lib/api.ts`：`AssetWalletResponse` + `normalizeWallet` 处理 snake → camel；新增 `patchAssetWallet(id, {name?, remark?})` 与 `deleteAssetWallet(id)`，错误体走与 postJson 一致的 detail/message 解析
- `components/assets-page.tsx`：
  - 每个钱包卡片右侧追加「编辑」按钮（`Pencil`，outline）
  - 非顶级钱包再追加「删除」按钮（`Trash2`，ghost）；顶级 = `parentId` 为空且 `isGroup` 的根（RMB钱包/USDT钱包），仅显示编辑
  - 弹窗用居中固定 div + Card（无新依赖），表单用 useState，提交用 useMutation；成功后 invalidate `["assets"]` + `["dashboard"]`
  - 编辑弹窗预填 name/remark，仅把变更字段发到后端；备注空串视为 null（允许清空）
  - 删除弹窗显示「确认删除「{name}」？删除后流水保留，钱包不再显示。」
  - 后端 400（顶级保护/余额非 0/有子）以 inline alert（红色边框 + 红色文字）显示在弹窗内，不静默
  - 钱包名下方用 `text-xs text-muted-foreground` 显示备注（无备注则不占位）
- `mock-data.ts`：所有 mock 钱包补 `remark: null` + `deletedAt: null` 与新类型同步

## 现有按钮验证
经手工测试 入账 / 出账 / + 添加子钱包 三个按钮 ✅ 正常。直接打 backend API（`POST /credit`、`POST /debit`、`POST /sub`）均 201 返回流水/新钱包；前端组件已通过 useMutation 接到这些 client 函数，无需修复。CEO 之前反映的"点击没反应"未能复现——可能是当时后端未起或后端 #36 PATCH/DELETE 上线前的版本快照。

## 自测
- [x] `npm run typecheck` 通过（无 TS 错误）
- [x] 手工测过 PATCH（改 name + remark）/ DELETE（204）/ credit / debit / sub
- [x] 顶级钱包 UI 上确认无删除按钮，仅显示编辑

## 后续复用建议（给 broky 自己 F-3/F-4/F-5/F-6）
- `EditWalletModal` / `DeleteWalletModal` 结构通用，下一模块可抽到 `components/ui/wallet-modals.tsx` 或保持 inline。当前留 inline 是因为 props 还没定型，等 F-3 一起重构。
- 错误显示用 inline div（红框红字）足够，未来引 toast 时再统一替换

---
> 由 broky 实现，请 PM 审查