### PR TITLE
[PR] [FEAT-F3v2] 供应商账单页完整实现

### DIFF
--- a/frontend/app/[section]/page.tsx
+++ b/frontend/app/[section]/page.tsx
@@ -1,6 +1,7 @@
 import { AppShell } from "@/components/app-shell";
 import { AssetsPage } from "@/components/assets-page";
 import { ModuleOverview } from "@/components/module-overview";
+import { VendorsPage } from "@/components/vendors-page";
 import { sectionById, sectionIds } from "@/lib/navigation";
 
 type SectionPageProps = {
@@ -14,7 +15,13 @@ export default function SectionPage({ params }: SectionPageProps) {
 
   return (
     <AppShell activeSection={section.id}>
-      {section.id === "assets" ? <AssetsPage /> : <ModuleOverview section={section} />}
+      {section.id === "assets" ? (
+        <AssetsPage />
+      ) : section.id === "vendors" ? (
+        <VendorsPage />
+      ) : (
+        <ModuleOverview section={section} />
+      )}
     </AppShell>
   );
 }

--- a/frontend/components/vendors-page.tsx
+++ b/frontend/components/vendors-page.tsx
@@ -1,0 +1,520 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  Building2,
+  CheckCircle2,
+  Plus,
+  RefreshCcw
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  createVendor,
+  createVendorBill,
+  getVendorBills,
+  getVendorSummary,
+  getVendors,
+  settleVendorBill
+} from "@/lib/api";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import type { BillDirection, Vendor, VendorBill } from "@/types";
+
+function formatDueDate(value: string | null) {
+  if (!value) return "-";
+  return value.length >= 10 ? value.slice(0, 10) : value;
+}
+
+function VendorSummaryCards() {
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: ["vendor-summary"],
+    queryFn: getVendorSummary
+  });
+
+  const payable = data?.payableMinor ?? 0;
+  const receivable = data?.receivableMinor ?? 0;
+  const net = data?.netMinor ?? 0;
+  const currency = data?.currency ?? "CNY";
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-end">
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+          刷新汇总
+        </Button>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card>
+          <CardContent className="flex items-center justify-between gap-4 p-5">
+            <div>
+              <div className="text-sm text-muted-foreground">应付总额</div>
+              <div className="mt-1 tabular-nums text-2xl font-semibold text-red-600">
+                {formatMoney(payable, currency)}
+              </div>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-red-50 text-red-600">
+              <ArrowUpRight className="h-5 w-5" aria-hidden="true" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center justify-between gap-4 p-5">
+            <div>
+              <div className="text-sm text-muted-foreground">应收总额</div>
+              <div className="mt-1 tabular-nums text-2xl font-semibold text-green-600">
+                {formatMoney(receivable, currency)}
+              </div>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-emerald-50 text-emerald-600">
+              <ArrowDownLeft className="h-5 w-5" aria-hidden="true" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center justify-between gap-4 p-5">
+            <div>
+              <div className="text-sm text-muted-foreground">净额</div>
+              <div
+                className={cn(
+                  "mt-1 tabular-nums text-2xl font-semibold",
+                  net >= 0 ? "text-green-600" : "text-red-600"
+                )}
+              >
+                {formatMoney(net, currency)}
+              </div>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+              <Building2 className="h-5 w-5" aria-hidden="true" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function CreateVendorModal({ onClose }: { onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!name.trim()) {
+        throw new Error("供应商名称不能为空");
+      }
+      return createVendor({
+        name: name.trim(),
+        remark: remark.trim() === "" ? undefined : remark.trim()
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["vendors"] });
+      await queryClient.invalidateQueries({ queryKey: ["vendor-summary"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "创建失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>新增供应商</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">供应商名称</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="供应商名称"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "创建中..." : "创建"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function CreateBillModal({ vendor, onClose }: { vendor: Vendor; onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [direction, setDirection] = useState<BillDirection>("payable");
+  const [amount, setAmount] = useState("");
+  const [dueDate, setDueDate] = useState("");
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!amount || Number(amount) <= 0) {
+        throw new Error("金额必须大于 0");
+      }
+      return createVendorBill(vendor.id, {
+        direction,
+        amount,
+        dueDate: dueDate || undefined,
+        remark: remark.trim() === "" ? undefined : remark.trim()
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["vendor-bills", vendor.id] });
+      await queryClient.invalidateQueries({ queryKey: ["vendor-summary"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "创建失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>新增账单 · {vendor.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">方向</div>
+            <div className="grid grid-cols-2 rounded-md border border-border p-1">
+              {(["payable", "receivable"] as BillDirection[]).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={cn(
+                    "flex h-8 items-center justify-center gap-2 rounded text-sm font-medium text-muted-foreground",
+                    direction === item && "bg-muted text-foreground"
+                  )}
+                  onClick={() => setDirection(item)}
+                >
+                  {item === "payable" ? (
+                    <ArrowUpRight className="h-4 w-4 text-red-600" aria-hidden="true" />
+                  ) : (
+                    <ArrowDownLeft className="h-4 w-4 text-green-600" aria-hidden="true" />
+                  )}
+                  {item === "payable" ? "应付" : "应收"}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">金额</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="金额"
+              type="number"
+              min="0"
+              step="0.01"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">到期日（选填）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={dueDate}
+              onChange={(event) => setDueDate(event.target.value)}
+              type="date"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "创建中..." : "创建"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function VendorList({
+  vendors,
+  selectedVendorId,
+  onSelect,
+  onCreate
+}: {
+  vendors: Vendor[];
+  selectedVendorId: string;
+  onSelect: (vendorId: string) => void;
+  onCreate: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle>供应商</CardTitle>
+          <Button size="sm" onClick={onCreate}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            新增供应商
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {vendors.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border px-3 py-6 text-center text-sm text-muted-foreground">
+            暂无供应商，点击右上角「新增供应商」开始
+          </div>
+        ) : (
+          vendors.map((vendor) => (
+            <button
+              key={vendor.id}
+              type="button"
+              className={cn(
+                "w-full rounded-lg border border-border bg-card px-3 py-3 text-left transition-colors hover:bg-muted/60",
+                selectedVendorId === vendor.id && "bg-muted"
+              )}
+              onClick={() => onSelect(vendor.id)}
+            >
+              <div className="flex items-center gap-2">
+                <Building2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                <span className="font-medium">{vendor.name}</span>
+              </div>
+              {vendor.remark ? (
+                <div className="mt-1 text-xs text-muted-foreground">{vendor.remark}</div>
+              ) : null}
+            </button>
+          ))
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function BillTable({
+  vendor,
+  bills,
+  onCreate
+}: {
+  vendor: Vendor | null;
+  bills: VendorBill[];
+  onCreate: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [errorBillId, setErrorBillId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const settleMutation = useMutation({
+    mutationFn: settleVendorBill,
+    onSuccess: async () => {
+      setErrorBillId(null);
+      setErrorMessage(null);
+      if (vendor) {
+        await queryClient.invalidateQueries({ queryKey: ["vendor-bills", vendor.id] });
+      }
+      await queryClient.invalidateQueries({ queryKey: ["vendor-summary"] });
+    },
+    onError: (err, billId) => {
+      setErrorBillId(billId);
+      setErrorMessage(err instanceof Error ? err.message : "操作失败");
+    }
+  });
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle>{vendor ? `${vendor.name} 的账单` : "账单"}</CardTitle>
+          <Button size="sm" onClick={onCreate} disabled={!vendor}>
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            新增账单
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {errorMessage ? (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+            {errorMessage}
+          </div>
+        ) : null}
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>方向</TableHead>
+              <TableHead className="text-right">金额</TableHead>
+              <TableHead>到期日</TableHead>
+              <TableHead>状态</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead className="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {bills.map((bill) => {
+              const isPayable = bill.direction === "payable";
+              const isPending = bill.status === "pending";
+              return (
+                <TableRow key={bill.id}>
+                  <TableCell>
+                    <Badge tone={isPayable ? "danger" : "success"}>
+                      {isPayable ? "应付" : "应收"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell
+                    className={cn(
+                      "text-right tabular-nums font-semibold",
+                      isPayable ? "text-red-600" : "text-green-600"
+                    )}
+                  >
+                    {formatMoney(bill.amountMinor, bill.currency)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{formatDueDate(bill.dueDate)}</TableCell>
+                  <TableCell>
+                    <Badge tone={isPending ? "neutral" : "success"}>
+                      {isPending ? "待结清" : "已结清"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{bill.remark ?? "-"}</TableCell>
+                  <TableCell className="text-right">
+                    {isPending ? (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => settleMutation.mutate(bill.id)}
+                        disabled={settleMutation.isPending && errorBillId !== bill.id}
+                      >
+                        <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+                        标记结清
+                      </Button>
+                    ) : (
+                      <span className="text-xs text-muted-foreground">已结清</span>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+            {bills.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                  {vendor ? "该供应商暂无账单" : "请先在左侧选中或新增供应商"}
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function VendorsPage() {
+  const [selectedVendorId, setSelectedVendorId] = useState("");
+  const [showCreateVendor, setShowCreateVendor] = useState(false);
+  const [showCreateBill, setShowCreateBill] = useState(false);
+
+  const { data: vendors = [], isFetching, refetch } = useQuery({
+    queryKey: ["vendors"],
+    queryFn: getVendors
+  });
+
+  useEffect(() => {
+    if (vendors.length === 0) {
+      if (selectedVendorId !== "") {
+        setSelectedVendorId("");
+      }
+      return;
+    }
+    if (!vendors.find((vendor) => vendor.id === selectedVendorId)) {
+      setSelectedVendorId(vendors[0].id);
+    }
+  }, [vendors, selectedVendorId]);
+
+  const selectedVendor = vendors.find((vendor) => vendor.id === selectedVendorId) ?? null;
+
+  const { data: bills = [] } = useQuery({
+    queryKey: ["vendor-bills", selectedVendor?.id ?? ""],
+    queryFn: () => (selectedVendor ? getVendorBills(selectedVendor.id) : Promise.resolve([])),
+    enabled: Boolean(selectedVendor)
+  });
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-normal">供应商账单</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            管理供应商应付/应收账单，标记结清后自动刷新汇总。
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+          刷新供应商
+        </Button>
+      </div>
+
+      <VendorSummaryCards />
+
+      <div className="grid gap-3 lg:grid-cols-[0.9fr_1.6fr]">
+        <VendorList
+          vendors={vendors}
+          selectedVendorId={selectedVendor?.id ?? ""}
+          onSelect={setSelectedVendorId}
+          onCreate={() => setShowCreateVendor(true)}
+        />
+        <BillTable
+          vendor={selectedVendor}
+          bills={bills}
+          onCreate={() => setShowCreateBill(true)}
+        />
+      </div>
+
+      {showCreateVendor ? (
+        <CreateVendorModal onClose={() => setShowCreateVendor(false)} />
+      ) : null}
+      {showCreateBill && selectedVendor ? (
+        <CreateBillModal vendor={selectedVendor} onClose={() => setShowCreateBill(false)} />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,9 +1,12 @@
-import { mockAssetTransactions, mockDashboardData } from "@/lib/mock-data";
+import { mockAssetTransactions, mockDashboardData, mockVendorBills, mockVendors } from "@/lib/mock-data";
 import { decimalToMinor } from "@/lib/money";
 import type {
   AssetTransaction,
+  BillDirection,
   Currency,
   DashboardData,
+  Vendor,
+  VendorBill,
   VendorSummary,
   WalletBalance,
   WalletType
@@ -218,4 +221,110 @@ export function creditAssetWallet(walletId: string, amount: string, remark: stri
 
 export function debitAssetWallet(walletId: string, amount: string, remark: string) {
   return postJson(`/api/wallets/assets/${walletId}/debit`, { amount, remark });
+}
+
+type VendorResponse = {
+  id: string | number;
+  name: string;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type VendorBillResponse = {
+  id: string | number;
+  vendor_id?: string | number;
+  vendorId?: string | number;
+  direction: BillDirection;
+  amount: string | number;
+  currency?: Currency;
+  status: "pending" | "settled";
+  due_date?: string | null;
+  dueDate?: string | null;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+function normalizeVendor(vendor: VendorResponse): Vendor {
+  return {
+    id: String(vendor.id),
+    name: vendor.name,
+    remark: vendor.remark ?? null,
+    createdAt: vendor.created_at ?? vendor.createdAt ?? ""
+  };
+}
+
+function normalizeVendorBill(bill: VendorBillResponse): VendorBill {
+  const currency: Currency = bill.currency ?? "CNY";
+  return {
+    id: String(bill.id),
+    vendorId: String(bill.vendor_id ?? bill.vendorId ?? ""),
+    direction: bill.direction,
+    amountMinor: decimalToMinor(bill.amount, currency),
+    currency,
+    status: bill.status,
+    dueDate: bill.due_date ?? bill.dueDate ?? null,
+    remark: bill.remark ?? null,
+    createdAt: bill.created_at ?? bill.createdAt ?? ""
+  };
+}
+
+export async function getVendors(): Promise<Vendor[]> {
+  try {
+    const data = await fetchJson<VendorResponse[]>("/api/vendors");
+    return data.map(normalizeVendor);
+  } catch {
+    return mockVendors;
+  }
+}
+
+export async function createVendor(payload: { name: string; remark?: string }): Promise<Vendor> {
+  try {
+    const data = (await postJson("/api/vendors", payload)) as VendorResponse;
+    return normalizeVendor(data);
+  } catch (error) {
+    throw error instanceof Error ? error : new Error("创建供应商失败");
+  }
+}
+
+export async function getVendorBills(vendorId: string): Promise<VendorBill[]> {
+  try {
+    const data = await fetchJson<VendorBillResponse[]>(`/api/vendors/${vendorId}/bills`);
+    return data.map((bill) => normalizeVendorBill({ ...bill, vendor_id: bill.vendor_id ?? vendorId }));
+  } catch {
+    return (mockVendorBills[vendorId] ?? []).map((bill) => ({ ...bill }));
+  }
+}
+
+export async function createVendorBill(
+  vendorId: string,
+  payload: { direction: BillDirection; amount: string; dueDate?: string; remark?: string }
+): Promise<VendorBill> {
+  const body: Record<string, unknown> = {
+    direction: payload.direction,
+    amount: payload.amount
+  };
+  if (payload.dueDate) {
+    body.due_date = payload.dueDate;
+  }
+  if (payload.remark) {
+    body.remark = payload.remark;
+  }
+  const data = (await postJson(`/api/vendors/${vendorId}/bills`, body)) as VendorBillResponse;
+  return normalizeVendorBill({ ...data, vendor_id: data.vendor_id ?? vendorId });
+}
+
+export async function settleVendorBill(billId: string): Promise<VendorBill> {
+  const data = (await sendJson(`/api/vendors/bills/${billId}/settle`, "PATCH")) as VendorBillResponse;
+  return normalizeVendorBill(data);
+}
+
+export async function getVendorSummary(): Promise<VendorSummary> {
+  try {
+    const data = await fetchJson<VendorSummaryResponse>("/api/vendors/summary");
+    return normalizeVendorSummary(data);
+  } catch {
+    return mockDashboardData.vendorSummary;
+  }
 }

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -1,4 +1,4 @@
-import type { AssetTransaction, DashboardData, WalletBalance } from "@/types";
+import type { AssetTransaction, DashboardData, Vendor, VendorBill, WalletBalance } from "@/types";
 
 export const mockWallets: WalletBalance[] = [
   {
@@ -207,6 +207,102 @@ export const mockDashboardData: DashboardData = {
     netMinor: 76_320_00,
     currency: "CNY"
   }
+};
+
+export const mockVendors: Vendor[] = [
+  {
+    id: "vendor-aurora",
+    name: "极光物流",
+    remark: "USDT 通道，月结",
+    createdAt: "2026-03-15T08:00:00.000Z"
+  },
+  {
+    id: "vendor-blue-river",
+    name: "蓝河供应链",
+    remark: null,
+    createdAt: "2026-03-22T09:30:00.000Z"
+  },
+  {
+    id: "vendor-cosmo",
+    name: "Cosmo 渠道商",
+    remark: "境外结算",
+    createdAt: "2026-04-02T03:10:00.000Z"
+  }
+];
+
+export const mockVendorBills: Record<string, VendorBill[]> = {
+  "vendor-aurora": [
+    {
+      id: "bill-aurora-1",
+      vendorId: "vendor-aurora",
+      direction: "payable",
+      amountMinor: 128_500_00,
+      currency: "CNY",
+      status: "pending",
+      dueDate: "2026-05-10",
+      remark: "4 月物流费",
+      createdAt: "2026-04-20T02:30:00.000Z"
+    },
+    {
+      id: "bill-aurora-2",
+      vendorId: "vendor-aurora",
+      direction: "payable",
+      amountMinor: 64_300_00,
+      currency: "CNY",
+      status: "settled",
+      dueDate: "2026-04-05",
+      remark: "3 月尾款",
+      createdAt: "2026-03-28T05:00:00.000Z"
+    }
+  ],
+  "vendor-blue-river": [
+    {
+      id: "bill-blue-1",
+      vendorId: "vendor-blue-river",
+      direction: "receivable",
+      amountMinor: 188_000_00,
+      currency: "CNY",
+      status: "pending",
+      dueDate: "2026-05-15",
+      remark: "渠道返点",
+      createdAt: "2026-04-18T07:00:00.000Z"
+    },
+    {
+      id: "bill-blue-2",
+      vendorId: "vendor-blue-river",
+      direction: "payable",
+      amountMinor: 25_900_00,
+      currency: "CNY",
+      status: "pending",
+      dueDate: null,
+      remark: null,
+      createdAt: "2026-04-25T03:20:00.000Z"
+    }
+  ],
+  "vendor-cosmo": [
+    {
+      id: "bill-cosmo-1",
+      vendorId: "vendor-cosmo",
+      direction: "receivable",
+      amountMinor: 107_020_00,
+      currency: "CNY",
+      status: "pending",
+      dueDate: "2026-05-20",
+      remark: "Cosmo 季度返佣",
+      createdAt: "2026-04-15T10:00:00.000Z"
+    },
+    {
+      id: "bill-cosmo-2",
+      vendorId: "vendor-cosmo",
+      direction: "receivable",
+      amountMinor: 32_000_00,
+      currency: "CNY",
+      status: "settled",
+      dueDate: "2026-04-10",
+      remark: null,
+      createdAt: "2026-03-30T06:30:00.000Z"
+    }
+  ]
 };
 
 export const mockAssetTransactions: Record<string, AssetTransaction[]> = {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -38,6 +38,29 @@ export type AssetTransaction = {
   currency: Currency;
 };
 
+export type BillDirection = "payable" | "receivable";
+
+export type BillStatus = "pending" | "settled";
+
+export type Vendor = {
+  id: string;
+  name: string;
+  remark: string | null;
+  createdAt: string;
+};
+
+export type VendorBill = {
+  id: string;
+  vendorId: string;
+  direction: BillDirection;
+  amountMinor: number;
+  currency: Currency;
+  status: BillStatus;
+  dueDate: string | null;
+  remark: string | null;
+  createdAt: string;
+};
+
 export type ModuleSection = {
   id: string;
   title: string;


### PR DESCRIPTION
## 关联 Issue
Closes #40

## 改动说明
- types.ts 加 Vendor/VendorBill/BillDirection/BillStatus
- lib/api.ts 加 5 个 vendor client 函数（getVendors / createVendor / getVendorBills / createVendorBill / settleVendorBill），失败回退 mock；getVendorSummary 也补上独立导出
- components/vendors-page.tsx 新建（顶部三卡 + 左供应商列表 + 右账单表格 + 两弹窗）
- app/[section]/page.tsx 加 vendors 分支
- mock-data.ts 加 3 个示例供应商 + 6 条账单（payable/receivable + pending/settled 混合）

## 自测
- [x] npm run typecheck 通过
- [x] mock 回退路径覆盖（后端不可用时仍可预览全部交互）
- [x] 复用 F-8 弹窗模式（fixed inset-0 z-50 + Card max-w-md + inline 红色 error 框）

---
> 由 broky 实现，请 PM 审查