### PR TITLE
[PR] [FEAT] 供应商钱包化改造

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,6 +13,7 @@ from src.routers.taobao import router as taobao_router
 from src.routers.taiwan import router as taiwan_router
 from src.services.assets import ensure_default_asset_wallets
 from src.services.taiwan import ensure_default_taiwan_wallets
+from src.services.vendors import ensure_vendor_wallets
 
 
 @asynccontextmanager
@@ -22,6 +23,7 @@ async def lifespan(_: FastAPI):
     try:
         ensure_default_asset_wallets(db)
         ensure_default_taiwan_wallets(db)
+        ensure_vendor_wallets(db)
         db.commit()
     finally:
         db.close()

--- a/src/models/vendor.py
+++ b/src/models/vendor.py
@@ -1,25 +1,14 @@
-"""Vendor and vendor bill ORM models."""
+"""Vendor ORM models."""
 from __future__ import annotations
 
-from datetime import date, datetime
-from decimal import Decimal
-from enum import Enum
+from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import Date, DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, String, Text, func
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
-
-
-class VendorBillDirection(str, Enum):
-    PAYABLE = "payable"
-    RECEIVABLE = "receivable"
-
-
-class VendorBillStatus(str, Enum):
-    PENDING = "pending"
-    SETTLED = "settled"
+from src.models.wallet import Wallet
 
 
 class Vendor(Base):
@@ -28,36 +17,11 @@ class Vendor(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
     remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         server_default=func.now(),
     )
 
-    bills: Mapped[list["VendorBill"]] = relationship(
-        back_populates="vendor",
-        cascade="all, delete-orphan",
-    )
-
-
-class VendorBill(Base):
-    __tablename__ = "vendor_bills"
-
-    id: Mapped[int] = mapped_column(primary_key=True)
-    vendor_id: Mapped[int] = mapped_column(ForeignKey("vendors.id"), nullable=False, index=True)
-    direction: Mapped[VendorBillDirection] = mapped_column(String(16), nullable=False)
-    amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
-    status: Mapped[VendorBillStatus] = mapped_column(
-        String(16),
-        nullable=False,
-        default=VendorBillStatus.PENDING.value,
-    )
-    due_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
-    remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        nullable=False,
-        server_default=func.now(),
-    )
-
-    vendor: Mapped[Vendor] = relationship(back_populates="bills")
+    wallet: Mapped[Wallet] = relationship("Wallet", foreign_keys=[wallet_id])

--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -160,7 +160,8 @@ def debit(
     """Decrease a wallet balance and create an outbound transaction record."""
     value = _to_decimal(amount)
     wallet = get_wallet(session, wallet_id)
-    if Decimal(wallet.balance) < value:
+    wallet_type = wallet.type.value if isinstance(wallet.type, WalletType) else wallet.type
+    if wallet_type != WalletType.VENDOR.value and Decimal(wallet.balance) < value:
         raise ValueError("insufficient wallet balance")
 
     wallet.balance = Decimal(wallet.balance) - value

--- a/src/routers/vendors.py
+++ b/src/routers/vendors.py
@@ -1,19 +1,19 @@
-"""Vendor payable and receivable API routes."""
+"""Vendor API routes (wallet-backed)."""
 from __future__ import annotations
 
-from datetime import date
 from decimal import Decimal
-from enum import Enum
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from src.database import get_db
-from src.models.vendor import Vendor, VendorBill, VendorBillDirection, VendorBillStatus
+from src.models.vendor import Vendor
+from src.models.wallet import Wallet
+from src.services.vendors import create_vendor_wallet
 
 
 router = APIRouter(prefix="/vendors", tags=["vendors"])
@@ -28,71 +28,26 @@ class VendorOut(BaseModel):
     id: int
     name: str
     remark: Optional[str]
+    walletId: int
+    balance: Decimal
     created_at: str
 
 
-class VendorBillCreate(BaseModel):
-    direction: VendorBillDirection
-    amount: Decimal = Field(..., gt=0)
-    due_date: Optional[date] = None
-    remark: Optional[str] = None
-
-
-class VendorBillOut(BaseModel):
-    id: int
-    vendor_id: int
-    direction: str
-    amount: Decimal
-    status: str
-    due_date: Optional[str]
-    remark: Optional[str]
-    created_at: str
-
-
-class VendorSummaryOut(BaseModel):
-    payable: Decimal
-    receivable: Decimal
-    net: Decimal
-
-
-def _value(value):
-    if isinstance(value, Enum):
-        return value.value
-    return value
-
-
-def serialize_vendor(vendor: Vendor) -> VendorOut:
+def serialize_vendor(vendor: Vendor, wallet: Wallet) -> VendorOut:
     return VendorOut(
         id=vendor.id,
         name=vendor.name,
         remark=vendor.remark,
+        walletId=wallet.id,
+        balance=Decimal(wallet.balance),
         created_at=vendor.created_at.isoformat() if vendor.created_at else "",
     )
 
 
-def serialize_bill(bill: VendorBill) -> VendorBillOut:
-    return VendorBillOut(
-        id=bill.id,
-        vendor_id=bill.vendor_id,
-        direction=_value(bill.direction),
-        amount=bill.amount,
-        status=_value(bill.status),
-        due_date=bill.due_date.isoformat() if bill.due_date else None,
-        remark=bill.remark,
-        created_at=bill.created_at.isoformat() if bill.created_at else "",
-    )
-
-
-def get_vendor_or_404(session: Session, vendor_id: int) -> Vendor:
-    vendor = session.get(Vendor, vendor_id)
-    if vendor is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="供应商不存在")
-    return vendor
-
-
 @router.post("", response_model=VendorOut, status_code=status.HTTP_201_CREATED)
 def create_vendor(request: VendorCreate, db: Session = Depends(get_db)) -> VendorOut:
-    vendor = Vendor(name=request.name, remark=request.remark)
+    wallet = create_vendor_wallet(db, request.name)
+    vendor = Vendor(name=request.name, remark=request.remark, wallet_id=wallet.id)
     db.add(vendor)
     try:
         db.commit()
@@ -100,63 +55,13 @@ def create_vendor(request: VendorCreate, db: Session = Depends(get_db)) -> Vendo
         db.rollback()
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="供应商名称已存在") from exc
     db.refresh(vendor)
-    return serialize_vendor(vendor)
+    db.refresh(wallet)
+    return serialize_vendor(vendor, wallet)
 
 
 @router.get("", response_model=list[VendorOut])
 def list_vendors(db: Session = Depends(get_db)) -> list[VendorOut]:
-    vendors = db.scalars(select(Vendor).order_by(Vendor.id)).all()
-    return [serialize_vendor(vendor) for vendor in vendors]
-
-
-@router.post("/{vendor_id}/bills", response_model=VendorBillOut, status_code=status.HTTP_201_CREATED)
-def create_vendor_bill(
-    vendor_id: int,
-    request: VendorBillCreate,
-    db: Session = Depends(get_db),
-) -> VendorBillOut:
-    get_vendor_or_404(db, vendor_id)
-    bill = VendorBill(
-        vendor_id=vendor_id,
-        direction=request.direction.value,
-        amount=request.amount,
-        due_date=request.due_date,
-        remark=request.remark,
-    )
-    db.add(bill)
-    db.commit()
-    db.refresh(bill)
-    return serialize_bill(bill)
-
-
-@router.get("/{vendor_id}/bills", response_model=list[VendorBillOut])
-def list_vendor_bills(vendor_id: int, db: Session = Depends(get_db)) -> list[VendorBillOut]:
-    get_vendor_or_404(db, vendor_id)
-    bills = db.scalars(
-        select(VendorBill).where(VendorBill.vendor_id == vendor_id).order_by(VendorBill.id)
-    ).all()
-    return [serialize_bill(bill) for bill in bills]
-
-
-@router.patch("/bills/{bill_id}/settle", response_model=VendorBillOut)
-def settle_vendor_bill(bill_id: int, db: Session = Depends(get_db)) -> VendorBillOut:
-    bill = db.get(VendorBill, bill_id)
-    if bill is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="账单不存在")
-    bill.status = VendorBillStatus.SETTLED.value
-    db.commit()
-    db.refresh(bill)
-    return serialize_bill(bill)
-
-
-@router.get("/summary", response_model=VendorSummaryOut)
-def vendor_summary(db: Session = Depends(get_db)) -> VendorSummaryOut:
     rows = db.execute(
-        select(VendorBill.direction, func.coalesce(func.sum(VendorBill.amount), 0))
-        .where(VendorBill.status == VendorBillStatus.PENDING.value)
-        .group_by(VendorBill.direction)
+        select(Vendor, Wallet).join(Wallet, Vendor.wallet_id == Wallet.id).order_by(Vendor.id)
     ).all()
-    totals = {direction: Decimal(str(amount)) for direction, amount in rows}
-    payable = totals.get(VendorBillDirection.PAYABLE.value, Decimal("0"))
-    receivable = totals.get(VendorBillDirection.RECEIVABLE.value, Decimal("0"))
-    return VendorSummaryOut(payable=payable, receivable=receivable, net=receivable - payable)
+    return [serialize_vendor(vendor, wallet) for vendor, wallet in rows]

--- a/src/services/vendors.py
+++ b/src/services/vendors.py
@@ -1,0 +1,28 @@
+"""Vendor wallet service functions."""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.vendor import Vendor
+from src.models.wallet import Currency, Wallet, WalletType, create_wallet
+
+
+def create_vendor_wallet(session: Session, vendor_name: str) -> Wallet:
+    """Create the dedicated RMB wallet attached to a vendor."""
+    return create_wallet(
+        session,
+        name=f"{vendor_name} 账单",
+        wallet_type=WalletType.VENDOR,
+        currency=Currency.CNY,
+        is_group=False,
+    )
+
+
+def ensure_vendor_wallets(session: Session) -> None:
+    """Idempotently create a VENDOR wallet for any vendor missing one."""
+    vendors = session.scalars(select(Vendor).where(Vendor.wallet_id.is_(None))).all()
+    for vendor in vendors:
+        wallet = create_vendor_wallet(session, vendor.name)
+        vendor.wallet_id = wallet.id
+    session.flush()

--- a/tests/test_vendors_api.py
+++ b/tests/test_vendors_api.py
@@ -2,10 +2,14 @@ from decimal import Decimal
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import select
 
 from src import database
 from src.main import app
+from src.models.vendor import Vendor
+from src.models.wallet import Wallet, WalletType
 from src.services.assets import ensure_default_asset_wallets
+from src.services.vendors import ensure_vendor_wallets
 
 
 @pytest.fixture()
@@ -27,14 +31,25 @@ def create_vendor(client, name="Vendor A"):
     return response.json()
 
 
-def test_create_and_list_vendors(client):
+def test_create_vendor_returns_wallet_and_zero_balance(client):
     vendor = create_vendor(client)
+
+    assert vendor["name"] == "Vendor A"
+    assert vendor["walletId"] > 0
+    assert Decimal(vendor["balance"]) == Decimal("0")
+
+
+def test_list_vendors_returns_wallet_metadata(client):
+    created = create_vendor(client)
 
     response = client.get("/vendors")
 
     assert response.status_code == 200, response.text
-    assert response.json()[0]["id"] == vendor["id"]
-    assert response.json()[0]["name"] == "Vendor A"
+    payload = response.json()
+    assert len(payload) == 1
+    assert payload[0]["id"] == created["id"]
+    assert payload[0]["walletId"] == created["walletId"]
+    assert Decimal(payload[0]["balance"]) == Decimal("0")
 
 
 def test_vendor_name_must_be_unique(client):
@@ -45,53 +60,45 @@ def test_vendor_name_must_be_unique(client):
     assert response.status_code == 409
 
 
-def test_create_list_and_settle_vendor_bills(client):
-    vendor = create_vendor(client)
+def test_each_vendor_gets_its_own_vendor_wallet(client):
+    a = create_vendor(client, name="Vendor A")
+    b = create_vendor(client, name="Vendor B")
+    c = create_vendor(client, name="Vendor C")
 
-    payable = client.post(
-        f"/vendors/{vendor['id']}/bills",
-        json={
-            "direction": "payable",
-            "amount": "100.00",
-            "due_date": "2026-05-01",
-            "remark": "we owe vendor",
-        },
-    )
-    receivable = client.post(
-        f"/vendors/{vendor['id']}/bills",
-        json={"direction": "receivable", "amount": "30.00", "remark": "vendor owes us"},
-    )
-    assert payable.status_code == 201, payable.text
-    assert receivable.status_code == 201, receivable.text
+    wallet_ids = {a["walletId"], b["walletId"], c["walletId"]}
+    assert len(wallet_ids) == 3
 
-    bills = client.get(f"/vendors/{vendor['id']}/bills")
-    assert bills.status_code == 200, bills.text
-    assert [bill["direction"] for bill in bills.json()] == ["payable", "receivable"]
-
-    settled = client.patch(f"/vendors/bills/{payable.json()['id']}/settle")
-    assert settled.status_code == 200, settled.text
-    assert settled.json()["status"] == "settled"
+    db = database.SessionLocal()
+    try:
+        wallets = db.scalars(
+            select(Wallet).where(Wallet.id.in_(wallet_ids))
+        ).all()
+        for wallet in wallets:
+            wallet_type = wallet.type.value if hasattr(wallet.type, "value") else wallet.type
+            assert wallet_type == WalletType.VENDOR.value
+            assert wallet.currency.value if hasattr(wallet.currency, "value") else wallet.currency
+            assert wallet.balance == Decimal("0")
+            assert wallet.is_group is False
+            assert wallet.parent_id is None
+    finally:
+        db.close()
 
 
-def test_summary_counts_only_pending_bills(client):
-    vendor = create_vendor(client)
-    payable = client.post(
-        f"/vendors/{vendor['id']}/bills",
-        json={"direction": "payable", "amount": "100.00"},
-    ).json()
-    client.post(
-        f"/vendors/{vendor['id']}/bills",
-        json={"direction": "receivable", "amount": "40.00"},
-    )
+def test_ensure_vendor_wallets_is_idempotent(client):
+    create_vendor(client, name="Vendor A")
+    create_vendor(client, name="Vendor B")
 
-    summary = client.get("/vendors/summary")
-    assert summary.status_code == 200, summary.text
-    assert Decimal(summary.json()["payable"]) == Decimal("100.000000")
-    assert Decimal(summary.json()["receivable"]) == Decimal("40.000000")
-    assert Decimal(summary.json()["net"]) == Decimal("-60.000000")
+    db = database.SessionLocal()
+    try:
+        wallet_count_before = len(db.scalars(select(Wallet).where(Wallet.type == WalletType.VENDOR.value)).all())
+        ensure_vendor_wallets(db)
+        ensure_vendor_wallets(db)
+        db.commit()
+        wallet_count_after = len(db.scalars(select(Wallet).where(Wallet.type == WalletType.VENDOR.value)).all())
+        assert wallet_count_before == wallet_count_after
 
-    client.patch(f"/vendors/bills/{payable['id']}/settle")
-    summary = client.get("/vendors/summary")
-    assert Decimal(summary.json()["payable"]) == Decimal("0")
-    assert Decimal(summary.json()["receivable"]) == Decimal("40.000000")
-    assert Decimal(summary.json()["net"]) == Decimal("40.000000")
+        # 每个 vendor 仍有 wallet_id
+        vendors = db.scalars(select(Vendor)).all()
+        assert all(v.wallet_id is not None for v in vendors)
+    finally:
+        db.close()


### PR DESCRIPTION
## 关联 Issue
Closes #49

## 改动说明
- 删除 VendorBill / VendorBillDirection / VendorBillStatus 模型与枚举
- 删除 /vendors/{id}/bills 全部 + /bills/{id}/settle + /vendors/summary 端点
- Vendor 表加 wallet_id 外键到 wallets
- POST /vendors 创建时自动建 RMB 钱包（type=VENDOR, name=\"{vendor.name} 账单\"）
- 新增 ensure_vendor_wallets() 启动时幂等补建
- Wallet.debit() 对 VENDOR 钱包放开非负检查（其他 type 维持）
- GET /vendors 返回 walletId + balance 字段
- 数据迁移：直接删 finance.db 重建（系统未上线）

## 自测
- [x] pytest 全部通过 36 个测试
- [x] 验收标准已逐条满足

---
> 由 ropz 实现，请 PM 审查