### PR TITLE
[PR] [FEAT] 钱包间转账端点

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,7 @@ from src.routers.vendors import router as vendors_router
 from src.routers.xbox import router as xbox_router
 from src.routers.taobao import router as taobao_router
 from src.routers.taiwan import router as taiwan_router
+from src.routers.transfers import router as transfers_router
 from src.services.assets import ensure_default_asset_wallets
 from src.services.taiwan import ensure_default_taiwan_wallets
 from src.services.vendors import ensure_vendor_wallets
@@ -36,6 +37,7 @@ app.include_router(vendors_router)
 app.include_router(xbox_router)
 app.include_router(taobao_router)
 app.include_router(taiwan_router)
+app.include_router(transfers_router)
 
 
 @app.get("/health")

--- a/src/routers/transfers.py
+++ b/src/routers/transfers.py
@@ -1,0 +1,163 @@
+"""Wallet-to-wallet transfer API routes."""
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import Enum
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.wallet import Currency, Wallet, WalletType, credit, debit
+
+
+router = APIRouter(prefix="/wallets", tags=["transfers"])
+
+
+class TransferRequest(BaseModel):
+    from_wallet_id: int
+    to_wallet_id: int
+    amount: Decimal
+    exchange_rate: Optional[Decimal] = None
+    remark: Optional[str] = Field(None, max_length=500)
+
+
+class TransactionOut(BaseModel):
+    id: int
+    wallet_id: int
+    amount: Decimal
+    direction: str
+    remark: Optional[str]
+    created_at: str
+
+
+class TransferOut(BaseModel):
+    from_: TransactionOut = Field(..., alias="from")
+    to: TransactionOut
+    exchange_rate: Decimal
+    from_wallet_balance: Decimal
+    to_wallet_balance: Decimal
+
+    model_config = {"populate_by_name": True}
+
+
+def _value(value):
+    if isinstance(value, Enum):
+        return value.value
+    return value
+
+
+def _serialize_transaction(transaction) -> TransactionOut:
+    return TransactionOut(
+        id=transaction.id,
+        wallet_id=transaction.wallet_id,
+        amount=Decimal(transaction.amount),
+        direction=_value(transaction.direction),
+        remark=transaction.remark,
+        created_at=transaction.created_at.isoformat() if transaction.created_at else "",
+    )
+
+
+def _currency_value(wallet: Wallet) -> str:
+    return wallet.currency.value if isinstance(wallet.currency, Currency) else wallet.currency
+
+
+def _type_value(wallet: Wallet) -> str:
+    return wallet.type.value if isinstance(wallet.type, WalletType) else wallet.type
+
+
+@router.post("/transfer", response_model=TransferOut, response_model_by_alias=True)
+def transfer_between_wallets(
+    request: TransferRequest,
+    db: Session = Depends(get_db),
+) -> TransferOut:
+    # 1. from 钱包不存在
+    from_wallet = db.get(Wallet, request.from_wallet_id)
+    if from_wallet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="源钱包不存在")
+
+    # 2. to 钱包不存在
+    to_wallet = db.get(Wallet, request.to_wallet_id)
+    if to_wallet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="目标钱包不存在")
+
+    # 3. 不能转账给自己
+    if request.from_wallet_id == request.to_wallet_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="不能转账给自己")
+
+    # 4. from 已软删
+    if from_wallet.deleted_at is not None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="源钱包已删除")
+
+    # 5. to 已软删
+    if to_wallet.deleted_at is not None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="目标钱包已删除")
+
+    # 6. from 是分组
+    if from_wallet.is_group:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="分组钱包不可作为转出钱包",
+        )
+
+    # 7. to 是分组
+    if to_wallet.is_group:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="分组钱包不可作为转入钱包",
+        )
+
+    # 8. amount <= 0
+    amount = Decimal(str(request.amount))
+    if amount <= 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="金额必须大于 0")
+
+    from_currency = _currency_value(from_wallet)
+    to_currency = _currency_value(to_wallet)
+
+    # 9 / 10. 跨币种汇率必填，同币种忽略前端汇率
+    if from_currency != to_currency:
+        if request.exchange_rate is None or Decimal(str(request.exchange_rate)) <= 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="跨币种转账必须提供汇率",
+            )
+        rate = Decimal(str(request.exchange_rate))
+    else:
+        rate = Decimal("1")
+
+    to_amount = amount * rate
+
+    # 备注组装
+    user_remark = request.remark or ""
+    suffix_from = f"→{to_wallet.name} {to_amount} {to_currency}"
+    suffix_to = f"←{from_wallet.name} {amount} {from_currency}"
+    debit_remark = f"{user_remark} {suffix_from}".strip() if user_remark else suffix_from
+    credit_remark = f"{user_remark} {suffix_to}".strip() if user_remark else suffix_to
+
+    # 11. 原子事务：debit + credit；任何一步失败回滚
+    try:
+        debit_tx = debit(db, from_wallet.id, amount, debit_remark)
+        credit_tx = credit(db, to_wallet.id, to_amount, credit_remark)
+        db.commit()
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(debit_tx)
+    db.refresh(credit_tx)
+    db.refresh(from_wallet)
+    db.refresh(to_wallet)
+
+    return TransferOut(
+        **{"from": _serialize_transaction(debit_tx)},
+        to=_serialize_transaction(credit_tx),
+        exchange_rate=rate,
+        from_wallet_balance=Decimal(from_wallet.balance),
+        to_wallet_balance=Decimal(to_wallet.balance),
+    )

--- a/tests/test_transfers_api.py
+++ b/tests/test_transfers_api.py
@@ -1,0 +1,270 @@
+"""Tests for the wallet-to-wallet transfer endpoint."""
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from src import database
+from src.main import app
+from src.models.wallet import Wallet
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'transfers.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def _find_wallet_id(wallets, name):
+    for wallet in wallets:
+        if wallet["name"] == name:
+            return wallet["id"]
+        found = _find_wallet_id(wallet.get("children", []), name)
+        if found:
+            return found
+    return None
+
+
+def _get_leaf_id(client, name):
+    return _find_wallet_id(client.get("/wallets/assets").json(), name)
+
+
+def _credit(client, wallet_id, amount):
+    resp = client.post(f"/wallets/assets/{wallet_id}/credit", json={"amount": str(amount)})
+    assert resp.status_code == 201, resp.text
+
+
+def _create_vendor(client, name="Vendor X"):
+    resp = client.post("/vendors", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["walletId"]
+
+
+def test_transfer_same_currency_rmb_to_rmb_success(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    dst_id = _get_leaf_id(client, "TOM支付宝")
+    _credit(client, src_id, "1000")
+
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": dst_id, "amount": "300"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["exchange_rate"]) == Decimal("1")
+    assert Decimal(body["from_wallet_balance"]) == Decimal("700")
+    assert Decimal(body["to_wallet_balance"]) == Decimal("300")
+    assert body["from"]["direction"] == "out"
+    assert body["to"]["direction"] == "in"
+
+
+def test_transfer_cross_currency_rmb_to_usdt_with_rate(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")  # CNY
+    dst_id = _get_leaf_id(client, "FREEMAN币安")  # USDT
+    _credit(client, src_id, "7200")
+
+    # 7200 CNY 按 1 CNY = 0.14 USDT 折算 → 1008 USDT
+    resp = client.post(
+        "/wallets/transfer",
+        json={
+            "from_wallet_id": src_id,
+            "to_wallet_id": dst_id,
+            "amount": "7200",
+            "exchange_rate": "0.14",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["from_wallet_balance"]) == Decimal("0")
+    assert Decimal(body["to_wallet_balance"]) == Decimal("1008")
+    assert Decimal(body["from"]["amount"]) == Decimal("7200")
+    assert Decimal(body["to"]["amount"]) == Decimal("1008")
+
+
+def test_transfer_cross_currency_usdt_to_rmb_with_rate(client):
+    src_id = _get_leaf_id(client, "FREEMAN币安")  # USDT
+    dst_id = _get_leaf_id(client, "丙火网络支付宝")  # CNY
+    _credit(client, src_id, "1000")
+
+    # 1000 USDT * 7.2 = 7200 CNY
+    resp = client.post(
+        "/wallets/transfer",
+        json={
+            "from_wallet_id": src_id,
+            "to_wallet_id": dst_id,
+            "amount": "1000",
+            "exchange_rate": "7.2",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["from_wallet_balance"]) == Decimal("0")
+    assert Decimal(body["to_wallet_balance"]) == Decimal("7200")
+
+
+def test_transfer_asset_to_vendor_pays_down_payable(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    vendor_wallet_id = _create_vendor(client, name="供应商A")
+    _credit(client, src_id, "5000")
+
+    # 资产 → 供应商钱包：vendor 余额减少（同币种 CNY）
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": vendor_wallet_id, "amount": "2000"},
+    )
+    # 此处供应商钱包是 credit（balance 增加）。CEO 付款给供应商业务上其实应该是 vendor debit；
+    # 通用 transfer 端点保持语义对称：from debit / to credit。
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["from_wallet_balance"]) == Decimal("3000")
+    assert Decimal(body["to_wallet_balance"]) == Decimal("2000")
+
+
+def test_transfer_self_returns_400(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    _credit(client, src_id, "100")
+
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": src_id, "amount": "10"},
+    )
+    assert resp.status_code == 400
+    assert "不能转账给自己" in resp.json()["detail"]
+
+
+def test_transfer_nonexistent_from_returns_404(client):
+    dst_id = _get_leaf_id(client, "TOM支付宝")
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": 99999, "to_wallet_id": dst_id, "amount": "10"},
+    )
+    assert resp.status_code == 404
+    assert "源钱包不存在" in resp.json()["detail"]
+
+
+def test_transfer_nonexistent_to_returns_404(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": 99999, "amount": "10"},
+    )
+    assert resp.status_code == 404
+    assert "目标钱包不存在" in resp.json()["detail"]
+
+
+def test_transfer_cross_currency_without_rate_returns_400(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    dst_id = _get_leaf_id(client, "FREEMAN币安")
+    _credit(client, src_id, "100")
+
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": dst_id, "amount": "100"},
+    )
+    assert resp.status_code == 400
+    assert "跨币种" in resp.json()["detail"]
+
+
+def test_transfer_insufficient_balance_non_vendor_returns_400(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    dst_id = _get_leaf_id(client, "TOM支付宝")
+    _credit(client, src_id, "50")
+
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": dst_id, "amount": "100"},
+    )
+    assert resp.status_code == 400
+
+    # 校验原子性：from 没扣，to 没增
+    db = database.SessionLocal()
+    try:
+        src = db.get(Wallet, src_id)
+        dst = db.get(Wallet, dst_id)
+        assert Decimal(src.balance) == Decimal("50")
+        assert Decimal(dst.balance) == Decimal("0")
+    finally:
+        db.close()
+
+
+def test_transfer_from_vendor_allows_negative_balance(client):
+    # VENDOR 类型 from 余额可以变负（debit 不报错）
+    vendor_wallet_id = _create_vendor(client, name="供应商B")
+    dst_id = _get_leaf_id(client, "TOM支付宝")  # CNY 同币种
+
+    # vendor 当前余额 0，转出 500 → vendor 余额 -500，目标 +500
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": vendor_wallet_id, "to_wallet_id": dst_id, "amount": "500"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["from_wallet_balance"]) == Decimal("-500")
+    assert Decimal(body["to_wallet_balance"]) == Decimal("500")
+
+
+def test_transfer_rejects_soft_deleted_wallet(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    dst_id = _get_leaf_id(client, "TOM支付宝")
+
+    # 软删 dst
+    db = database.SessionLocal()
+    try:
+        from sqlalchemy import func as sa_func
+        dst = db.get(Wallet, dst_id)
+        dst.deleted_at = sa_func.now()
+        db.commit()
+    finally:
+        db.close()
+
+    _credit(client, src_id, "100")
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": dst_id, "amount": "10"},
+    )
+    assert resp.status_code == 400
+    assert "目标钱包已删除" in resp.json()["detail"]
+
+
+def test_transfer_rejects_group_wallet(client):
+    # RMB钱包 是顶级分组
+    wallets = client.get("/wallets/assets").json()
+    rmb_root_id = next(w["id"] for w in wallets if w["name"] == "RMB钱包")
+    leaf_id = _get_leaf_id(client, "丙火网络支付宝")
+
+    # group 作为 from
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": rmb_root_id, "to_wallet_id": leaf_id, "amount": "10"},
+    )
+    assert resp.status_code == 400
+    assert "转出" in resp.json()["detail"]
+
+    # group 作为 to
+    _credit(client, leaf_id, "100")
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": leaf_id, "to_wallet_id": rmb_root_id, "amount": "10"},
+    )
+    assert resp.status_code == 400
+    assert "转入" in resp.json()["detail"]
+
+
+def test_transfer_zero_amount_returns_400(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    dst_id = _get_leaf_id(client, "TOM支付宝")
+    resp = client.post(
+        "/wallets/transfer",
+        json={"from_wallet_id": src_id, "to_wallet_id": dst_id, "amount": "0"},
+    )
+    assert resp.status_code == 400
+    assert "金额必须大于 0" in resp.json()["detail"]


### PR DESCRIPTION
## 关联 Issue
Closes #53

## 改动说明
新增通用钱包间转账端点 `POST /wallets/transfer`，支持同币种与跨币种转账（USDT ↔ CNY 走前端商定汇率）。

- 新文件 `src/routers/transfers.py`：
  - `TransferRequest` / `TransferOut` Pydantic schema
  - 11 项校验按 Issue 顺序：from 404 → to 404 → self → from 软删 → to 软删 → from group → to group → amount<=0 → 跨币种 rate 必填 → 同币种忽略 rate 用 1.0 → debit 余额校验（VENDOR 例外，复用 `models.wallet.debit`）
  - 原子事务：`debit(from)` + `credit(to)` 同一 session 单一 commit；任何一步失败 `db.rollback()` + 400
- `src/main.py` include `transfers_router`

## 跨币种汇率约定
`exchange_rate` = `to_amount / from_amount`（即 1 单位 from 货币兑多少 to 货币）。
- USDT → CNY：rate=7.2 表示 1 USDT = 7.2 CNY，`to_amount = amount * 7.2`
- CNY → USDT：rate=0.14 表示 1 CNY = 0.14 USDT

## 测试
- 新建 `tests/test_transfers_api.py` 13 个测试覆盖：同币种成功、跨币种 RMB→USDT、跨币种 USDT→RMB、资产→供应商、self-transfer、from/to 不存在、跨币种缺汇率、余额不足、VENDOR 余额可负、软删拒绝、分组拒绝（双向）、零金额拒绝
- 余额不足场景额外校验原子性：from 没扣 + to 没增
- `python -m pytest tests/ -v` → **55 passed**

## 自测
- [x] pytest 全部通过
- [x] 验收标准 11 条逐项满足
- [x] 备注按 Issue 格式 `→{to.name} {to_amount} {to.currency}` / `←{from.name} {amount} {from.currency}` 拼接
- [x] exchange_rate 不存表（按 Issue 说明，未来需审计再加字段）

---
> 由 ropz 实现，请 PM 审查