### PR TITLE
[PR] [FEAT-F4v2] XBOX 账号页完整实现

### DIFF
--- a/frontend/app/[section]/page.tsx
+++ b/frontend/app/[section]/page.tsx
@@ -2,6 +2,7 @@ import { AppShell } from "@/components/app-shell";
 import { AssetsPage } from "@/components/assets-page";
 import { ModuleOverview } from "@/components/module-overview";
 import { VendorsPage } from "@/components/vendors-page";
+import { XboxPage } from "@/components/xbox-page";
 import { sectionById, sectionIds } from "@/lib/navigation";
 
 type SectionPageProps = {
@@ -19,6 +20,8 @@ export default function SectionPage({ params }: SectionPageProps) {
         <AssetsPage />
       ) : section.id === "vendors" ? (
         <VendorsPage />
+      ) : section.id === "xbox" ? (
+        <XboxPage />
       ) : (
         <ModuleOverview section={section} />
       )}

--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -1,0 +1,593 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowDownLeft,
+  ArrowUpRight,
+  Gamepad2,
+  ListOrdered,
+  Plus,
+  RefreshCcw
+} from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  consumeXbox,
+  createXboxAccount,
+  getXboxAccounts,
+  getXboxSummary,
+  getXboxTransactions,
+  rechargeXbox
+} from "@/lib/api";
+import { formatMoney } from "@/lib/money";
+import { cn } from "@/lib/utils";
+import type { Currency, XboxAccount, XboxCountry } from "@/types";
+
+const COUNTRY_META: Record<XboxCountry, { label: string; currency: Currency; accentBorder: string; accentText: string }> = {
+  US: {
+    label: "美国 (USD)",
+    currency: "USD",
+    accentBorder: "border-blue-500/50",
+    accentText: "text-blue-600"
+  },
+  UK: {
+    label: "英国 (GBP)",
+    currency: "GBP",
+    accentBorder: "border-red-500/50",
+    accentText: "text-red-600"
+  }
+};
+
+function formatDateTime(value: string) {
+  if (!value) return "-";
+  return value.length >= 16 ? value.slice(0, 16).replace("T", " ") : value;
+}
+
+function SummaryCards({ country }: { country: XboxCountry }) {
+  const { data, isFetching, refetch } = useQuery({
+    queryKey: ["xbox-summary"],
+    queryFn: getXboxSummary
+  });
+
+  const meta = COUNTRY_META[country];
+  const summary = country === "US" ? data?.us : data?.uk;
+  const rmbCost = summary?.rmbCostMinor ?? 0;
+  const localBalance = summary?.localBalanceMinor ?? 0;
+  const accountCount = summary?.accountCount ?? 0;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-end">
+        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+          刷新汇总
+        </Button>
+      </div>
+      <div className="grid gap-3 md:grid-cols-3">
+        <Card className={cn("border", meta.accentBorder)}>
+          <CardContent className="flex items-center justify-between gap-4 p-5">
+            <div>
+              <div className="text-sm text-muted-foreground">累计 RMB 成本</div>
+              <div className="mt-1 tabular-nums text-2xl font-semibold text-red-600">
+                {formatMoney(rmbCost, "CNY")}
+              </div>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-red-50 text-red-600">
+              <ArrowUpRight className="h-5 w-5" aria-hidden="true" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={cn("border", meta.accentBorder)}>
+          <CardContent className="flex items-center justify-between gap-4 p-5">
+            <div>
+              <div className="text-sm text-muted-foreground">本地余额</div>
+              <div className={cn("mt-1 tabular-nums text-2xl font-semibold", meta.accentText)}>
+                {formatMoney(localBalance, meta.currency)}
+              </div>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-emerald-50 text-emerald-600">
+              <ArrowDownLeft className="h-5 w-5" aria-hidden="true" />
+            </div>
+          </CardContent>
+        </Card>
+        <Card className={cn("border", meta.accentBorder)}>
+          <CardContent className="flex items-center justify-between gap-4 p-5">
+            <div>
+              <div className="text-sm text-muted-foreground">账号数</div>
+              <div className="mt-1 tabular-nums text-2xl font-semibold">{accountCount}</div>
+            </div>
+            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+              <Gamepad2 className="h-5 w-5" aria-hidden="true" />
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function CreateAccountModal({
+  defaultCountry,
+  onClose
+}: {
+  defaultCountry: XboxCountry;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("");
+  const [country, setCountry] = useState<XboxCountry>(defaultCountry);
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!name.trim()) {
+        throw new Error("账号名不能为空");
+      }
+      return createXboxAccount({
+        name: name.trim(),
+        country,
+        remark: remark.trim() === "" ? undefined : remark.trim()
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-summary"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "创建失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>新建 XBOX 账号</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">账号名</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="账号名"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">国家</div>
+            <div className="grid grid-cols-2 rounded-md border border-border p-1">
+              {(["US", "UK"] as XboxCountry[]).map((item) => (
+                <button
+                  key={item}
+                  type="button"
+                  className={cn(
+                    "flex h-8 items-center justify-center rounded text-sm font-medium text-muted-foreground",
+                    country === item && "bg-muted text-foreground"
+                  )}
+                  onClick={() => setCountry(item)}
+                >
+                  {COUNTRY_META[item].label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "创建中..." : "创建"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function RechargeModal({ account, onClose }: { account: XboxAccount; onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [rmbAmount, setRmbAmount] = useState("");
+  const [localAmount, setLocalAmount] = useState("");
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!rmbAmount || Number(rmbAmount) <= 0) {
+        throw new Error("花费人民币必须大于 0");
+      }
+      if (!localAmount || Number(localAmount) <= 0) {
+        throw new Error("到账当地货币必须大于 0");
+      }
+      return rechargeXbox(account.id, {
+        rmbAmount,
+        localAmount,
+        remark: remark.trim() === "" ? undefined : remark.trim()
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-summary"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-transactions", account.id] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "充值失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>充值 · {account.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">花费人民币</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={rmbAmount}
+              onChange={(event) => setRmbAmount(event.target.value)}
+              placeholder="花费人民币"
+              type="number"
+              min="0"
+              step="0.01"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">到账当地货币（{account.currency}）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={localAmount}
+              onChange={(event) => setLocalAmount(event.target.value)}
+              placeholder="到账当地货币"
+              type="number"
+              min="0"
+              step="0.01"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "提交中..." : "确认充值"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ConsumeModal({ account, onClose }: { account: XboxAccount; onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [localAmount, setLocalAmount] = useState("");
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!localAmount || Number(localAmount) <= 0) {
+        throw new Error("消费金额必须大于 0");
+      }
+      return consumeXbox(account.id, {
+        localAmount,
+        remark: remark.trim() === "" ? undefined : remark.trim()
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-summary"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-transactions", account.id] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "消费失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>消费 · {account.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">消费金额（{account.currency}）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={localAmount}
+              onChange={(event) => setLocalAmount(event.target.value)}
+              placeholder="消费金额"
+              type="number"
+              min="0"
+              step="0.01"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "提交中..." : "确认消费"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function TransactionsModal({ account, onClose }: { account: XboxAccount; onClose: () => void }) {
+  const { data: transactions = [], isFetching } = useQuery({
+    queryKey: ["xbox-transactions", account.id],
+    queryFn: () => getXboxTransactions(account)
+  });
+
+  const sorted = [...transactions].sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-3xl">
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle>{account.name} · 流水</CardTitle>
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              关闭
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>类型</TableHead>
+                <TableHead className="text-right">RMB 金额</TableHead>
+                <TableHead className="text-right">本地金额</TableHead>
+                <TableHead>备注</TableHead>
+                <TableHead>时间</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sorted.map((tx) => {
+                const isRecharge = tx.type === "recharge";
+                return (
+                  <TableRow key={tx.id}>
+                    <TableCell>
+                      <Badge tone={isRecharge ? "success" : "danger"}>
+                        {isRecharge ? "充值" : "消费"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      {tx.rmbAmountMinor > 0 ? formatMoney(tx.rmbAmountMinor, "CNY") : "-"}
+                    </TableCell>
+                    <TableCell
+                      className={cn(
+                        "text-right tabular-nums font-semibold",
+                        isRecharge ? "text-green-600" : "text-red-600"
+                      )}
+                    >
+                      {formatMoney(tx.localAmountMinor, tx.currency)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">{tx.remark ?? "-"}</TableCell>
+                    <TableCell className="text-muted-foreground">{formatDateTime(tx.createdAt)}</TableCell>
+                  </TableRow>
+                );
+              })}
+              {sorted.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+                    {isFetching ? "加载中..." : "暂无流水"}
+                  </TableCell>
+                </TableRow>
+              ) : null}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function AccountsTable({
+  accounts,
+  country,
+  onRecharge,
+  onConsume,
+  onTransactions
+}: {
+  accounts: XboxAccount[];
+  country: XboxCountry;
+  onRecharge: (account: XboxAccount) => void;
+  onConsume: (account: XboxAccount) => void;
+  onTransactions: (account: XboxAccount) => void;
+}) {
+  const meta = COUNTRY_META[country];
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>账号名</TableHead>
+          <TableHead className="text-right">RMB 累计成本</TableHead>
+          <TableHead className="text-right">本地余额</TableHead>
+          <TableHead>备注</TableHead>
+          <TableHead className="text-right">操作</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {accounts.map((account) => (
+          <TableRow key={account.id}>
+            <TableCell className="font-medium">{account.name}</TableCell>
+            <TableCell className="text-right tabular-nums text-red-600">
+              {formatMoney(account.rmbCostMinor, "CNY")}
+            </TableCell>
+            <TableCell className={cn("text-right tabular-nums font-semibold", meta.accentText)}>
+              {formatMoney(account.localBalanceMinor, account.currency)}
+            </TableCell>
+            <TableCell className="text-muted-foreground">{account.remark ?? "-"}</TableCell>
+            <TableCell className="text-right">
+              <div className="flex justify-end gap-2">
+                <Button size="sm" variant="outline" onClick={() => onRecharge(account)}>
+                  <ArrowDownLeft className="h-4 w-4 text-green-600" aria-hidden="true" />
+                  充值
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => onConsume(account)}>
+                  <ArrowUpRight className="h-4 w-4 text-red-600" aria-hidden="true" />
+                  消费
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => onTransactions(account)}>
+                  <ListOrdered className="h-4 w-4" aria-hidden="true" />
+                  流水
+                </Button>
+              </div>
+            </TableCell>
+          </TableRow>
+        ))}
+        {accounts.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+              当前 Tab 暂无账号，点击右上角「+ 新建账号」开始
+            </TableCell>
+          </TableRow>
+        ) : null}
+      </TableBody>
+    </Table>
+  );
+}
+
+export function XboxPage() {
+  const [country, setCountry] = useState<XboxCountry>("US");
+  const [showCreate, setShowCreate] = useState(false);
+  const [rechargeTarget, setRechargeTarget] = useState<XboxAccount | null>(null);
+  const [consumeTarget, setConsumeTarget] = useState<XboxAccount | null>(null);
+  const [transactionsTarget, setTransactionsTarget] = useState<XboxAccount | null>(null);
+
+  const { data: accounts = [], isFetching, refetch } = useQuery({
+    queryKey: ["xbox-accounts", country],
+    queryFn: () => getXboxAccounts(country)
+  });
+
+  const meta = COUNTRY_META[country];
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-normal">XBOX 账号</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            按国家管理 XBOX 账号，记录 RMB 成本与本地余额，支持充值/消费/查流水。
+          </p>
+        </div>
+        <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+          刷新账号
+        </Button>
+      </div>
+
+      <div className="inline-flex rounded-md border border-border p-1">
+        {(["US", "UK"] as XboxCountry[]).map((item) => (
+          <button
+            key={item}
+            type="button"
+            className={cn(
+              "h-9 px-4 rounded text-sm font-medium text-muted-foreground transition-colors",
+              country === item && "bg-muted text-foreground"
+            )}
+            onClick={() => setCountry(item)}
+          >
+            {COUNTRY_META[item].label}
+          </button>
+        ))}
+      </div>
+
+      <SummaryCards country={country} />
+
+      <Card className={cn("border", meta.accentBorder)}>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle>{meta.label} 账号列表</CardTitle>
+            <Button size="sm" onClick={() => setShowCreate(true)}>
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              新建账号
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <AccountsTable
+            accounts={accounts}
+            country={country}
+            onRecharge={setRechargeTarget}
+            onConsume={setConsumeTarget}
+            onTransactions={setTransactionsTarget}
+          />
+        </CardContent>
+      </Card>
+
+      {showCreate ? (
+        <CreateAccountModal defaultCountry={country} onClose={() => setShowCreate(false)} />
+      ) : null}
+      {rechargeTarget ? (
+        <RechargeModal account={rechargeTarget} onClose={() => setRechargeTarget(null)} />
+      ) : null}
+      {consumeTarget ? (
+        <ConsumeModal account={consumeTarget} onClose={() => setConsumeTarget(null)} />
+      ) : null}
+      {transactionsTarget ? (
+        <TransactionsModal account={transactionsTarget} onClose={() => setTransactionsTarget(null)} />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,12 @@
-import { mockAssetTransactions, mockDashboardData, mockVendorBills, mockVendors } from "@/lib/mock-data";
+import {
+  mockAssetTransactions,
+  mockDashboardData,
+  mockVendorBills,
+  mockVendors,
+  mockXboxAccounts,
+  mockXboxSummary,
+  mockXboxTransactions
+} from "@/lib/mock-data";
 import { decimalToMinor } from "@/lib/money";
 import type {
   AssetTransaction,
@@ -9,7 +17,12 @@ import type {
   VendorBill,
   VendorSummary,
   WalletBalance,
-  WalletType
+  WalletType,
+  XboxAccount,
+  XboxCountry,
+  XboxSummary,
+  XboxTransaction,
+  XboxTransactionType
 } from "@/types";
 
 type AssetWalletResponse = {
@@ -318,6 +331,162 @@ export async function createVendorBill(
 export async function settleVendorBill(billId: string): Promise<VendorBill> {
   const data = (await sendJson(`/api/vendors/bills/${billId}/settle`, "PATCH")) as VendorBillResponse;
   return normalizeVendorBill(data);
+}
+
+type XboxAccountResponse = {
+  id: string | number;
+  name: string;
+  country: string;
+  currency: string;
+  rmb_cost?: string | number;
+  rmbCost?: string | number;
+  local_balance?: string | number;
+  localBalance?: string | number;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type XboxTransactionResponse = {
+  id: string | number;
+  account_id?: string | number;
+  accountId?: string | number;
+  rmb_amount?: string | number;
+  rmbAmount?: string | number;
+  local_amount?: string | number;
+  localAmount?: string | number;
+  type: XboxTransactionType;
+  remark?: string | null;
+  created_at?: string;
+  createdAt?: string;
+};
+
+type XboxSummaryResponse = {
+  USD?: { rmb_cost?: string | number; local_balance?: string | number; rmbCost?: string | number; localBalance?: string | number };
+  GBP?: { rmb_cost?: string | number; local_balance?: string | number; rmbCost?: string | number; localBalance?: string | number };
+};
+
+function normalizeXboxAccount(account: XboxAccountResponse): XboxAccount {
+  const country = (account.country === "UK" ? "UK" : "US") as XboxCountry;
+  const currency: Currency = country === "US" ? "USD" : "GBP";
+  return {
+    id: String(account.id),
+    name: account.name,
+    country,
+    currency,
+    rmbCostMinor: decimalToMinor(account.rmb_cost ?? account.rmbCost ?? 0, "CNY"),
+    localBalanceMinor: decimalToMinor(account.local_balance ?? account.localBalance ?? 0, currency),
+    remark: account.remark ?? null,
+    createdAt: account.created_at ?? account.createdAt ?? ""
+  };
+}
+
+function normalizeXboxTransaction(transaction: XboxTransactionResponse, currency: Currency): XboxTransaction {
+  return {
+    id: String(transaction.id),
+    accountId: String(transaction.account_id ?? transaction.accountId ?? ""),
+    rmbAmountMinor: decimalToMinor(transaction.rmb_amount ?? transaction.rmbAmount ?? 0, "CNY"),
+    localAmountMinor: decimalToMinor(transaction.local_amount ?? transaction.localAmount ?? 0, currency),
+    type: transaction.type,
+    remark: transaction.remark ?? null,
+    createdAt: transaction.created_at ?? transaction.createdAt ?? "",
+    currency
+  };
+}
+
+export async function getXboxAccounts(country?: XboxCountry): Promise<XboxAccount[]> {
+  try {
+    const path = country ? `/api/xbox/accounts?country=${country}` : "/api/xbox/accounts";
+    const data = await fetchJson<XboxAccountResponse[]>(path);
+    return data.map(normalizeXboxAccount);
+  } catch {
+    return country ? mockXboxAccounts.filter((acc) => acc.country === country) : mockXboxAccounts;
+  }
+}
+
+export async function createXboxAccount(payload: {
+  name: string;
+  country: XboxCountry;
+  remark?: string;
+}): Promise<XboxAccount> {
+  const body: Record<string, unknown> = {
+    name: payload.name,
+    country: payload.country
+  };
+  if (payload.remark) {
+    body.remark = payload.remark;
+  }
+  const data = (await postJson("/api/xbox/accounts", body)) as XboxAccountResponse;
+  return normalizeXboxAccount(data);
+}
+
+export async function rechargeXbox(
+  accountId: string,
+  payload: { rmbAmount: string; localAmount: string; remark?: string }
+): Promise<XboxTransaction> {
+  const body: Record<string, unknown> = {
+    rmb_amount: payload.rmbAmount,
+    local_amount: payload.localAmount
+  };
+  if (payload.remark) {
+    body.remark = payload.remark;
+  }
+  const data = (await postJson(`/api/xbox/accounts/${accountId}/recharge`, body)) as XboxTransactionResponse;
+  // currency unknown without account context; default USD-safe normalization happens via currency arg below
+  const account = mockXboxAccounts.find((acc) => acc.id === accountId);
+  return normalizeXboxTransaction({ ...data, account_id: data.account_id ?? accountId }, account?.currency ?? "USD");
+}
+
+export async function consumeXbox(
+  accountId: string,
+  payload: { localAmount: string; remark?: string }
+): Promise<XboxTransaction> {
+  const body: Record<string, unknown> = {
+    local_amount: payload.localAmount
+  };
+  if (payload.remark) {
+    body.remark = payload.remark;
+  }
+  const data = (await postJson(`/api/xbox/accounts/${accountId}/consume`, body)) as XboxTransactionResponse;
+  const account = mockXboxAccounts.find((acc) => acc.id === accountId);
+  return normalizeXboxTransaction({ ...data, account_id: data.account_id ?? accountId }, account?.currency ?? "USD");
+}
+
+export async function getXboxTransactions(account: XboxAccount): Promise<XboxTransaction[]> {
+  try {
+    const data = await fetchJson<XboxTransactionResponse[]>(`/api/xbox/accounts/${account.id}/transactions`);
+    return data.map((tx) => normalizeXboxTransaction({ ...tx, account_id: tx.account_id ?? account.id }, account.currency));
+  } catch {
+    return mockXboxTransactions[account.id] ?? [];
+  }
+}
+
+export async function getXboxSummary(): Promise<XboxSummary> {
+  try {
+    const data = await fetchJson<XboxSummaryResponse>("/api/xbox/summary");
+    const usd = data.USD ?? {};
+    const gbp = data.GBP ?? {};
+    // accountCount unknown from summary endpoint — fetch accounts lazily on consumer if needed
+    const accounts = await fetchJson<XboxAccountResponse[]>("/api/xbox/accounts").catch(() => [] as XboxAccountResponse[]);
+    const usCount = accounts.filter((acc) => acc.country === "US").length;
+    const ukCount = accounts.filter((acc) => acc.country === "UK").length;
+    return {
+      us: {
+        rmbCostMinor: decimalToMinor(usd.rmb_cost ?? usd.rmbCost ?? 0, "CNY"),
+        localBalanceMinor: decimalToMinor(usd.local_balance ?? usd.localBalance ?? 0, "USD"),
+        accountCount: usCount,
+        currency: "USD"
+      },
+      uk: {
+        rmbCostMinor: decimalToMinor(gbp.rmb_cost ?? gbp.rmbCost ?? 0, "CNY"),
+        localBalanceMinor: decimalToMinor(gbp.local_balance ?? gbp.localBalance ?? 0, "GBP"),
+        accountCount: ukCount,
+        currency: "GBP"
+      }
+    };
+  } catch {
+    return mockXboxSummary;
+  }
 }
 
 export async function getVendorSummary(): Promise<VendorSummary> {

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -1,4 +1,13 @@
-import type { AssetTransaction, DashboardData, Vendor, VendorBill, WalletBalance } from "@/types";
+import type {
+  AssetTransaction,
+  DashboardData,
+  Vendor,
+  VendorBill,
+  WalletBalance,
+  XboxAccount,
+  XboxSummary,
+  XboxTransaction
+} from "@/types";
 
 export const mockWallets: WalletBalance[] = [
   {
@@ -303,6 +312,113 @@ export const mockVendorBills: Record<string, VendorBill[]> = {
       createdAt: "2026-03-30T06:30:00.000Z"
     }
   ]
+};
+
+export const mockXboxAccounts: XboxAccount[] = [
+  {
+    id: "xbox-us-1",
+    name: "US-Main",
+    country: "US",
+    currency: "USD",
+    rmbCostMinor: 28_000_00,
+    localBalanceMinor: 3_840_00,
+    remark: "主号",
+    createdAt: "2026-03-12T08:00:00.000Z"
+  },
+  {
+    id: "xbox-us-2",
+    name: "US-Backup",
+    country: "US",
+    currency: "USD",
+    rmbCostMinor: 12_500_00,
+    localBalanceMinor: 1_720_00,
+    remark: null,
+    createdAt: "2026-03-30T03:20:00.000Z"
+  },
+  {
+    id: "xbox-uk-1",
+    name: "UK-Main",
+    country: "UK",
+    currency: "GBP",
+    rmbCostMinor: 18_400_00,
+    localBalanceMinor: 2_100_00,
+    remark: "英区主力",
+    createdAt: "2026-04-02T05:00:00.000Z"
+  }
+];
+
+export const mockXboxTransactions: Record<string, XboxTransaction[]> = {
+  "xbox-us-1": [
+    {
+      id: "xbox-us-1-tx-1",
+      accountId: "xbox-us-1",
+      rmbAmountMinor: 14_000_00,
+      localAmountMinor: 2_000_00,
+      type: "recharge",
+      remark: "首充",
+      createdAt: "2026-03-12T08:30:00.000Z",
+      currency: "USD"
+    },
+    {
+      id: "xbox-us-1-tx-2",
+      accountId: "xbox-us-1",
+      rmbAmountMinor: 0,
+      localAmountMinor: 160_00,
+      type: "consume",
+      remark: "购买游戏",
+      createdAt: "2026-04-10T11:00:00.000Z",
+      currency: "USD"
+    }
+  ],
+  "xbox-us-2": [
+    {
+      id: "xbox-us-2-tx-1",
+      accountId: "xbox-us-2",
+      rmbAmountMinor: 12_500_00,
+      localAmountMinor: 1_800_00,
+      type: "recharge",
+      remark: null,
+      createdAt: "2026-03-30T03:25:00.000Z",
+      currency: "USD"
+    }
+  ],
+  "xbox-uk-1": [
+    {
+      id: "xbox-uk-1-tx-1",
+      accountId: "xbox-uk-1",
+      rmbAmountMinor: 18_400_00,
+      localAmountMinor: 2_200_00,
+      type: "recharge",
+      remark: "英区开号",
+      createdAt: "2026-04-02T05:10:00.000Z",
+      currency: "GBP"
+    },
+    {
+      id: "xbox-uk-1-tx-2",
+      accountId: "xbox-uk-1",
+      rmbAmountMinor: 0,
+      localAmountMinor: 100_00,
+      type: "consume",
+      remark: "Game Pass",
+      createdAt: "2026-04-20T09:00:00.000Z",
+      currency: "GBP"
+    }
+  ]
+};
+
+export const mockXboxSummary: XboxSummary = {
+  us: {
+    rmbCostMinor: 40_500_00,
+    localBalanceMinor: 5_560_00,
+    accountCount: 2,
+    currency: "USD"
+  },
+  uk: {
+    rmbCostMinor: 18_400_00,
+    localBalanceMinor: 2_100_00,
+    accountCount: 1,
+    currency: "GBP"
+  }
 };
 
 export const mockAssetTransactions: Record<string, AssetTransaction[]> = {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -61,6 +61,44 @@ export type VendorBill = {
   createdAt: string;
 };
 
+export type XboxCountry = "US" | "UK";
+
+export type XboxTransactionType = "recharge" | "consume";
+
+export type XboxAccount = {
+  id: string;
+  name: string;
+  country: XboxCountry;
+  currency: Currency;
+  rmbCostMinor: number;
+  localBalanceMinor: number;
+  remark: string | null;
+  createdAt: string;
+};
+
+export type XboxTransaction = {
+  id: string;
+  accountId: string;
+  rmbAmountMinor: number;
+  localAmountMinor: number;
+  type: XboxTransactionType;
+  remark: string | null;
+  createdAt: string;
+  currency: Currency;
+};
+
+export type XboxCountrySummary = {
+  rmbCostMinor: number;
+  localBalanceMinor: number;
+  accountCount: number;
+  currency: Currency;
+};
+
+export type XboxSummary = {
+  us: XboxCountrySummary;
+  uk: XboxCountrySummary;
+};
+
 export type ModuleSection = {
   id: string;
   title: string;


### PR DESCRIPTION
## 关联 Issue
Closes #42

## 改动说明
- types.ts 加 XboxCountry/XboxAccount/XboxTransaction/XboxSummary
- lib/api.ts 加 6 个 xbox client 函数（getXboxAccounts/createXboxAccount/rechargeXbox/consumeXbox/getXboxTransactions/getXboxSummary）
- components/xbox-page.tsx 新建（Tab + 汇总卡 + 表格 + 4 弹窗）
- app/[section]/page.tsx 加 xbox 分支
- mock-data.ts 加示例数据（US 2 + UK 1 + 流水）

## 自测
- [x] npm run typecheck 通过
- [x] 后端 6 个端点 curl 实测：POST /xbox/accounts (US/UK) → GET ?country= 过滤 → POST recharge → POST consume → GET transactions → GET summary，全部 200，余额计算正确（US 充 700 RMB / 100 USD，消费 15 USD，summary 返回 85 USD / 700 RMB）
- [x] http://localhost:3000/xbox SSR 200，Next.js 编译无错
- [x] Chrome MCP 当前不可用，未做点击级手测；UI 行为通过代码 review + API 实测覆盖（弹窗 = vendors-page 同模式，invalidate 后 React Query 自刷）

## 字段映射
后端 snake_case → 前端 camelCase 在 normalizeXboxAccount / normalizeXboxTransaction 内处理：rmb_cost↔rmbCostMinor、local_balance↔localBalanceMinor、rmb_amount↔rmbAmountMinor、local_amount↔localAmountMinor、account_id↔accountId、created_at↔createdAt。POST body 用 rmb_amount/local_amount 与后端 schema 对齐。

---
> 由 broky 实现，请 PM 审查