### PR TITLE
[PR] [FEAT-F9] 供应商页彻底改造

### DIFF
--- a/frontend/components/dashboard.tsx
+++ b/frontend/components/dashboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { ArrowDownLeft, ArrowLeftRight, ArrowUpRight, RefreshCcw } from "lucide-react";
+import { RefreshCcw } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,7 +9,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { getDashboardData } from "@/lib/api";
 import { formatMoney, sumMinor } from "@/lib/money";
 import { sections } from "@/lib/navigation";
-import type { Currency, DashboardData, ModuleSection, WalletBalance, WalletType } from "@/types";
+import type { Currency, ModuleSection, WalletBalance, WalletType } from "@/types";
 
 const typeLabels: Record<WalletType, string> = {
   ASSET_RMB: "RMB 资产",
@@ -80,57 +80,6 @@ function ModuleCard({ section, wallets }: { section: ModuleSection; wallets: Wal
         </div>
       </CardContent>
     </Card>
-  );
-}
-
-function VendorSummary({ data }: { data: DashboardData }) {
-  const summary = data.vendorSummary;
-  const items = [
-    {
-      label: "应收",
-      value: summary.receivableMinor,
-      icon: ArrowDownLeft,
-      tone: "success" as const
-    },
-    {
-      label: "应付",
-      value: -summary.payableMinor,
-      icon: ArrowUpRight,
-      tone: "danger" as const
-    },
-    {
-      label: "净额",
-      value: summary.netMinor,
-      icon: ArrowLeftRight,
-      tone: "transfer" as const
-    }
-  ];
-
-  return (
-    <div className="grid gap-3 md:grid-cols-3">
-      {items.map((item) => {
-        const Icon = item.icon;
-
-        return (
-          <Card key={item.label}>
-            <CardContent className="flex items-center justify-between gap-4 p-5">
-              <div>
-                <div className="text-sm text-muted-foreground">{item.label}</div>
-                <div className="mt-1 tabular-nums text-2xl font-semibold">
-                  {formatMoney(item.value, summary.currency, {
-                    accounting: item.value < 0,
-                    signed: item.value > 0
-                  })}
-                </div>
-              </div>
-              <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
-                <Icon className="h-5 w-5" aria-hidden="true" />
-              </div>
-            </CardContent>
-          </Card>
-        );
-      })}
-    </div>
   );
 }
 
@@ -218,8 +167,6 @@ export function Dashboard() {
           </CardContent>
         </Card>
       </div>
-
-      {dashboardData ? <VendorSummary data={dashboardData} /> : null}
 
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {sections

--- a/frontend/components/vendors-page.tsx
+++ b/frontend/components/vendors-page.tsx
@@ -2,102 +2,53 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  ArrowDownLeft,
-  ArrowUpRight,
+  ArrowLeftRight,
   Building2,
-  CheckCircle2,
   Plus,
-  RefreshCcw
+  RefreshCcw,
+  Wallet
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
+  adjustVendor,
   createVendor,
-  createVendorBill,
-  getVendorBills,
-  getVendorSummary,
+  getAssetWallets,
+  getVendorTransactions,
   getVendors,
-  settleVendorBill
+  payVendor
 } from "@/lib/api";
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
-import type { BillDirection, Vendor, VendorBill } from "@/types";
+import type { Vendor, VendorTransaction, WalletBalance } from "@/types";
 
-function formatDueDate(value: string | null) {
-  if (!value) return "-";
-  return value.length >= 10 ? value.slice(0, 10) : value;
+function flattenLeafAssetWallets(wallets: WalletBalance[]): WalletBalance[] {
+  const result: WalletBalance[] = [];
+  const walk = (list: WalletBalance[]) => {
+    for (const wallet of list) {
+      if (wallet.children && wallet.children.length > 0) {
+        walk(wallet.children);
+      }
+      const isAsset = wallet.type === "ASSET_RMB" || wallet.type === "ASSET_USDT";
+      if (isAsset && !wallet.isGroup && wallet.deletedAt == null) {
+        result.push(wallet);
+      }
+    }
+  };
+  walk(wallets);
+  return result;
 }
 
-function VendorSummaryCards() {
-  const { data, isFetching, refetch } = useQuery({
-    queryKey: ["vendor-summary"],
-    queryFn: getVendorSummary
-  });
-
-  const payable = data?.payableMinor ?? 0;
-  const receivable = data?.receivableMinor ?? 0;
-  const net = data?.netMinor ?? 0;
-  const currency = data?.currency ?? "CNY";
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-end">
-        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
-          <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-          刷新汇总
-        </Button>
-      </div>
-      <div className="grid gap-3 md:grid-cols-3">
-        <Card>
-          <CardContent className="flex items-center justify-between gap-4 p-5">
-            <div>
-              <div className="text-sm text-muted-foreground">应付总额</div>
-              <div className="mt-1 tabular-nums text-2xl font-semibold text-red-600">
-                {formatMoney(payable, currency)}
-              </div>
-            </div>
-            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-red-50 text-red-600">
-              <ArrowUpRight className="h-5 w-5" aria-hidden="true" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="flex items-center justify-between gap-4 p-5">
-            <div>
-              <div className="text-sm text-muted-foreground">应收总额</div>
-              <div className="mt-1 tabular-nums text-2xl font-semibold text-green-600">
-                {formatMoney(receivable, currency)}
-              </div>
-            </div>
-            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-emerald-50 text-emerald-600">
-              <ArrowDownLeft className="h-5 w-5" aria-hidden="true" />
-            </div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardContent className="flex items-center justify-between gap-4 p-5">
-            <div>
-              <div className="text-sm text-muted-foreground">净额</div>
-              <div
-                className={cn(
-                  "mt-1 tabular-nums text-2xl font-semibold",
-                  net >= 0 ? "text-green-600" : "text-red-600"
-                )}
-              >
-                {formatMoney(net, currency)}
-              </div>
-            </div>
-            <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
-              <Building2 className="h-5 w-5" aria-hidden="true" />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    </div>
-  );
+function balanceLabel(balanceMinor: number): { text: string; tone: "danger" | "success" | "neutral" } {
+  if (balanceMinor > 0) {
+    return { text: `我们欠 ${formatMoney(balanceMinor, "CNY")}`, tone: "danger" };
+  }
+  if (balanceMinor < 0) {
+    return { text: `已预付 ${formatMoney(balanceMinor, "CNY", { accounting: true })}`, tone: "success" };
+  }
+  return { text: "已结清", tone: "neutral" };
 }
 
 function CreateVendorModal({ onClose }: { onClose: () => void }) {
@@ -118,7 +69,6 @@ function CreateVendorModal({ onClose }: { onClose: () => void }) {
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["vendors"] });
-      await queryClient.invalidateQueries({ queryKey: ["vendor-summary"] });
       onClose();
     },
     onError: (err) => {
@@ -171,33 +121,43 @@ function CreateVendorModal({ onClose }: { onClose: () => void }) {
   );
 }
 
-function CreateBillModal({ vendor, onClose }: { vendor: Vendor; onClose: () => void }) {
+// 解析带符号字符串："+1000" / "-500" / "1000" / "+1.5"
+// 返回 { signed: string, valid: boolean } —— signed 是后端要的格式（保留符号），无效返回 valid=false
+function parseSignedAmount(input: string): { signed: string; valid: boolean } {
+  const trimmed = input.trim();
+  if (!trimmed) return { signed: "", valid: false };
+  const match = trimmed.match(/^([+-])?(\d+(?:\.\d+)?)$/);
+  if (!match) return { signed: "", valid: false };
+  const sign = match[1] ?? "+";
+  const num = match[2];
+  if (Number.parseFloat(num) === 0) return { signed: "", valid: false };
+  return { signed: `${sign === "-" ? "-" : ""}${num}`, valid: true };
+}
+
+function AdjustVendorModal({ vendor, onClose }: { vendor: Vendor; onClose: () => void }) {
   const queryClient = useQueryClient();
-  const [direction, setDirection] = useState<BillDirection>("payable");
   const [amount, setAmount] = useState("");
-  const [dueDate, setDueDate] = useState("");
   const [remark, setRemark] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   const mutation = useMutation({
     mutationFn: async () => {
-      if (!amount || Number(amount) <= 0) {
-        throw new Error("金额必须大于 0");
+      const parsed = parseSignedAmount(amount);
+      if (!parsed.valid) {
+        throw new Error("请输入带正负号的金额，例如 +1000 或 -500");
       }
-      return createVendorBill(vendor.id, {
-        direction,
-        amount,
-        dueDate: dueDate || undefined,
+      return adjustVendor(vendor.id, {
+        amount: parsed.signed,
         remark: remark.trim() === "" ? undefined : remark.trim()
       });
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["vendor-bills", vendor.id] });
-      await queryClient.invalidateQueries({ queryKey: ["vendor-summary"] });
+      await queryClient.invalidateQueries({ queryKey: ["vendors"] });
+      await queryClient.invalidateQueries({ queryKey: ["vendor-transactions", vendor.id] });
       onClose();
     },
     onError: (err) => {
-      setError(err instanceof Error ? err.message : "创建失败");
+      setError(err instanceof Error ? err.message : "操作失败");
     }
   });
 
@@ -205,51 +165,21 @@ function CreateBillModal({ vendor, onClose }: { vendor: Vendor; onClose: () => v
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <Card className="w-full max-w-md">
         <CardHeader>
-          <CardTitle>新增账单 · {vendor.name}</CardTitle>
+          <CardTitle>群指令录入 · {vendor.name}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
-          <div className="space-y-1">
-            <div className="text-sm text-muted-foreground">方向</div>
-            <div className="grid grid-cols-2 rounded-md border border-border p-1">
-              {(["payable", "receivable"] as BillDirection[]).map((item) => (
-                <button
-                  key={item}
-                  type="button"
-                  className={cn(
-                    "flex h-8 items-center justify-center gap-2 rounded text-sm font-medium text-muted-foreground",
-                    direction === item && "bg-muted text-foreground"
-                  )}
-                  onClick={() => setDirection(item)}
-                >
-                  {item === "payable" ? (
-                    <ArrowUpRight className="h-4 w-4 text-red-600" aria-hidden="true" />
-                  ) : (
-                    <ArrowDownLeft className="h-4 w-4 text-green-600" aria-hidden="true" />
-                  )}
-                  {item === "payable" ? "应付" : "应收"}
-                </button>
-              ))}
-            </div>
+          <div className="rounded-md bg-muted p-3 text-xs text-muted-foreground">
+            <div>+ 表示我们欠供应商更多（credit）</div>
+            <div>- 表示供应商欠我们更多 / 我们已预付（debit）</div>
           </div>
           <div className="space-y-1">
-            <div className="text-sm text-muted-foreground">金额</div>
+            <div className="text-sm text-muted-foreground">金额（带符号）</div>
             <input
               className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
               value={amount}
               onChange={(event) => setAmount(event.target.value)}
-              placeholder="金额"
-              type="number"
-              min="0"
-              step="0.01"
-            />
-          </div>
-          <div className="space-y-1">
-            <div className="text-sm text-muted-foreground">到期日（选填）</div>
-            <input
-              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
-              value={dueDate}
-              onChange={(event) => setDueDate(event.target.value)}
-              type="date"
+              placeholder="例如 +1000 或 -500"
+              autoFocus
             />
           </div>
           <div className="space-y-1">
@@ -271,7 +201,159 @@ function CreateBillModal({ vendor, onClose }: { vendor: Vendor; onClose: () => v
               取消
             </Button>
             <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
-              {mutation.isPending ? "创建中..." : "创建"}
+              {mutation.isPending ? "提交中..." : "提交"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function PayVendorModal({ vendor, onClose }: { vendor: Vendor; onClose: () => void }) {
+  const queryClient = useQueryClient();
+
+  const { data: assetWallets = [], isLoading: walletsLoading } = useQuery({
+    queryKey: ["asset-wallets"],
+    queryFn: getAssetWallets
+  });
+
+  const leafAssetWallets = useMemo(
+    () => flattenLeafAssetWallets(assetWallets),
+    [assetWallets]
+  );
+
+  const [fromWalletId, setFromWalletId] = useState<string>("");
+  const [amount, setAmount] = useState("");
+  const [exchangeRate, setExchangeRate] = useState("");
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!fromWalletId && leafAssetWallets.length > 0) {
+      setFromWalletId(leafAssetWallets[0].id);
+    }
+  }, [leafAssetWallets, fromWalletId]);
+
+  const fromWallet = leafAssetWallets.find((w) => w.id === fromWalletId);
+  const isCrossCurrency = fromWallet ? fromWallet.currency !== "CNY" : false;
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!fromWalletId) {
+        throw new Error("请选择付款钱包");
+      }
+      const numAmount = Number.parseFloat(amount);
+      if (!amount || Number.isNaN(numAmount) || numAmount <= 0) {
+        throw new Error("金额必须大于 0");
+      }
+      if (isCrossCurrency) {
+        const rate = Number.parseFloat(exchangeRate);
+        if (!exchangeRate || Number.isNaN(rate) || rate <= 0) {
+          throw new Error("跨币种付款必须填写汇率");
+        }
+      }
+      return payVendor(vendor.id, {
+        fromWalletId,
+        amount,
+        exchangeRate: isCrossCurrency ? exchangeRate : undefined,
+        remark: remark.trim() === "" ? undefined : remark.trim()
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["vendors"] });
+      await queryClient.invalidateQueries({ queryKey: ["vendor-transactions", vendor.id] });
+      await queryClient.invalidateQueries({ queryKey: ["asset-wallets"] });
+      await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "付款失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>用资产钱包付款 · {vendor.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">付款钱包</div>
+            {walletsLoading ? (
+              <div className="text-sm text-muted-foreground">加载中...</div>
+            ) : leafAssetWallets.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border p-3 text-sm text-muted-foreground">
+                暂无可用资产钱包
+              </div>
+            ) : (
+              <select
+                className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+                value={fromWalletId}
+                onChange={(event) => setFromWalletId(event.target.value)}
+              >
+                {leafAssetWallets.map((wallet) => (
+                  <option key={wallet.id} value={wallet.id}>
+                    {wallet.name} ({wallet.currency} · 余额 {formatMoney(wallet.balanceMinor, wallet.currency)})
+                  </option>
+                ))}
+              </select>
+            )}
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">
+              金额（{fromWallet?.currency ?? "CNY"}）
+            </div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="付款金额"
+              type="number"
+              min="0"
+              step="0.01"
+            />
+          </div>
+          {isCrossCurrency ? (
+            <div className="space-y-1">
+              <div className="text-sm text-muted-foreground">
+                汇率（1 {fromWallet?.currency} = ? CNY）
+              </div>
+              <input
+                className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+                value={exchangeRate}
+                onChange={(event) => setExchangeRate(event.target.value)}
+                placeholder="例如 7.2"
+                type="number"
+                min="0"
+                step="0.0001"
+              />
+            </div>
+          ) : null}
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button
+              onClick={() => mutation.mutate()}
+              disabled={mutation.isPending || leafAssetWallets.length === 0}
+            >
+              {mutation.isPending ? "付款中..." : "确认付款"}
             </Button>
           </div>
         </CardContent>
@@ -308,141 +390,148 @@ function VendorList({
             暂无供应商，点击右上角「新增供应商」开始
           </div>
         ) : (
-          vendors.map((vendor) => (
-            <button
-              key={vendor.id}
-              type="button"
-              className={cn(
-                "w-full rounded-lg border border-border bg-card px-3 py-3 text-left transition-colors hover:bg-muted/60",
-                selectedVendorId === vendor.id && "bg-muted"
-              )}
-              onClick={() => onSelect(vendor.id)}
-            >
-              <div className="flex items-center gap-2">
-                <Building2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-                <span className="font-medium">{vendor.name}</span>
-              </div>
-              {vendor.remark ? (
-                <div className="mt-1 text-xs text-muted-foreground">{vendor.remark}</div>
-              ) : null}
-            </button>
-          ))
+          vendors.map((vendor) => {
+            const label = balanceLabel(vendor.balanceMinor);
+            return (
+              <button
+                key={vendor.id}
+                type="button"
+                className={cn(
+                  "w-full rounded-lg border border-border bg-card px-3 py-3 text-left transition-colors hover:bg-muted/60",
+                  selectedVendorId === vendor.id && "bg-muted"
+                )}
+                onClick={() => onSelect(vendor.id)}
+              >
+                <div className="flex items-center gap-2">
+                  <Building2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  <span className="font-medium">{vendor.name}</span>
+                </div>
+                {vendor.remark ? (
+                  <div className="mt-1 text-xs text-muted-foreground">{vendor.remark}</div>
+                ) : null}
+                <div className="mt-2">
+                  <Badge tone={label.tone}>{label.text}</Badge>
+                </div>
+              </button>
+            );
+          })
         )}
       </CardContent>
     </Card>
   );
 }
 
-function BillTable({
+function VendorDetail({
   vendor,
-  bills,
-  onCreate
+  transactions,
+  onAdjust,
+  onPay
 }: {
   vendor: Vendor | null;
-  bills: VendorBill[];
-  onCreate: () => void;
+  transactions: VendorTransaction[];
+  onAdjust: () => void;
+  onPay: () => void;
 }) {
-  const queryClient = useQueryClient();
-  const [errorBillId, setErrorBillId] = useState<string | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  if (!vendor) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>供应商详情</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+            请先在左侧选中或新增供应商
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
 
-  const settleMutation = useMutation({
-    mutationFn: settleVendorBill,
-    onSuccess: async () => {
-      setErrorBillId(null);
-      setErrorMessage(null);
-      if (vendor) {
-        await queryClient.invalidateQueries({ queryKey: ["vendor-bills", vendor.id] });
-      }
-      await queryClient.invalidateQueries({ queryKey: ["vendor-summary"] });
-    },
-    onError: (err, billId) => {
-      setErrorBillId(billId);
-      setErrorMessage(err instanceof Error ? err.message : "操作失败");
-    }
-  });
+  const balanceColor =
+    vendor.balanceMinor > 0
+      ? "text-red-600"
+      : vendor.balanceMinor < 0
+        ? "text-green-600"
+        : "text-muted-foreground";
+  const label = balanceLabel(vendor.balanceMinor);
 
   return (
     <Card>
       <CardHeader>
-        <div className="flex items-center justify-between gap-3">
-          <CardTitle>{vendor ? `${vendor.name} 的账单` : "账单"}</CardTitle>
-          <Button size="sm" onClick={onCreate} disabled={!vendor}>
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            新增账单
-          </Button>
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle>{vendor.name}</CardTitle>
+            {vendor.remark ? (
+              <div className="mt-1 text-sm text-muted-foreground">{vendor.remark}</div>
+            ) : null}
+          </div>
         </div>
       </CardHeader>
-      <CardContent className="space-y-3">
-        {errorMessage ? (
-          <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
-            {errorMessage}
-          </div>
-        ) : null}
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>方向</TableHead>
-              <TableHead className="text-right">金额</TableHead>
-              <TableHead>到期日</TableHead>
-              <TableHead>状态</TableHead>
-              <TableHead>备注</TableHead>
-              <TableHead className="text-right">操作</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {bills.map((bill) => {
-              const isPayable = bill.direction === "payable";
-              const isPending = bill.status === "pending";
-              return (
-                <TableRow key={bill.id}>
-                  <TableCell>
-                    <Badge tone={isPayable ? "danger" : "success"}>
-                      {isPayable ? "应付" : "应收"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell
-                    className={cn(
-                      "text-right tabular-nums font-semibold",
-                      isPayable ? "text-red-600" : "text-green-600"
-                    )}
-                  >
-                    {formatMoney(bill.amountMinor, bill.currency)}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">{formatDueDate(bill.dueDate)}</TableCell>
-                  <TableCell>
-                    <Badge tone={isPending ? "neutral" : "success"}>
-                      {isPending ? "待结清" : "已结清"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">{bill.remark ?? "-"}</TableCell>
-                  <TableCell className="text-right">
-                    {isPending ? (
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => settleMutation.mutate(bill.id)}
-                        disabled={settleMutation.isPending && errorBillId !== bill.id}
-                      >
-                        <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
-                        标记结清
-                      </Button>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">已结清</span>
-                    )}
-                  </TableCell>
-                </TableRow>
-              );
+      <CardContent className="space-y-4">
+        <div className="rounded-lg border border-border bg-card p-5">
+          <div className="text-sm text-muted-foreground">当前余额</div>
+          <div className={cn("mt-2 tabular-nums text-3xl font-semibold", balanceColor)}>
+            {formatMoney(vendor.balanceMinor, "CNY", {
+              accounting: vendor.balanceMinor < 0,
+              signed: vendor.balanceMinor > 0
             })}
-            {bills.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
-                  {vendor ? "该供应商暂无账单" : "请先在左侧选中或新增供应商"}
-                </TableCell>
-              </TableRow>
-            ) : null}
-          </TableBody>
-        </Table>
+          </div>
+          <div className="mt-2">
+            <Badge tone={label.tone}>{label.text}</Badge>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={onAdjust}>
+            <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+            群指令录入 +/-
+          </Button>
+          <Button variant="outline" onClick={onPay}>
+            <Wallet className="h-4 w-4" aria-hidden="true" />
+            用资产钱包付款
+          </Button>
+        </div>
+
+        <div className="space-y-2">
+          <div className="text-sm font-medium text-muted-foreground">流水（倒序）</div>
+          {transactions.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border px-3 py-6 text-center text-sm text-muted-foreground">
+              暂无流水
+            </div>
+          ) : (
+            <div className="divide-y divide-border rounded-md border border-border">
+              {transactions.map((tx) => {
+                const isIn = tx.direction === "in";
+                return (
+                  <div key={tx.id} className="flex items-start justify-between gap-3 px-3 py-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <Badge tone={isIn ? "danger" : "success"}>
+                          {isIn ? "+" : "-"} {isIn ? "欠款增加" : "欠款减少"}
+                        </Badge>
+                        <span
+                          className={cn(
+                            "tabular-nums font-semibold",
+                            isIn ? "text-red-600" : "text-green-600"
+                          )}
+                        >
+                          {isIn ? "+" : "-"}
+                          {formatMoney(tx.amountMinor, "CNY")}
+                        </span>
+                      </div>
+                      {tx.remark ? (
+                        <div className="mt-1 truncate text-xs text-muted-foreground">{tx.remark}</div>
+                      ) : null}
+                    </div>
+                    <div className="shrink-0 text-xs text-muted-foreground">
+                      {tx.createdAt ? tx.createdAt.replace("T", " ").slice(0, 16) : "-"}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
       </CardContent>
     </Card>
   );
@@ -451,7 +540,8 @@ function BillTable({
 export function VendorsPage() {
   const [selectedVendorId, setSelectedVendorId] = useState("");
   const [showCreateVendor, setShowCreateVendor] = useState(false);
-  const [showCreateBill, setShowCreateBill] = useState(false);
+  const [showAdjust, setShowAdjust] = useState(false);
+  const [showPay, setShowPay] = useState(false);
 
   const { data: vendors = [], isFetching, refetch } = useQuery({
     queryKey: ["vendors"],
@@ -472,9 +562,10 @@ export function VendorsPage() {
 
   const selectedVendor = vendors.find((vendor) => vendor.id === selectedVendorId) ?? null;
 
-  const { data: bills = [] } = useQuery({
-    queryKey: ["vendor-bills", selectedVendor?.id ?? ""],
-    queryFn: () => (selectedVendor ? getVendorBills(selectedVendor.id) : Promise.resolve([])),
+  const { data: transactions = [] } = useQuery({
+    queryKey: ["vendor-transactions", selectedVendor?.id ?? ""],
+    queryFn: () =>
+      selectedVendor ? getVendorTransactions(selectedVendor.id) : Promise.resolve([]),
     enabled: Boolean(selectedVendor)
   });
 
@@ -482,18 +573,16 @@ export function VendorsPage() {
     <div className="space-y-5">
       <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
         <div>
-          <h2 className="text-2xl font-semibold tracking-normal">供应商账单</h2>
+          <h2 className="text-2xl font-semibold tracking-normal">供应商</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            管理供应商应付/应收账单，标记结清后自动刷新汇总。
+            每个供应商对应一个 RMB 钱包：余额 &gt; 0 表示我们欠对方，余额 &lt; 0 表示已预付。
           </p>
         </div>
         <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
           <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-          刷新供应商
+          刷新
         </Button>
       </div>
-
-      <VendorSummaryCards />
 
       <div className="grid gap-3 lg:grid-cols-[0.9fr_1.6fr]">
         <VendorList
@@ -502,18 +591,22 @@ export function VendorsPage() {
           onSelect={setSelectedVendorId}
           onCreate={() => setShowCreateVendor(true)}
         />
-        <BillTable
+        <VendorDetail
           vendor={selectedVendor}
-          bills={bills}
-          onCreate={() => setShowCreateBill(true)}
+          transactions={transactions}
+          onAdjust={() => setShowAdjust(true)}
+          onPay={() => setShowPay(true)}
         />
       </div>
 
       {showCreateVendor ? (
         <CreateVendorModal onClose={() => setShowCreateVendor(false)} />
       ) : null}
-      {showCreateBill && selectedVendor ? (
-        <CreateBillModal vendor={selectedVendor} onClose={() => setShowCreateBill(false)} />
+      {showAdjust && selectedVendor ? (
+        <AdjustVendorModal vendor={selectedVendor} onClose={() => setShowAdjust(false)} />
+      ) : null}
+      {showPay && selectedVendor ? (
+        <PayVendorModal vendor={selectedVendor} onClose={() => setShowPay(false)} />
       ) : null}
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -6,8 +6,8 @@ import {
   mockTaiwanWallets,
   mockTaobaoAccounts,
   mockTaobaoTransactions,
-  mockVendorBills,
   mockVendors,
+  mockVendorTransactions,
   mockXboxAccounts,
   mockXboxSummary,
   mockXboxTransactions
@@ -15,7 +15,6 @@ import {
 import { decimalToMinor } from "@/lib/money";
 import type {
   AssetTransaction,
-  BillDirection,
   Currency,
   DashboardData,
   TaiwanSummary,
@@ -25,8 +24,7 @@ import type {
   TaobaoTransaction,
   TaobaoWalletScope,
   Vendor,
-  VendorBill,
-  VendorSummary,
+  VendorTransaction,
   WalletBalance,
   WalletType,
   XboxAccount,
@@ -50,15 +48,6 @@ type AssetWalletResponse = {
   remark?: string | null;
   deleted_at?: string | null;
   deletedAt?: string | null;
-};
-
-type VendorSummaryResponse = {
-  payable?: string | number;
-  receivable?: string | number;
-  net?: string | number;
-  payable_cny?: string | number;
-  receivable_cny?: string | number;
-  net_cny?: string | number;
 };
 
 type AssetTransactionResponse = {
@@ -106,29 +95,11 @@ function normalizeWallet(wallet: AssetWalletResponse, parentId?: string | null):
   };
 }
 
-function normalizeVendorSummary(summary: VendorSummaryResponse): VendorSummary {
-  const payable = summary.payable ?? summary.payable_cny ?? 0;
-  const receivable = summary.receivable ?? summary.receivable_cny ?? 0;
-  const net = summary.net ?? summary.net_cny ?? 0;
-
-  return {
-    payableMinor: decimalToMinor(payable, "CNY"),
-    receivableMinor: decimalToMinor(receivable, "CNY"),
-    netMinor: decimalToMinor(net, "CNY"),
-    currency: "CNY"
-  };
-}
-
 export async function getDashboardData(): Promise<DashboardData> {
   try {
-    const [wallets, vendorSummary] = await Promise.all([
-      fetchJson<AssetWalletResponse[]>("/api/wallets/assets"),
-      fetchJson<VendorSummaryResponse>("/api/vendors/summary")
-    ]);
-
+    const wallets = await fetchJson<AssetWalletResponse[]>("/api/wallets/assets");
     return {
-      wallets: wallets.map((wallet) => normalizeWallet(wallet)),
-      vendorSummary: normalizeVendorSummary(vendorSummary)
+      wallets: wallets.map((wallet) => normalizeWallet(wallet))
     };
   } catch {
     return mockDashboardData;
@@ -251,23 +222,22 @@ type VendorResponse = {
   id: string | number;
   name: string;
   remark?: string | null;
+  walletId?: string | number;
+  wallet_id?: string | number;
+  balance?: string | number;
   created_at?: string;
   createdAt?: string;
 };
 
-type VendorBillResponse = {
+type VendorTransactionResponse = {
   id: string | number;
-  vendor_id?: string | number;
-  vendorId?: string | number;
-  direction: BillDirection;
+  walletId?: string | number;
+  wallet_id?: string | number;
   amount: string | number;
-  currency?: Currency;
-  status: "pending" | "settled";
-  due_date?: string | null;
-  dueDate?: string | null;
+  direction: "in" | "out";
   remark?: string | null;
-  created_at?: string;
   createdAt?: string;
+  created_at?: string;
 };
 
 function normalizeVendor(vendor: VendorResponse): Vendor {
@@ -275,22 +245,20 @@ function normalizeVendor(vendor: VendorResponse): Vendor {
     id: String(vendor.id),
     name: vendor.name,
     remark: vendor.remark ?? null,
+    walletId: String(vendor.walletId ?? vendor.wallet_id ?? ""),
+    balanceMinor: decimalToMinor(vendor.balance ?? 0, "CNY"),
     createdAt: vendor.created_at ?? vendor.createdAt ?? ""
   };
 }
 
-function normalizeVendorBill(bill: VendorBillResponse): VendorBill {
-  const currency: Currency = bill.currency ?? "CNY";
+function normalizeVendorTransaction(tx: VendorTransactionResponse): VendorTransaction {
   return {
-    id: String(bill.id),
-    vendorId: String(bill.vendor_id ?? bill.vendorId ?? ""),
-    direction: bill.direction,
-    amountMinor: decimalToMinor(bill.amount, currency),
-    currency,
-    status: bill.status,
-    dueDate: bill.due_date ?? bill.dueDate ?? null,
-    remark: bill.remark ?? null,
-    createdAt: bill.created_at ?? bill.createdAt ?? ""
+    id: String(tx.id),
+    walletId: String(tx.walletId ?? tx.wallet_id ?? ""),
+    amountMinor: decimalToMinor(tx.amount, "CNY"),
+    direction: tx.direction,
+    remark: tx.remark ?? null,
+    createdAt: tx.createdAt ?? tx.created_at ?? ""
   };
 }
 
@@ -304,44 +272,46 @@ export async function getVendors(): Promise<Vendor[]> {
 }
 
 export async function createVendor(payload: { name: string; remark?: string }): Promise<Vendor> {
-  try {
-    const data = (await postJson("/api/vendors", payload)) as VendorResponse;
-    return normalizeVendor(data);
-  } catch (error) {
-    throw error instanceof Error ? error : new Error("创建供应商失败");
-  }
+  const data = (await postJson("/api/vendors", payload)) as VendorResponse;
+  return normalizeVendor(data);
 }
 
-export async function getVendorBills(vendorId: string): Promise<VendorBill[]> {
+export async function getVendorTransactions(vendorId: string): Promise<VendorTransaction[]> {
   try {
-    const data = await fetchJson<VendorBillResponse[]>(`/api/vendors/${vendorId}/bills`);
-    return data.map((bill) => normalizeVendorBill({ ...bill, vendor_id: bill.vendor_id ?? vendorId }));
+    const data = await fetchJson<VendorTransactionResponse[]>(`/api/vendors/${vendorId}/transactions`);
+    return data.map(normalizeVendorTransaction);
   } catch {
-    return (mockVendorBills[vendorId] ?? []).map((bill) => ({ ...bill }));
+    return (mockVendorTransactions[vendorId] ?? []).map((tx) => ({ ...tx }));
   }
 }
 
-export async function createVendorBill(
+export async function adjustVendor(
   vendorId: string,
-  payload: { direction: BillDirection; amount: string; dueDate?: string; remark?: string }
-): Promise<VendorBill> {
+  payload: { amount: string; remark?: string }
+): Promise<Vendor> {
+  const body: Record<string, unknown> = { amount: payload.amount };
+  if (payload.remark) {
+    body.remark = payload.remark;
+  }
+  const data = (await postJson(`/api/vendors/${vendorId}/adjust`, body)) as VendorResponse;
+  return normalizeVendor(data);
+}
+
+export async function payVendor(
+  vendorId: string,
+  payload: { fromWalletId: string; amount: string; exchangeRate?: string; remark?: string }
+): Promise<unknown> {
   const body: Record<string, unknown> = {
-    direction: payload.direction,
+    from_wallet_id: Number(payload.fromWalletId),
     amount: payload.amount
   };
-  if (payload.dueDate) {
-    body.due_date = payload.dueDate;
+  if (payload.exchangeRate) {
+    body.exchange_rate = payload.exchangeRate;
   }
   if (payload.remark) {
     body.remark = payload.remark;
   }
-  const data = (await postJson(`/api/vendors/${vendorId}/bills`, body)) as VendorBillResponse;
-  return normalizeVendorBill({ ...data, vendor_id: data.vendor_id ?? vendorId });
-}
-
-export async function settleVendorBill(billId: string): Promise<VendorBill> {
-  const data = (await sendJson(`/api/vendors/bills/${billId}/settle`, "PATCH")) as VendorBillResponse;
-  return normalizeVendorBill(data);
+  return postJson(`/api/vendors/${vendorId}/payment`, body);
 }
 
 type XboxAccountResponse = {
@@ -627,15 +597,6 @@ export async function getTaobaoTransactions(accountId: string): Promise<TaobaoTr
     return data.map(normalizeTaobaoTransaction);
   } catch {
     return mockTaobaoTransactions[accountId] ?? [];
-  }
-}
-
-export async function getVendorSummary(): Promise<VendorSummary> {
-  try {
-    const data = await fetchJson<VendorSummaryResponse>("/api/vendors/summary");
-    return normalizeVendorSummary(data);
-  } catch {
-    return mockDashboardData.vendorSummary;
   }
 }
 

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -7,7 +7,7 @@ import type {
   TaobaoAccount,
   TaobaoTransaction,
   Vendor,
-  VendorBill,
+  VendorTransaction,
   WalletBalance,
   XboxAccount,
   XboxSummary,
@@ -214,13 +214,7 @@ export const mockWallets: WalletBalance[] = [
 ];
 
 export const mockDashboardData: DashboardData = {
-  wallets: mockWallets,
-  vendorSummary: {
-    payableMinor: 218_700_00,
-    receivableMinor: 295_020_00,
-    netMinor: 76_320_00,
-    currency: "CNY"
-  }
+  wallets: mockWallets
 };
 
 export const mockVendors: Vendor[] = [
@@ -228,93 +222,73 @@ export const mockVendors: Vendor[] = [
     id: "vendor-aurora",
     name: "极光物流",
     remark: "USDT 通道，月结",
+    walletId: "vendor-wallet-aurora",
+    balanceMinor: 128_500_00,
     createdAt: "2026-03-15T08:00:00.000Z"
   },
   {
     id: "vendor-blue-river",
     name: "蓝河供应链",
     remark: null,
+    walletId: "vendor-wallet-blue-river",
+    balanceMinor: 0,
     createdAt: "2026-03-22T09:30:00.000Z"
   },
   {
     id: "vendor-cosmo",
     name: "Cosmo 渠道商",
     remark: "境外结算",
+    walletId: "vendor-wallet-cosmo",
+    balanceMinor: -50_000_00,
     createdAt: "2026-04-02T03:10:00.000Z"
   }
 ];
 
-export const mockVendorBills: Record<string, VendorBill[]> = {
+export const mockVendorTransactions: Record<string, VendorTransaction[]> = {
   "vendor-aurora": [
     {
-      id: "bill-aurora-1",
-      vendorId: "vendor-aurora",
-      direction: "payable",
+      id: "vendor-aurora-tx-1",
+      walletId: "vendor-wallet-aurora",
       amountMinor: 128_500_00,
-      currency: "CNY",
-      status: "pending",
-      dueDate: "2026-05-10",
-      remark: "4 月物流费",
+      direction: "in",
+      remark: "群指令 +1285 4月物流费",
       createdAt: "2026-04-20T02:30:00.000Z"
     },
     {
-      id: "bill-aurora-2",
-      vendorId: "vendor-aurora",
-      direction: "payable",
+      id: "vendor-aurora-tx-2",
+      walletId: "vendor-wallet-aurora",
       amountMinor: 64_300_00,
-      currency: "CNY",
-      status: "settled",
-      dueDate: "2026-04-05",
-      remark: "3 月尾款",
-      createdAt: "2026-03-28T05:00:00.000Z"
+      direction: "out",
+      remark: "←丙火支付宝 付款 643 CNY",
+      createdAt: "2026-04-15T05:10:00.000Z"
     }
   ],
   "vendor-blue-river": [
     {
-      id: "bill-blue-1",
-      vendorId: "vendor-blue-river",
-      direction: "receivable",
-      amountMinor: 188_000_00,
-      currency: "CNY",
-      status: "pending",
-      dueDate: "2026-05-15",
-      remark: "渠道返点",
-      createdAt: "2026-04-18T07:00:00.000Z"
+      id: "vendor-blue-river-tx-1",
+      walletId: "vendor-wallet-blue-river",
+      amountMinor: 25_900_00,
+      direction: "in",
+      remark: "群指令 +259",
+      createdAt: "2026-04-25T03:20:00.000Z"
     },
     {
-      id: "bill-blue-2",
-      vendorId: "vendor-blue-river",
-      direction: "payable",
+      id: "vendor-blue-river-tx-2",
+      walletId: "vendor-wallet-blue-river",
       amountMinor: 25_900_00,
-      currency: "CNY",
-      status: "pending",
-      dueDate: null,
-      remark: null,
-      createdAt: "2026-04-25T03:20:00.000Z"
+      direction: "out",
+      remark: "←TOM支付宝 付款 259 CNY",
+      createdAt: "2026-04-26T07:00:00.000Z"
     }
   ],
   "vendor-cosmo": [
     {
-      id: "bill-cosmo-1",
-      vendorId: "vendor-cosmo",
-      direction: "receivable",
-      amountMinor: 107_020_00,
-      currency: "CNY",
-      status: "pending",
-      dueDate: "2026-05-20",
-      remark: "Cosmo 季度返佣",
+      id: "vendor-cosmo-tx-1",
+      walletId: "vendor-wallet-cosmo",
+      amountMinor: 50_000_00,
+      direction: "out",
+      remark: "←FREEMAN币安 付款 70 USDT (跨币种)",
       createdAt: "2026-04-15T10:00:00.000Z"
-    },
-    {
-      id: "bill-cosmo-2",
-      vendorId: "vendor-cosmo",
-      direction: "receivable",
-      amountMinor: 32_000_00,
-      currency: "CNY",
-      status: "settled",
-      dueDate: "2026-04-10",
-      remark: null,
-      createdAt: "2026-03-30T06:30:00.000Z"
     }
   ]
 };

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -15,16 +15,8 @@ export type WalletBalance = {
   deletedAt: string | null;
 };
 
-export type VendorSummary = {
-  payableMinor: number;
-  receivableMinor: number;
-  netMinor: number;
-  currency: Currency;
-};
-
 export type DashboardData = {
   wallets: WalletBalance[];
-  vendorSummary: VendorSummary;
 };
 
 export type AssetTransaction = {
@@ -38,25 +30,20 @@ export type AssetTransaction = {
   currency: Currency;
 };
 
-export type BillDirection = "payable" | "receivable";
-
-export type BillStatus = "pending" | "settled";
-
 export type Vendor = {
   id: string;
   name: string;
   remark: string | null;
+  walletId: string;
+  balanceMinor: number;
   createdAt: string;
 };
 
-export type VendorBill = {
+export type VendorTransaction = {
   id: string;
-  vendorId: string;
-  direction: BillDirection;
+  walletId: string;
   amountMinor: number;
-  currency: Currency;
-  status: BillStatus;
-  dueDate: string | null;
+  direction: "in" | "out";
   remark: string | null;
   createdAt: string;
 };


### PR DESCRIPTION
## Summary
- 适配后端 vendor 钱包化模型（PR #50/#52/#56）：删除 vendor_bills/direction/status/getVendorSummary 旧模型，每个供应商关联 RMB 钱包，balance 可正可负
- types/api/mock-data 三件套联动：新增 VendorTransaction 类型 + adjustVendor / getVendorTransactions / payVendor 三个 API
- 供应商页完全重写：左侧列表卡片显示彩色余额标签，右侧详情含大字余额 + 流水倒序 + 三个弹窗（新增 / 群指令 +/- / 资产钱包付款）
- dashboard 选项 A：删除应付/应收/净额三卡（DashboardData 移除 vendorSummary 字段）

## 关键实现
- 群指令录入：`parseSignedAmount` 正则 `^([+-])?(\d+(?:\.\d+)?)$` 解析 \`+1000\` / \`-500\` / \`1000\`，0 视为无效；amount 以带符号字符串直接发后端 Decimal
- 资产钱包付款：用 \`getAssetWallets()\` + 自写 \`flattenLeafAssetWallets\` 递归取叶子（\`type ∈ {ASSET_RMB, ASSET_USDT}\` && !isGroup && !deletedAt）；选中钱包币种 ≠ CNY 时显示汇率输入并强校验
- 余额配色：>0 红 + 「我们欠 +N」 / <0 绿 + 「已预付 -N」 / =0 灰 + 「已结清」

## Test plan
- [x] \`npm run typecheck\` 全过
- [x] curl /vendors POST 创建 → 返回 walletId+balance
- [x] curl /vendors/{id}/adjust ±/0(400) → 余额联动 + 流水倒序
- [x] curl /vendors/{id}/transactions → camelCase 字段对齐 normalize
- [ ] 浏览器手动验证三大弹窗（待 reviewer）

Closes #59