### PR TITLE
[PR] [FEAT] 礼品卡加载三方联动端点

### DIFF
--- a/src/routers/vendors.py
+++ b/src/routers/vendors.py
@@ -21,6 +21,12 @@ from src.models.wallet import (
     credit,
     debit,
 )
+from src.models.xbox import XboxAccount, XboxCurrency
+from src.routers.xbox import (
+    XboxAccountOut,
+    apply_recharge_to_account,
+    serialize_account as serialize_xbox_account,
+)
 from src.services.vendors import create_vendor_wallet
 
 
@@ -261,6 +267,97 @@ def pay_vendor(
         exchange_rate=rate,
         from_wallet_balance=Decimal(from_wallet.balance),
         vendor_wallet_balance=Decimal(vendor_wallet.balance),
+    )
+
+
+class GiftcardLoadRequest(BaseModel):
+    xbox_account_id: int
+    card_face_amount: Decimal
+    rmb_cost: Decimal
+    remark: Optional[str] = Field(None, max_length=500)
+
+
+class GiftcardLoadOut(BaseModel):
+    xbox_account: XboxAccountOut
+    vendor_balance: Decimal
+    xbox_transaction_id: int
+    vendor_transaction_id: int
+
+
+@router.post("/{vendor_id}/giftcard-load", response_model=GiftcardLoadOut)
+def giftcard_load(
+    vendor_id: int,
+    request: GiftcardLoadRequest,
+    db: Session = Depends(get_db),
+) -> GiftcardLoadOut:
+    # 1. vendor 不存在 → 404
+    vendor = _get_vendor_or_404(db, vendor_id)
+
+    # 2. xbox 账号不存在 → 404
+    xbox_account = db.get(XboxAccount, request.xbox_account_id)
+    if xbox_account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="XBOX 账号不存在")
+
+    # 3. card_face_amount <= 0
+    card_face = Decimal(str(request.card_face_amount))
+    if card_face <= 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="卡面额必须大于 0")
+
+    # 4. rmb_cost <= 0
+    rmb_cost = Decimal(str(request.rmb_cost))
+    if rmb_cost <= 0:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="RMB 成本必须大于 0")
+
+    # 5. vendor wallet 兜底
+    vendor_wallet = db.get(Wallet, vendor.wallet_id)
+    if vendor_wallet is None or vendor_wallet.deleted_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="供应商钱包不可用",
+        )
+
+    xbox_currency = (
+        xbox_account.currency.value
+        if isinstance(xbox_account.currency, XboxCurrency)
+        else xbox_account.currency
+    )
+    xbox_remark = f"礼品卡加载←{vendor.name}"
+    if request.remark:
+        xbox_remark = f"{request.remark} {xbox_remark}"
+    vendor_remark = (
+        f"礼品卡→XBOX {xbox_account.name} {card_face} {xbox_currency}"
+    )
+    if request.remark:
+        vendor_remark = f"{request.remark} {vendor_remark}"
+
+    # 原子事务：XBOX 账号双字段累加 + XboxTransaction + vendor wallet credit
+    try:
+        xbox_tx = apply_recharge_to_account(
+            db,
+            xbox_account,
+            rmb_amount=rmb_cost,
+            local_amount=card_face,
+            remark=xbox_remark,
+        )
+        vendor_tx = credit(db, vendor_wallet.id, rmb_cost, vendor_remark)
+        db.commit()
+    except ValueError as exc:
+        db.rollback()
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(xbox_account)
+    db.refresh(vendor_wallet)
+    db.refresh(xbox_tx)
+    db.refresh(vendor_tx)
+
+    return GiftcardLoadOut(
+        xbox_account=serialize_xbox_account(xbox_account),
+        vendor_balance=Decimal(vendor_wallet.balance),
+        xbox_transaction_id=xbox_tx.id,
+        vendor_transaction_id=vendor_tx.id,
     )
 
 

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -115,6 +115,31 @@ def get_account_or_404(session: Session, account_id: int) -> XboxAccount:
     return account
 
 
+def apply_recharge_to_account(
+    session: Session,
+    account: XboxAccount,
+    rmb_amount: Decimal,
+    local_amount: Decimal,
+    remark: Optional[str] = None,
+) -> XboxTransaction:
+    """累加 XBOX 账号 rmb_cost / local_balance 并写入一条 recharge 流水。
+
+    仅 add + flush，不 commit；调用方负责事务边界，便于嵌入更大的原子操作。
+    """
+    account.rmb_cost = Decimal(account.rmb_cost) + Decimal(rmb_amount)
+    account.local_balance = Decimal(account.local_balance) + Decimal(local_amount)
+    transaction = XboxTransaction(
+        account_id=account.id,
+        rmb_amount=Decimal(rmb_amount),
+        local_amount=Decimal(local_amount),
+        type=XboxTransactionType.RECHARGE.value,
+        remark=remark,
+    )
+    session.add(transaction)
+    session.flush()
+    return transaction
+
+
 @router.post("/accounts", response_model=XboxAccountOut, status_code=status.HTTP_201_CREATED)
 def create_account(request: XboxAccountCreate, db: Session = Depends(get_db)) -> XboxAccountOut:
     account = XboxAccount(
@@ -152,16 +177,13 @@ def recharge_account(
     db: Session = Depends(get_db),
 ) -> XboxTransactionOut:
     account = get_account_or_404(db, account_id)
-    account.rmb_cost = Decimal(account.rmb_cost) + request.rmb_amount
-    account.local_balance = Decimal(account.local_balance) + request.local_amount
-    transaction = XboxTransaction(
-        account_id=account.id,
+    transaction = apply_recharge_to_account(
+        db,
+        account,
         rmb_amount=request.rmb_amount,
         local_amount=request.local_amount,
-        type=XboxTransactionType.RECHARGE.value,
         remark=request.remark,
     )
-    db.add(transaction)
     db.commit()
     db.refresh(transaction)
     return serialize_transaction(transaction)

--- a/tests/test_giftcard_load_api.py
+++ b/tests/test_giftcard_load_api.py
@@ -1,0 +1,192 @@
+"""Tests for the gift-card load endpoint (POST /vendors/{id}/giftcard-load)."""
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'giftcard_load.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def _create_vendor(client, name="供应商X"):
+    resp = client.post("/vendors", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _create_xbox(client, name="FREEMAN", country="US"):
+    resp = client.post("/xbox/accounts", json={"name": name, "country": country})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def test_giftcard_load_success(client):
+    """加载 USD 100 / RMB 700 → XBOX 账号 local_balance + rmb_cost + vendor 余额三方变化"""
+    vendor = _create_vendor(client, name="供A")
+    xbox = _create_xbox(client, name="FREEMAN-US", country="US")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/giftcard-load",
+        json={
+            "xbox_account_id": xbox["id"],
+            "card_face_amount": "100",
+            "rmb_cost": "700",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert Decimal(body["xbox_account"]["local_balance"]) == Decimal("100")
+    assert Decimal(body["xbox_account"]["rmb_cost"]) == Decimal("700")
+    assert body["xbox_account"]["currency"] == "USD"
+    assert Decimal(body["vendor_balance"]) == Decimal("700")
+    assert body["xbox_transaction_id"] > 0
+    assert body["vendor_transaction_id"] > 0
+
+
+def test_giftcard_load_multiple_accumulate(client):
+    """同账号连续加载 2 次，rmb_cost 与 local_balance 都累加"""
+    vendor = _create_vendor(client, name="供B")
+    xbox = _create_xbox(client, name="FREEMAN-US2", country="US")
+
+    for face, rmb in [("50", "350"), ("80", "560")]:
+        resp = client.post(
+            f"/vendors/{vendor['id']}/giftcard-load",
+            json={
+                "xbox_account_id": xbox["id"],
+                "card_face_amount": face,
+                "rmb_cost": rmb,
+            },
+        )
+        assert resp.status_code == 200, resp.text
+
+    final = client.get("/xbox/accounts").json()
+    acc = next(a for a in final if a["id"] == xbox["id"])
+    assert Decimal(acc["local_balance"]) == Decimal("130")
+    assert Decimal(acc["rmb_cost"]) == Decimal("910")
+
+    txs = client.get(f"/vendors/{vendor['id']}/transactions").json()
+    assert len(txs) == 2
+    assert all(tx["direction"] == "in" for tx in txs)
+
+
+def test_giftcard_load_vendor_not_found(client):
+    xbox = _create_xbox(client, name="FREEMAN-NF")
+    resp = client.post(
+        "/vendors/99999/giftcard-load",
+        json={"xbox_account_id": xbox["id"], "card_face_amount": "10", "rmb_cost": "70"},
+    )
+    assert resp.status_code == 404
+    assert "供应商不存在" in resp.json()["detail"]
+
+
+def test_giftcard_load_xbox_not_found(client):
+    vendor = _create_vendor(client, name="供C")
+    resp = client.post(
+        f"/vendors/{vendor['id']}/giftcard-load",
+        json={"xbox_account_id": 99999, "card_face_amount": "10", "rmb_cost": "70"},
+    )
+    assert resp.status_code == 404
+    assert "XBOX 账号不存在" in resp.json()["detail"]
+
+
+def test_giftcard_load_face_amount_zero_or_negative(client):
+    vendor = _create_vendor(client, name="供D")
+    xbox = _create_xbox(client, name="FREEMAN-D")
+
+    for bad in ["0", "-5"]:
+        resp = client.post(
+            f"/vendors/{vendor['id']}/giftcard-load",
+            json={"xbox_account_id": xbox["id"], "card_face_amount": bad, "rmb_cost": "70"},
+        )
+        assert resp.status_code == 400, (bad, resp.text)
+        assert "卡面额" in resp.json()["detail"]
+
+
+def test_giftcard_load_rmb_cost_zero_or_negative(client):
+    vendor = _create_vendor(client, name="供E")
+    xbox = _create_xbox(client, name="FREEMAN-E")
+
+    for bad in ["0", "-100"]:
+        resp = client.post(
+            f"/vendors/{vendor['id']}/giftcard-load",
+            json={"xbox_account_id": xbox["id"], "card_face_amount": "10", "rmb_cost": bad},
+        )
+        assert resp.status_code == 400, (bad, resp.text)
+        assert "RMB 成本" in resp.json()["detail"]
+
+
+def test_giftcard_load_creates_vendor_credit_transaction(client):
+    """加载后查 vendor transactions 能看到该笔 credit"""
+    vendor = _create_vendor(client, name="供F")
+    xbox = _create_xbox(client, name="FREEMAN-F")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/giftcard-load",
+        json={"xbox_account_id": xbox["id"], "card_face_amount": "20", "rmb_cost": "140"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    txs = client.get(f"/vendors/{vendor['id']}/transactions").json()
+    assert len(txs) == 1
+    assert txs[0]["direction"] == "in"
+    assert Decimal(txs[0]["amount"]) == Decimal("140")
+    assert "礼品卡→XBOX" in txs[0]["remark"]
+
+
+def test_giftcard_load_creates_xbox_recharge_transaction(client):
+    """加载后查 XBOX transactions 能看到 type=recharge 的记录"""
+    vendor = _create_vendor(client, name="供G")
+    xbox = _create_xbox(client, name="FREEMAN-G")
+
+    resp = client.post(
+        f"/vendors/{vendor['id']}/giftcard-load",
+        json={"xbox_account_id": xbox["id"], "card_face_amount": "30", "rmb_cost": "210"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    txs = client.get(f"/xbox/accounts/{xbox['id']}/transactions").json()
+    assert len(txs) == 1
+    assert txs[0]["type"] == "recharge"
+    assert Decimal(txs[0]["rmb_amount"]) == Decimal("210")
+    assert Decimal(txs[0]["local_amount"]) == Decimal("30")
+    assert "礼品卡加载←供G" in txs[0]["remark"]
+
+
+def test_giftcard_load_cross_country(client):
+    """US (USD) 与 UK (GBP) 各加载一次，金额 / 货币正确"""
+    vendor = _create_vendor(client, name="供H")
+    us_xbox = _create_xbox(client, name="FREEMAN-USX", country="US")
+    uk_xbox = _create_xbox(client, name="FREEMAN-UKX", country="UK")
+
+    resp_us = client.post(
+        f"/vendors/{vendor['id']}/giftcard-load",
+        json={"xbox_account_id": us_xbox["id"], "card_face_amount": "100", "rmb_cost": "700"},
+    )
+    assert resp_us.status_code == 200, resp_us.text
+    assert resp_us.json()["xbox_account"]["currency"] == "USD"
+    assert Decimal(resp_us.json()["xbox_account"]["local_balance"]) == Decimal("100")
+
+    resp_uk = client.post(
+        f"/vendors/{vendor['id']}/giftcard-load",
+        json={"xbox_account_id": uk_xbox["id"], "card_face_amount": "50", "rmb_cost": "500"},
+    )
+    assert resp_uk.status_code == 200, resp_uk.text
+    assert resp_uk.json()["xbox_account"]["currency"] == "GBP"
+    assert Decimal(resp_uk.json()["xbox_account"]["local_balance"]) == Decimal("50")
+
+    # vendor 累计欠款 1200
+    assert Decimal(resp_uk.json()["vendor_balance"]) == Decimal("1200")


### PR DESCRIPTION
## 关联 Issue
Closes #57

## 改动说明
- `src/routers/xbox.py`：抽出 `apply_recharge_to_account(session, account, rmb_amount, local_amount, remark)` helper（add+flush，不 commit），原 `/xbox/accounts/{id}/recharge` 端点改为复用它
- `src/routers/vendors.py`：新增 `POST /vendors/{vendor_id}/giftcard-load`
  - body：`GiftcardLoadRequest{xbox_account_id, card_face_amount, rmb_cost, remark?}`
  - 5 项校验：vendor 不存在 404 / xbox 不存在 404 / card_face<=0 400 / rmb_cost<=0 400 / vendor wallet 软删兜底 400
  - 原子事务：`apply_recharge_to_account`（XBOX local_balance += / rmb_cost += / 新建 type=recharge 的 XboxTransaction）+ `credit(vendor.wallet_id, rmb_cost)`，单一 `db.commit()`，任何失败 `rollback`
  - 响应 `GiftcardLoadOut{xbox_account, vendor_balance, xbox_transaction_id, vendor_transaction_id}`
- `tests/test_giftcard_load_api.py`：9 个测试覆盖成功 / 累加 / 4 类校验失败 / vendor 流水 / xbox 流水 / 跨 country (US/UK)

## 自测
- [x] `pytest tests/test_giftcard_load_api.py -v` 9/9 全过
- [x] `pytest tests/` 全模块 75/75 全过（无回归）
- [x] 验收标准已逐条满足

---
> 由 ropz 实现，请 PM 审查