### PR TITLE
[PR] [FEAT] 供应商付款专用端点

### DIFF
--- a/src/routers/vendors.py
+++ b/src/routers/vendors.py
@@ -13,9 +13,11 @@ from sqlalchemy.orm import Session
 from src.database import get_db
 from src.models.vendor import Vendor
 from src.models.wallet import (
+    Currency,
     TransactionDirection,
     Wallet,
     WalletTransaction,
+    WalletType,
     credit,
     debit,
 )
@@ -116,6 +118,150 @@ def adjust_vendor(
     db.refresh(vendor)
     wallet = db.get(Wallet, vendor.wallet_id)
     return serialize_vendor(vendor, wallet)
+
+
+class PaymentRequest(BaseModel):
+    from_wallet_id: int
+    amount: Decimal
+    exchange_rate: Optional[Decimal] = None
+    remark: Optional[str] = Field(None, max_length=500)
+
+
+class PaymentTransactionOut(BaseModel):
+    id: int
+    wallet_id: int
+    amount: Decimal
+    direction: str
+    remark: Optional[str]
+    created_at: str
+
+
+class PaymentOut(BaseModel):
+    from_transaction: PaymentTransactionOut
+    vendor_transaction: PaymentTransactionOut
+    exchange_rate: Decimal
+    from_wallet_balance: Decimal
+    vendor_wallet_balance: Decimal
+
+
+def _currency_value(wallet: Wallet) -> str:
+    return wallet.currency.value if isinstance(wallet.currency, Currency) else wallet.currency
+
+
+def _type_value(wallet: Wallet) -> str:
+    return wallet.type.value if isinstance(wallet.type, WalletType) else wallet.type
+
+
+def _serialize_payment_tx(tx: WalletTransaction) -> PaymentTransactionOut:
+    direction = (
+        tx.direction.value
+        if isinstance(tx.direction, TransactionDirection)
+        else tx.direction
+    )
+    return PaymentTransactionOut(
+        id=tx.id,
+        wallet_id=tx.wallet_id,
+        amount=Decimal(tx.amount),
+        direction=direction,
+        remark=tx.remark,
+        created_at=tx.created_at.isoformat() if tx.created_at else "",
+    )
+
+
+_ASSET_TYPES = {WalletType.ASSET_RMB.value, WalletType.ASSET_USDT.value}
+
+
+@router.post("/{vendor_id}/payment", response_model=PaymentOut)
+def pay_vendor(
+    vendor_id: int,
+    request: PaymentRequest,
+    db: Session = Depends(get_db),
+) -> PaymentOut:
+    # 1. vendor 不存在
+    vendor = _get_vendor_or_404(db, vendor_id)
+
+    # 2. from 钱包不存在
+    from_wallet = db.get(Wallet, request.from_wallet_id)
+    if from_wallet is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="源钱包不存在")
+
+    # 3. from 必须是资产钱包
+    if _type_value(from_wallet) not in _ASSET_TYPES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="只能从资产钱包付款",
+        )
+
+    # 4. from 已软删
+    if from_wallet.deleted_at is not None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="钱包已删除")
+
+    # 5. from 是分组
+    if from_wallet.is_group:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="分组钱包不可作为付款源",
+        )
+
+    # 6. vendor wallet 兜底
+    vendor_wallet = db.get(Wallet, vendor.wallet_id)
+    if vendor_wallet is None or vendor_wallet.deleted_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="供应商钱包不可用",
+        )
+
+    # 7. amount <= 0
+    amount = Decimal(str(request.amount))
+    if amount <= 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="金额必须大于 0")
+
+    from_currency = _currency_value(from_wallet)
+    vendor_currency = _currency_value(vendor_wallet)
+
+    # 8/9. 跨币种汇率必填，同币种忽略
+    if from_currency != vendor_currency:
+        if request.exchange_rate is None or Decimal(str(request.exchange_rate)) <= 0:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="跨币种付款必须提供汇率",
+            )
+        rate = Decimal(str(request.exchange_rate))
+    else:
+        rate = Decimal("1")
+
+    vendor_amount = amount * rate
+
+    user_remark = request.remark or ""
+    suffix_from = f"付款→{vendor.name} {vendor_amount} {vendor_currency}"
+    suffix_vendor = f"←{from_wallet.name} 付款 {amount} {from_currency}"
+    from_remark = f"{user_remark} {suffix_from}".strip() if user_remark else suffix_from
+    vendor_remark = f"{user_remark} {suffix_vendor}".strip() if user_remark else suffix_vendor
+
+    # 10/11. 原子事务：双 debit
+    try:
+        from_tx = debit(db, from_wallet.id, amount, from_remark)
+        vendor_tx = debit(db, vendor_wallet.id, vendor_amount, vendor_remark)
+        db.commit()
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(from_tx)
+    db.refresh(vendor_tx)
+    db.refresh(from_wallet)
+    db.refresh(vendor_wallet)
+
+    return PaymentOut(
+        from_transaction=_serialize_payment_tx(from_tx),
+        vendor_transaction=_serialize_payment_tx(vendor_tx),
+        exchange_rate=rate,
+        from_wallet_balance=Decimal(from_wallet.balance),
+        vendor_wallet_balance=Decimal(vendor_wallet.balance),
+    )
 
 
 @router.get("/{vendor_id}/transactions", response_model=list[VendorTransactionOut])

--- a/tests/test_vendor_payments_api.py
+++ b/tests/test_vendor_payments_api.py
@@ -1,0 +1,244 @@
+"""Tests for the dedicated vendor payment endpoint (POST /vendors/{id}/payment)."""
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.models.wallet import Wallet
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'vendor_payments.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def _find_wallet_id(wallets, name):
+    for wallet in wallets:
+        if wallet["name"] == name:
+            return wallet["id"]
+        found = _find_wallet_id(wallet.get("children", []), name)
+        if found:
+            return found
+    return None
+
+
+def _get_leaf_id(client, name):
+    return _find_wallet_id(client.get("/wallets/assets").json(), name)
+
+
+def _credit(client, wallet_id, amount):
+    resp = client.post(f"/wallets/assets/{wallet_id}/credit", json={"amount": str(amount)})
+    assert resp.status_code == 201, resp.text
+
+
+def _create_vendor(client, name="供应商A"):
+    resp = client.post("/vendors", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _adjust_vendor(client, vendor_id, amount):
+    resp = client.post(f"/vendors/{vendor_id}/adjust", json={"amount": str(amount)})
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_payment_same_currency_partial_settle(client):
+    """vendor +1000，付 600 → vendor 余额 +400"""
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    _credit(client, src_id, "5000")
+    vendor = _create_vendor(client, name="供A")
+    _adjust_vendor(client, vendor["id"], "1000")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "600"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["exchange_rate"]) == Decimal("1")
+    assert Decimal(body["from_wallet_balance"]) == Decimal("4400")
+    assert Decimal(body["vendor_wallet_balance"]) == Decimal("400")
+    assert body["from_transaction"]["direction"] == "out"
+    assert body["vendor_transaction"]["direction"] == "out"
+
+
+def test_payment_same_currency_full_settle(client):
+    """vendor +1000，付 1000 → 0"""
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    _credit(client, src_id, "5000")
+    vendor = _create_vendor(client, name="供B")
+    _adjust_vendor(client, vendor["id"], "1000")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "1000"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert Decimal(resp.json()["vendor_wallet_balance"]) == Decimal("0")
+
+
+def test_payment_same_currency_overpay_becomes_prepaid(client):
+    """vendor +1000，付 1500 → -500（预付）"""
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    _credit(client, src_id, "5000")
+    vendor = _create_vendor(client, name="供C")
+    _adjust_vendor(client, vendor["id"], "1000")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "1500"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert Decimal(resp.json()["vendor_wallet_balance"]) == Decimal("-500")
+
+
+def test_payment_same_currency_zero_to_prepaid(client):
+    """vendor 0，付 500 → -500"""
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    _credit(client, src_id, "5000")
+    vendor = _create_vendor(client, name="供D")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "500"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert Decimal(resp.json()["vendor_wallet_balance"]) == Decimal("-500")
+    assert Decimal(resp.json()["from_wallet_balance"]) == Decimal("4500")
+
+
+def test_payment_cross_currency_usdt_to_cny(client):
+    """USDT 付 100，rate=7.2 → vendor 减 720 CNY"""
+    src_id = _get_leaf_id(client, "FREEMAN币安")  # USDT
+    _credit(client, src_id, "1000")
+    vendor = _create_vendor(client, name="供E")
+    _adjust_vendor(client, vendor["id"], "1000")  # vendor +1000 CNY
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "100", "exchange_rate": "7.2"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["from_wallet_balance"]) == Decimal("900")
+    assert Decimal(body["vendor_wallet_balance"]) == Decimal("280")  # 1000 - 720
+    assert Decimal(body["from_transaction"]["amount"]) == Decimal("100")
+    assert Decimal(body["vendor_transaction"]["amount"]) == Decimal("720")
+
+
+def test_payment_insufficient_asset_balance_atomic(client):
+    """from 余额不足 → 400 + DB 零变化"""
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    _credit(client, src_id, "50")
+    vendor = _create_vendor(client, name="供F")
+    _adjust_vendor(client, vendor["id"], "1000")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "100"},
+    )
+    assert resp.status_code == 400
+
+    db = database.SessionLocal()
+    try:
+        src = db.get(Wallet, src_id)
+        v_wallet = db.get(Wallet, vendor["walletId"])
+        assert Decimal(src.balance) == Decimal("50")
+        assert Decimal(v_wallet.balance) == Decimal("1000")
+    finally:
+        db.close()
+
+
+def test_payment_cross_currency_without_rate_returns_400(client):
+    src_id = _get_leaf_id(client, "FREEMAN币安")  # USDT
+    _credit(client, src_id, "1000")
+    vendor = _create_vendor(client, name="供G")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "100"},
+    )
+    assert resp.status_code == 400
+    assert "跨币种" in resp.json()["detail"]
+
+
+def test_payment_from_non_asset_wallet_returns_400(client):
+    """from 不是资产钱包（用另一个 vendor 钱包当 from）"""
+    other_vendor = _create_vendor(client, name="非资产源")
+    vendor = _create_vendor(client, name="供H")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": other_vendor["walletId"], "amount": "100"},
+    )
+    assert resp.status_code == 400
+    assert "只能从资产钱包付款" in resp.json()["detail"]
+
+
+def test_payment_from_group_wallet_returns_400(client):
+    """from 是分组（RMB钱包顶级）"""
+    wallets = client.get("/wallets/assets").json()
+    rmb_root_id = next(w["id"] for w in wallets if w["name"] == "RMB钱包")
+    vendor = _create_vendor(client, name="供I")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": rmb_root_id, "amount": "100"},
+    )
+    assert resp.status_code == 400
+    assert "分组钱包" in resp.json()["detail"]
+
+
+def test_payment_from_soft_deleted_wallet_returns_400(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    vendor = _create_vendor(client, name="供J")
+
+    db = database.SessionLocal()
+    try:
+        from sqlalchemy import func as sa_func
+        w = db.get(Wallet, src_id)
+        w.deleted_at = sa_func.now()
+        db.commit()
+    finally:
+        db.close()
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": src_id, "amount": "10"},
+    )
+    assert resp.status_code == 400
+    assert "已删除" in resp.json()["detail"]
+
+
+def test_payment_nonexistent_vendor_or_wallet_returns_404(client):
+    src_id = _get_leaf_id(client, "丙火网络支付宝")
+    _credit(client, src_id, "1000")
+
+    # vendor 不存在
+    resp = client.post(
+        "/vendors/99999/payment",
+        json={"from_wallet_id": src_id, "amount": "10"},
+    )
+    assert resp.status_code == 404
+    assert "供应商不存在" in resp.json()["detail"]
+
+    # from 钱包不存在
+    vendor = _create_vendor(client, name="供K")
+    resp = client.post(
+        f"/vendors/{vendor['id']}/payment",
+        json={"from_wallet_id": 99999, "amount": "10"},
+    )
+    assert resp.status_code == 404
+    assert "源钱包不存在" in resp.json()["detail"]


### PR DESCRIPTION
## 关联 Issue
Closes #55

## 改动说明
新增 `POST /vendors/{vendor_id}/payment` 端点，处理"用资产钱包给供应商付款"业务，与通用 `/wallets/transfer` 关键差异：**双 debit 语义**（资产钱包 debit + vendor 钱包 debit），消除欠款或转为预付。

- 在 `src/routers/vendors.py` 新增 `PaymentRequest` / `PaymentTransactionOut` / `PaymentOut` 模型 + `pay_vendor` handler
- 校验顺序严格按 Issue 10 项：vendor → from 钱包 → 类型必须 ASSET_RMB/USDT → 软删 → 分组 → vendor 钱包兜底 → amount > 0 → 跨币种汇率
- 复用现有 `_get_vendor_or_404` helper 与 `debit()`（VENDOR 类型已支持负余额，自然实现预付场景）
- 单一 `db.commit()` 原子事务，`ValueError` 回滚返 400

## 自测
- [x] `tests/test_vendor_payments_api.py` 11 个用例全过
- [x] `tests/` 全模块回归 66 个用例全过
- [x] 验收标准已逐条满足

---
> 由 ropz 实现，请 PM 审查