### PR TITLE
[PR] [FEAT] 供应商 adjust + transactions 端点

### DIFF
--- a/src/routers/vendors.py
+++ b/src/routers/vendors.py
@@ -12,7 +12,13 @@ from sqlalchemy.orm import Session
 
 from src.database import get_db
 from src.models.vendor import Vendor
-from src.models.wallet import Wallet
+from src.models.wallet import (
+    TransactionDirection,
+    Wallet,
+    WalletTransaction,
+    credit,
+    debit,
+)
 from src.services.vendors import create_vendor_wallet
 
 
@@ -65,3 +71,79 @@ def list_vendors(db: Session = Depends(get_db)) -> list[VendorOut]:
         select(Vendor, Wallet).join(Wallet, Vendor.wallet_id == Wallet.id).order_by(Vendor.id)
     ).all()
     return [serialize_vendor(vendor, wallet) for vendor, wallet in rows]
+
+
+class VendorAdjustRequest(BaseModel):
+    amount: Decimal
+    remark: Optional[str] = None
+
+
+class VendorTransactionOut(BaseModel):
+    id: int
+    walletId: int
+    amount: Decimal
+    direction: str  # "in" / "out"
+    remark: Optional[str]
+    createdAt: str
+
+
+def _get_vendor_or_404(db: Session, vendor_id: int) -> Vendor:
+    vendor = db.get(Vendor, vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="供应商不存在")
+    return vendor
+
+
+@router.post("/{vendor_id}/adjust", response_model=VendorOut)
+def adjust_vendor(
+    vendor_id: int,
+    request: VendorAdjustRequest,
+    db: Session = Depends(get_db),
+) -> VendorOut:
+    if request.amount == 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="调整金额不能为 0",
+        )
+    vendor = _get_vendor_or_404(db, vendor_id)
+
+    if request.amount > 0:
+        credit(db, vendor.wallet_id, request.amount, request.remark)
+    else:
+        debit(db, vendor.wallet_id, abs(request.amount), request.remark)
+
+    db.commit()
+    db.refresh(vendor)
+    wallet = db.get(Wallet, vendor.wallet_id)
+    return serialize_vendor(vendor, wallet)
+
+
+@router.get("/{vendor_id}/transactions", response_model=list[VendorTransactionOut])
+def list_vendor_transactions(
+    vendor_id: int,
+    db: Session = Depends(get_db),
+) -> list[VendorTransactionOut]:
+    vendor = _get_vendor_or_404(db, vendor_id)
+    txs = db.scalars(
+        select(WalletTransaction)
+        .where(WalletTransaction.wallet_id == vendor.wallet_id)
+        .order_by(WalletTransaction.created_at.desc(), WalletTransaction.id.desc())
+    ).all()
+    result: list[VendorTransactionOut] = []
+    for tx in txs:
+        direction = (
+            tx.direction.value
+            if isinstance(tx.direction, TransactionDirection)
+            else tx.direction
+        )
+        result.append(
+            VendorTransactionOut(
+                id=tx.id,
+                walletId=tx.wallet_id,
+                amount=Decimal(tx.amount),
+                direction=direction,
+                remark=tx.remark,
+                createdAt=tx.created_at.isoformat() if tx.created_at else "",
+            )
+        )
+    return result

--- a/tests/test_vendors_api.py
+++ b/tests/test_vendors_api.py
@@ -84,6 +84,81 @@ def test_each_vendor_gets_its_own_vendor_wallet(client):
         db.close()
 
 
+def test_adjust_positive_increases_balance(client):
+    vendor = create_vendor(client)
+
+    response = client.post(
+        f"/vendors/{vendor['id']}/adjust",
+        json={"amount": "1000", "remark": "+1000 群指令"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert Decimal(payload["balance"]) == Decimal("1000")
+
+
+def test_adjust_negative_decreases_balance_can_go_negative(client):
+    vendor = create_vendor(client)
+
+    response = client.post(
+        f"/vendors/{vendor['id']}/adjust",
+        json={"amount": "-500", "remark": "-500 已预付"},
+    )
+
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert Decimal(payload["balance"]) == Decimal("-500")
+
+
+def test_adjust_zero_returns_400(client):
+    vendor = create_vendor(client)
+
+    response = client.post(
+        f"/vendors/{vendor['id']}/adjust",
+        json={"amount": "0"},
+    )
+
+    assert response.status_code == 400
+    assert "0" in response.json()["detail"]
+
+
+def test_adjust_unknown_vendor_returns_404(client):
+    response = client.post(
+        "/vendors/9999/adjust",
+        json={"amount": "100"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_transactions_returned_in_reverse_chronological_order(client):
+    vendor = create_vendor(client)
+
+    client.post(f"/vendors/{vendor['id']}/adjust", json={"amount": "100", "remark": "first"})
+    client.post(f"/vendors/{vendor['id']}/adjust", json={"amount": "-30", "remark": "second"})
+    client.post(f"/vendors/{vendor['id']}/adjust", json={"amount": "50", "remark": "third"})
+
+    response = client.get(f"/vendors/{vendor['id']}/transactions")
+
+    assert response.status_code == 200, response.text
+    txs = response.json()
+    assert len(txs) == 3
+    # 倒序：third 在最前
+    assert txs[0]["remark"] == "third"
+    assert txs[0]["direction"] == "in"
+    assert Decimal(txs[0]["amount"]) == Decimal("50")
+    assert txs[1]["remark"] == "second"
+    assert txs[1]["direction"] == "out"
+    assert Decimal(txs[1]["amount"]) == Decimal("30")
+    assert txs[2]["remark"] == "first"
+    assert txs[2]["direction"] == "in"
+
+
+def test_transactions_unknown_vendor_returns_404(client):
+    response = client.get("/vendors/9999/transactions")
+    assert response.status_code == 404
+
+
 def test_ensure_vendor_wallets_is_idempotent(client):
     create_vendor(client, name="Vendor A")
     create_vendor(client, name="Vendor B")


### PR DESCRIPTION
Closes #51

## 改动
- `POST /vendors/{vendor_id}/adjust`：body `{amount, remark?}`，amount>0 调 `credit`，<0 调 `debit(abs)`，==0 返回 400「调整金额不能为 0」，vendor 不存在 404，成功返回更新后的 `VendorOut`
- `GET /vendors/{vendor_id}/transactions`：返回该 vendor wallet 的全部 `WalletTransaction`，按 `created_at` 倒序（同时按 `id` 倒序作为稳定排序），vendor 不存在 404
- 新增 Pydantic：`VendorAdjustRequest` / `VendorTransactionOut`（amount Decimal 字符串，direction 单独字段，前端自合成符号）

## 复用
- 直接调 `src/models/wallet.py` 的 `credit` / `debit`；VENDOR 钱包 debit 已支持负余额（PR #50 落地），未改 wallet.py
- 未改 vendor 模型 / 启动初始化

## 测试
新增 5 个测试 + 原有 6 个，全部 11 PASSED：
- adjust 正数 → 余额增加
- adjust 负数 → 余额减少（可负）
- adjust 0 → 400
- adjust 未知 vendor → 404
- transactions 倒序返回
- transactions 未知 vendor → 404

## Test plan
- [x] `python -m pytest tests/test_vendors_api.py -v` 全过