### PR TITLE
[PR] [FEAT] 淘宝 4 金流端点 + 订单/钱包流水

### DIFF
--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -1,17 +1,30 @@
 """Taobao shop API routes."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from decimal import Decimal
 from io import BytesIO
 from typing import Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.database import get_db
-from src.models.taobao import TaobaoShop
-from src.models.wallet import Wallet
+from src.models.taobao import (
+    TaobaoOrder,
+    TaobaoOrderPaymentMethod,
+    TaobaoOrderStatus,
+    TaobaoShop,
+)
+from src.models.wallet import (
+    TransactionDirection,
+    Wallet,
+    WalletTransaction,
+    credit,
+    debit,
+)
 from src.services.taobao import list_taobao_shops
 from src.services.taobao_import import (
     ImportReport,
@@ -65,6 +78,78 @@ class TaobaoImportReportOut(BaseModel):
     errors: list[str] = Field(default_factory=list)
 
 
+# ---------------------------------------------------------------------------
+# 金流端点请求 / 响应模型
+# ---------------------------------------------------------------------------
+
+
+class ReleaseReportOut(BaseModel):
+    """聚合冻结一键解冻响应。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    matured_count: int
+    matured_amount: Decimal
+    frozen_balance_after: Decimal
+    available_balance_after: Decimal
+
+
+class WithdrawRequest(BaseModel):
+    amount: Decimal = Field(..., gt=0)
+    remark: Optional[str] = Field(None, max_length=500)
+
+
+class TransferToAssetRequest(BaseModel):
+    amount: Optional[Decimal] = Field(None, gt=0)
+    remark: Optional[str] = Field(None, max_length=500)
+
+
+class FlowReportOut(BaseModel):
+    """提现 / 转资产 通用响应（金额 + 双钱包余额）。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    amount: Decimal
+    from_wallet_id: int
+    from_wallet_balance: Decimal
+    to_wallet_id: int
+    to_wallet_balance: Decimal
+    remark: str
+
+
+class TaobaoOrderOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    order_number: str
+    payment_method: str
+    amount: Decimal
+    status: str
+    bookkeeping_wallet_id: Optional[int] = None
+    bookkeeping_tx_id: Optional[int] = None
+    shipped_at: Optional[str] = None
+    received_at: Optional[str] = None
+    last_synced_at: str
+    recorded_at: str
+
+
+class WalletTransactionOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    wallet_id: int
+    amount: Decimal
+    direction: str
+    remark: Optional[str] = None
+    created_at: str
+    mature_at: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# 序列化 helper
+# ---------------------------------------------------------------------------
+
+
 def _serialize_wallet(wallet: Wallet) -> TaobaoShopWalletOut:
     return TaobaoShopWalletOut(
         id=wallet.id,
@@ -106,6 +191,71 @@ def _serialize_report(report: ImportReport) -> TaobaoImportReportOut:
     )
 
 
+def _enum_value(value) -> str:
+    if hasattr(value, "value"):
+        return value.value
+    return str(value)
+
+
+def _serialize_order(order: TaobaoOrder) -> TaobaoOrderOut:
+    return TaobaoOrderOut(
+        id=order.id,
+        order_number=order.order_number,
+        payment_method=_enum_value(order.payment_method),
+        amount=Decimal(order.amount),
+        status=_enum_value(order.status),
+        bookkeeping_wallet_id=order.bookkeeping_wallet_id,
+        bookkeeping_tx_id=order.bookkeeping_tx_id,
+        shipped_at=order.shipped_at.isoformat() if order.shipped_at else None,
+        received_at=order.received_at.isoformat() if order.received_at else None,
+        last_synced_at=order.last_synced_at.isoformat() if order.last_synced_at else "",
+        recorded_at=order.recorded_at.isoformat() if order.recorded_at else "",
+    )
+
+
+def _serialize_transaction(tx: WalletTransaction) -> WalletTransactionOut:
+    return WalletTransactionOut(
+        id=tx.id,
+        wallet_id=tx.wallet_id,
+        amount=Decimal(tx.amount),
+        direction=_enum_value(tx.direction),
+        remark=tx.remark,
+        created_at=tx.created_at.isoformat() if tx.created_at else "",
+        mature_at=tx.mature_at.isoformat() if tx.mature_at else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 通用 helper
+# ---------------------------------------------------------------------------
+
+
+def _get_shop_or_404(db: Session, shop_id: int) -> TaobaoShop:
+    shop = db.get(TaobaoShop, shop_id)
+    if shop is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="店铺不存在")
+    return shop
+
+
+def _shop_wallet_ids(shop: TaobaoShop) -> set[int]:
+    """该 shop 关联的所有钱包 id（5 内部 + 可空的 payment_wallet）。"""
+    ids = {
+        shop.unconfirmed_alipay_wallet_id,
+        shop.unconfirmed_wechat_wallet_id,
+        shop.aggregator_frozen_wallet_id,
+        shop.aggregator_available_wallet_id,
+        shop.bank_card_wallet_id,
+    }
+    if shop.payment_wallet_id is not None:
+        ids.add(shop.payment_wallet_id)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# 端点
+# ---------------------------------------------------------------------------
+
+
 @router.get("/shops", response_model=list[TaobaoShopOut], response_model_by_alias=True)
 def get_shops(db: Session = Depends(get_db)) -> list[TaobaoShopOut]:
     return [serialize_shop(shop) for shop in list_taobao_shops(db)]
@@ -129,9 +279,7 @@ def import_qianniu_excel(
     - 整个导入是单一事务：任何一行抛异常都 rollback，不会半成功
     """
     # 1. 店铺存在性校验
-    shop = db.get(TaobaoShop, shop_id)
-    if shop is None:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="店铺不存在")
+    shop = _get_shop_or_404(db, shop_id)
 
     # 2. 文件类型校验（按后缀；content-type 在不同客户端表现不一）
     filename = (file.filename or "").lower()
@@ -160,3 +308,264 @@ def import_qianniu_excel(
         raise
 
     return _serialize_report(report)
+
+
+@router.post(
+    "/shops/{shop_id}/aggregator/release",
+    response_model=ReleaseReportOut,
+    response_model_by_alias=True,
+)
+def release_matured_aggregator(
+    shop_id: int,
+    db: Session = Depends(get_db),
+) -> ReleaseReportOut:
+    """一键解冻所有到期聚合冻结流水。
+
+    - 查询 ``aggregator_frozen_wallet`` 上 ``mature_at <= now()`` 的所有 in 流水
+    - 仅解冻"仍有效"的流水（其 id 仍是某 TaobaoOrder 的 bookkeeping_tx_id）
+      —— 防御性，避免把已被 reconcile 撤销的旧流水重复解冻
+    - 把累计金额从 frozen debit、credit 到 available
+    - 单一事务；无到期流水返回 200 + matured_count=0
+    """
+    shop = _get_shop_or_404(db, shop_id)
+    now = datetime.now(timezone.utc)
+
+    matured_txs = list(
+        db.scalars(
+            select(WalletTransaction)
+            .where(
+                WalletTransaction.wallet_id == shop.aggregator_frozen_wallet_id,
+                WalletTransaction.direction == TransactionDirection.IN.value,
+                WalletTransaction.mature_at.is_not(None),
+                WalletTransaction.mature_at <= now,
+            )
+            .order_by(WalletTransaction.id)
+        )
+    )
+
+    # 防御：只解冻仍被某 order.bookkeeping_tx_id 引用的（说明状态未变化、未被撤）
+    if matured_txs:
+        tx_ids = [tx.id for tx in matured_txs]
+        active_tx_ids = set(
+            db.scalars(
+                select(TaobaoOrder.bookkeeping_tx_id)
+                .where(TaobaoOrder.bookkeeping_tx_id.in_(tx_ids))
+            )
+        )
+        matured_txs = [tx for tx in matured_txs if tx.id in active_tx_ids]
+
+    matured_count = len(matured_txs)
+    matured_amount = sum((Decimal(tx.amount) for tx in matured_txs), Decimal("0"))
+
+    if matured_count > 0:
+        try:
+            remark = f"解冻 {matured_count} 笔到期"
+            debit(db, shop.aggregator_frozen_wallet_id, matured_amount, remark=remark)
+            credit(db, shop.aggregator_available_wallet_id, matured_amount, remark=remark)
+            db.commit()
+        except ValueError as exc:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=str(exc),
+            ) from exc
+        except Exception:
+            db.rollback()
+            raise
+
+    db.refresh(shop.aggregator_frozen_wallet)
+    db.refresh(shop.aggregator_available_wallet)
+    return ReleaseReportOut(
+        matured_count=matured_count,
+        matured_amount=matured_amount,
+        frozen_balance_after=Decimal(shop.aggregator_frozen_wallet.balance),
+        available_balance_after=Decimal(shop.aggregator_available_wallet.balance),
+    )
+
+
+@router.post(
+    "/shops/{shop_id}/withdraw",
+    response_model=FlowReportOut,
+    response_model_by_alias=True,
+)
+def withdraw_to_bank_card(
+    shop_id: int,
+    request: WithdrawRequest,
+    db: Session = Depends(get_db),
+) -> FlowReportOut:
+    """可提现 → 银行卡（CEO 输金额）。"""
+    shop = _get_shop_or_404(db, shop_id)
+    amount = Decimal(str(request.amount))
+    remark = request.remark or "提现到银行卡"
+
+    available = shop.aggregator_available_wallet
+    bank_card = shop.bank_card_wallet
+
+    try:
+        debit(db, available.id, amount, remark=remark)
+        credit(db, bank_card.id, amount, remark=remark)
+        db.commit()
+    except ValueError as exc:
+        db.rollback()
+        message = str(exc)
+        if "insufficient" in message:
+            message = "可提现余额不足"
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(available)
+    db.refresh(bank_card)
+    return FlowReportOut(
+        amount=amount,
+        from_wallet_id=available.id,
+        from_wallet_balance=Decimal(available.balance),
+        to_wallet_id=bank_card.id,
+        to_wallet_balance=Decimal(bank_card.balance),
+        remark=remark,
+    )
+
+
+@router.post(
+    "/shops/{shop_id}/transfer-to-asset",
+    response_model=FlowReportOut,
+    response_model_by_alias=True,
+)
+def transfer_bank_card_to_asset(
+    shop_id: int,
+    request: TransferToAssetRequest,
+    db: Session = Depends(get_db),
+) -> FlowReportOut:
+    """银行卡 → 资产支付宝（仅丙火/小小，兔仔禁用）。
+
+    - amount 不传时默认 = 银行卡当前余额
+    - 兔仔（payment_wallet_id 为空）→ 400
+    - 银行卡余额不足或为 0 → 400
+    """
+    shop = _get_shop_or_404(db, shop_id)
+    if shop.payment_wallet_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="该店铺无关联资产支付宝",
+        )
+
+    bank_card = shop.bank_card_wallet
+    payment_wallet = shop.payment_wallet
+    assert payment_wallet is not None  # payment_wallet_id 非空时一定有
+
+    if request.amount is not None:
+        amount = Decimal(str(request.amount))
+    else:
+        amount = Decimal(bank_card.balance)
+
+    if amount <= 0:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="可转金额必须大于 0",
+        )
+
+    remark = request.remark or "提现"
+
+    try:
+        debit(db, bank_card.id, amount, remark=remark)
+        credit(db, payment_wallet.id, amount, remark=remark)
+        db.commit()
+    except ValueError as exc:
+        db.rollback()
+        message = str(exc)
+        if "insufficient" in message:
+            message = "银行卡余额不足"
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.refresh(bank_card)
+    db.refresh(payment_wallet)
+    return FlowReportOut(
+        amount=amount,
+        from_wallet_id=bank_card.id,
+        from_wallet_balance=Decimal(bank_card.balance),
+        to_wallet_id=payment_wallet.id,
+        to_wallet_balance=Decimal(payment_wallet.balance),
+        remark=remark,
+    )
+
+
+@router.get(
+    "/shops/{shop_id}/orders",
+    response_model=list[TaobaoOrderOut],
+    response_model_by_alias=True,
+)
+def list_shop_orders(
+    shop_id: int,
+    status_filter: Optional[str] = Query(None, alias="status"),
+    payment_method: Optional[str] = Query(None),
+    limit: int = Query(100, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+) -> list[TaobaoOrderOut]:
+    """订单列表 + 状态过滤 + 分页（按 last_synced_at desc）。"""
+    _get_shop_or_404(db, shop_id)
+
+    stmt = select(TaobaoOrder).where(TaobaoOrder.shop_id == shop_id)
+
+    if status_filter is not None:
+        # 校验枚举值；非法值返回 400
+        try:
+            status_enum = TaobaoOrderStatus(status_filter)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"非法 status: {status_filter}",
+            ) from exc
+        stmt = stmt.where(TaobaoOrder.status == status_enum.value)
+
+    if payment_method is not None:
+        try:
+            method_enum = TaobaoOrderPaymentMethod(payment_method)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"非法 payment_method: {payment_method}",
+            ) from exc
+        stmt = stmt.where(TaobaoOrder.payment_method == method_enum.value)
+
+    stmt = stmt.order_by(TaobaoOrder.last_synced_at.desc(), TaobaoOrder.id.desc()).limit(limit).offset(offset)
+
+    orders = list(db.scalars(stmt))
+    return [_serialize_order(order) for order in orders]
+
+
+@router.get(
+    "/shops/{shop_id}/wallets/{wallet_id}/transactions",
+    response_model=list[WalletTransactionOut],
+    response_model_by_alias=True,
+)
+def list_wallet_transactions_for_shop(
+    shop_id: int,
+    wallet_id: int,
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+) -> list[WalletTransactionOut]:
+    """单钱包流水（含 mature_at），仅允许查询该店铺关联的钱包。"""
+    shop = _get_shop_or_404(db, shop_id)
+
+    if wallet_id not in _shop_wallet_ids(shop):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="该钱包不属于本店铺",
+        )
+
+    txs = list(
+        db.scalars(
+            select(WalletTransaction)
+            .where(WalletTransaction.wallet_id == wallet_id)
+            .order_by(WalletTransaction.id.desc())
+            .limit(limit)
+            .offset(offset)
+        )
+    )
+    return [_serialize_transaction(tx) for tx in txs]

--- a/tests/test_taobao_flow_api.py
+++ b/tests/test_taobao_flow_api.py
@@ -1,0 +1,551 @@
+"""淘宝 4 个金流端点 + 订单/钱包流水查询 测试。
+
+覆盖：
+- /aggregator/release：到期累计、无到期、防御性排除已撤流水
+- /withdraw：可提现 → 银行卡 / 余额不足 / amount<=0
+- /transfer-to-asset：丙火 / 兔仔禁用 / amount 默认全额 / 银行卡空
+- /orders：列表 + status/payment_method 过滤 + 分页 + 排序
+- /wallets/{id}/transactions：mature_at 字段、wallet_id 校验
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from src import database
+from src.main import app
+from src.models.taobao import (
+    TaobaoOrder,
+    TaobaoOrderPaymentMethod,
+    TaobaoOrderStatus,
+    TaobaoShop,
+)
+from src.models.wallet import (
+    TransactionDirection,
+    Wallet,
+    WalletTransaction,
+    credit,
+    debit,
+)
+from src.services.assets import ensure_default_asset_wallets
+from src.services.taobao import ensure_default_taobao_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'taobao_flow.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        ensure_default_taobao_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def _shop_by_name(name: str) -> TaobaoShop:
+    db = database.SessionLocal()
+    try:
+        return db.scalar(select(TaobaoShop).where(TaobaoShop.name == name))
+    finally:
+        db.close()
+
+
+def _wallet_balance(wallet_id: int) -> Decimal:
+    db = database.SessionLocal()
+    try:
+        w = db.get(Wallet, wallet_id)
+        return Decimal(w.balance)
+    finally:
+        db.close()
+
+
+def _seed_aggregator_frozen_tx(
+    shop: TaobaoShop,
+    amount: Decimal,
+    mature_at: datetime,
+    *,
+    bind_to_order: bool = True,
+    order_number: str | None = None,
+) -> int:
+    """直接往 aggregator_frozen 钱包注入一笔 in 流水，并视情况绑定到 TaobaoOrder。
+
+    返回：插入的 WalletTransaction.id
+    """
+    db = database.SessionLocal()
+    try:
+        tx = credit(
+            db,
+            shop.aggregator_frozen_wallet_id,
+            amount,
+            remark="测试种子",
+            mature_at=mature_at,
+        )
+        if bind_to_order:
+            order = TaobaoOrder(
+                shop_id=shop.id,
+                order_number=order_number or f"SEED_{tx.id}",
+                payment_method=TaobaoOrderPaymentMethod.WECHAT.value,
+                amount=amount,
+                status=TaobaoOrderStatus.RECEIVED.value,
+                bookkeeping_wallet_id=shop.aggregator_frozen_wallet_id,
+                bookkeeping_tx_id=tx.id,
+            )
+            db.add(order)
+        db.commit()
+        return tx.id
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# /aggregator/release
+# ---------------------------------------------------------------------------
+
+
+def test_release_aggregates_only_matured_transactions(client):
+    """3 笔流水：2 笔已到期、1 笔未到期 → 仅解冻已到期金额。"""
+    shop = _shop_by_name("丙火电玩")
+    now = datetime.now(timezone.utc)
+
+    _seed_aggregator_frozen_tx(shop, Decimal("100"), now - timedelta(days=1), order_number="MAT_1")
+    _seed_aggregator_frozen_tx(shop, Decimal("50"), now - timedelta(hours=2), order_number="MAT_2")
+    _seed_aggregator_frozen_tx(shop, Decimal("80"), now + timedelta(days=3), order_number="FUTURE_1")
+
+    # 解冻前 frozen=230, available=0
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("230.000000")
+    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("0.000000")
+
+    response = client.post(f"/taobao/shops/{shop.id}/aggregator/release")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert payload["maturedCount"] == 2
+    assert Decimal(payload["maturedAmount"]) == Decimal("150")
+    assert Decimal(payload["frozenBalanceAfter"]) == Decimal("80.000000")
+    assert Decimal(payload["availableBalanceAfter"]) == Decimal("150.000000")
+
+    # 数据库实际余额一致
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("80.000000")
+    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("150.000000")
+
+
+def test_release_when_no_matured_returns_zero(client):
+    """无到期流水时 200 + matured_count=0，不报错、不动余额。"""
+    shop = _shop_by_name("丙火电玩")
+    now = datetime.now(timezone.utc)
+    _seed_aggregator_frozen_tx(shop, Decimal("99"), now + timedelta(days=2), order_number="FUT_ONLY")
+
+    response = client.post(f"/taobao/shops/{shop.id}/aggregator/release")
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert payload["maturedCount"] == 0
+    assert Decimal(payload["maturedAmount"]) == Decimal("0")
+    assert Decimal(payload["frozenBalanceAfter"]) == Decimal("99.000000")
+    assert Decimal(payload["availableBalanceAfter"]) == Decimal("0.000000")
+
+
+def test_release_skips_orphan_matured_tx(client):
+    """防御性：到期但已被 reconcile 撤掉（无 order 引用）的流水不应再被解冻。"""
+    shop = _shop_by_name("丙火电玩")
+    now = datetime.now(timezone.utc)
+
+    # 流水 A：到期，绑订单
+    _seed_aggregator_frozen_tx(shop, Decimal("200"), now - timedelta(days=1), order_number="ALIVE_A")
+    # 流水 B：到期，但故意不绑订单（模拟已被撤）
+    _seed_aggregator_frozen_tx(shop, Decimal("70"), now - timedelta(days=1), bind_to_order=False)
+
+    response = client.post(f"/taobao/shops/{shop.id}/aggregator/release")
+    assert response.status_code == 200
+    payload = response.json()
+
+    # 仅 A 被解冻
+    assert payload["maturedCount"] == 1
+    assert Decimal(payload["maturedAmount"]) == Decimal("200")
+
+
+def test_release_404_when_shop_not_found(client):
+    response = client.post("/taobao/shops/99999/aggregator/release")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /withdraw
+# ---------------------------------------------------------------------------
+
+
+def test_withdraw_moves_available_to_bank_card(client):
+    shop = _shop_by_name("丙火电玩")
+    # 先种 200 到 available
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.aggregator_available_wallet_id, Decimal("200"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/withdraw",
+        json={"amount": "120", "remark": "5月提现"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert Decimal(payload["amount"]) == Decimal("120")
+    assert Decimal(payload["fromWalletBalance"]) == Decimal("80.000000")
+    assert Decimal(payload["toWalletBalance"]) == Decimal("120.000000")
+    assert payload["remark"] == "5月提现"
+
+    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("80.000000")
+    assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("120.000000")
+
+
+def test_withdraw_400_when_insufficient_balance(client):
+    shop = _shop_by_name("丙火电玩")
+    response = client.post(
+        f"/taobao/shops/{shop.id}/withdraw",
+        json={"amount": "100"},
+    )
+    assert response.status_code == 400
+    assert "余额不足" in response.json()["detail"]
+
+
+def test_withdraw_default_remark(client):
+    shop = _shop_by_name("丙火电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.aggregator_available_wallet_id, Decimal("50"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/withdraw",
+        json={"amount": "30"},
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["remark"] == "提现到银行卡"
+
+
+def test_withdraw_404_when_shop_not_found(client):
+    response = client.post("/taobao/shops/99999/withdraw", json={"amount": "1"})
+    assert response.status_code == 404
+
+
+def test_withdraw_400_when_amount_not_positive(client):
+    """Pydantic gt=0 → 422，但 0 / 负数都被拦在前面。"""
+    shop = _shop_by_name("丙火电玩")
+    response = client.post(
+        f"/taobao/shops/{shop.id}/withdraw",
+        json={"amount": "0"},
+    )
+    assert response.status_code in (400, 422)
+
+
+# ---------------------------------------------------------------------------
+# /transfer-to-asset
+# ---------------------------------------------------------------------------
+
+
+def test_transfer_to_asset_a_shop_explicit_amount(client):
+    """丙火电玩：bank_card → 丙火网络支付宝，指定 amount。"""
+    shop = _shop_by_name("丙火电玩")
+    assert shop.payment_wallet_id is not None
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("500"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        json={"amount": "300"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert Decimal(payload["amount"]) == Decimal("300")
+    assert Decimal(payload["fromWalletBalance"]) == Decimal("200.000000")
+    assert Decimal(payload["toWalletBalance"]) == Decimal("300.000000")
+    assert payload["remark"] == "提现"
+
+    assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("200.000000")
+    assert _wallet_balance(shop.payment_wallet_id) == Decimal("300.000000")
+
+
+def test_transfer_to_asset_b_shop_400(client):
+    """兔仔电玩无 payment_wallet → 400。"""
+    shop = _shop_by_name("兔仔电玩")
+    assert shop.payment_wallet_id is None
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        json={"amount": "10"},
+    )
+    assert response.status_code == 400
+    assert "支付宝" in response.json()["detail"]
+
+
+def test_transfer_to_asset_default_amount_is_full_bank_balance(client):
+    """amount 不传 → 默认转走银行卡全余额。"""
+    shop = _shop_by_name("小小电玩")
+    assert shop.payment_wallet_id is not None
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("777"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        json={},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert Decimal(payload["amount"]) == Decimal("777")
+    assert Decimal(payload["fromWalletBalance"]) == Decimal("0.000000")
+    assert Decimal(payload["toWalletBalance"]) == Decimal("777.000000")
+
+
+def test_transfer_to_asset_400_when_bank_card_empty(client):
+    """银行卡余额为 0 时 amount 默认 0 → 400。"""
+    shop = _shop_by_name("丙火电玩")
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        json={},
+    )
+    assert response.status_code == 400
+
+
+def test_transfer_to_asset_custom_remark(client):
+    shop = _shop_by_name("丙火电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("100"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        json={"amount": "50", "remark": "5月转资产"},
+    )
+    assert response.status_code == 200
+    assert response.json()["remark"] == "5月转资产"
+
+
+# ---------------------------------------------------------------------------
+# /orders
+# ---------------------------------------------------------------------------
+
+
+def _seed_orders(shop: TaobaoShop) -> None:
+    """灌入 4 个不同状态/支付方式组合的订单。"""
+    db = database.SessionLocal()
+    try:
+        now = datetime.now(timezone.utc)
+        rows = [
+            ("ORD_AS_1", TaobaoOrderPaymentMethod.ALIPAY, TaobaoOrderStatus.SHIPPED_UNCONFIRMED, now - timedelta(hours=4)),
+            ("ORD_AR_1", TaobaoOrderPaymentMethod.ALIPAY, TaobaoOrderStatus.RECEIVED, now - timedelta(hours=3)),
+            ("ORD_WS_1", TaobaoOrderPaymentMethod.WECHAT, TaobaoOrderStatus.SHIPPED_UNCONFIRMED, now - timedelta(hours=2)),
+            ("ORD_C_1", TaobaoOrderPaymentMethod.ALIPAY, TaobaoOrderStatus.CLOSED, now - timedelta(hours=1)),
+        ]
+        for order_number, method, st, synced in rows:
+            order = TaobaoOrder(
+                shop_id=shop.id,
+                order_number=order_number,
+                payment_method=method.value,
+                amount=Decimal("10"),
+                status=st.value,
+                last_synced_at=synced,
+            )
+            db.add(order)
+        db.commit()
+    finally:
+        db.close()
+
+
+def test_list_orders_returns_all_for_shop_sorted_desc(client):
+    shop = _shop_by_name("丙火电玩")
+    _seed_orders(shop)
+
+    response = client.get(f"/taobao/shops/{shop.id}/orders")
+    assert response.status_code == 200, response.text
+    orders = response.json()
+
+    assert len(orders) == 4
+    # 排序：last_synced_at desc → CLOSED 最新 → 第一
+    assert orders[0]["orderNumber"] == "ORD_C_1"
+    assert orders[-1]["orderNumber"] == "ORD_AS_1"
+
+
+def test_list_orders_filter_by_status(client):
+    shop = _shop_by_name("丙火电玩")
+    _seed_orders(shop)
+
+    response = client.get(
+        f"/taobao/shops/{shop.id}/orders",
+        params={"status": "received"},
+    )
+    assert response.status_code == 200
+    orders = response.json()
+    assert len(orders) == 1
+    assert orders[0]["orderNumber"] == "ORD_AR_1"
+    assert orders[0]["status"] == "received"
+
+
+def test_list_orders_filter_by_payment_method(client):
+    shop = _shop_by_name("丙火电玩")
+    _seed_orders(shop)
+
+    response = client.get(
+        f"/taobao/shops/{shop.id}/orders",
+        params={"payment_method": "wechat"},
+    )
+    assert response.status_code == 200
+    orders = response.json()
+    assert len(orders) == 1
+    assert orders[0]["orderNumber"] == "ORD_WS_1"
+
+
+def test_list_orders_pagination(client):
+    shop = _shop_by_name("丙火电玩")
+    _seed_orders(shop)
+
+    response = client.get(
+        f"/taobao/shops/{shop.id}/orders",
+        params={"limit": 2, "offset": 1},
+    )
+    assert response.status_code == 200
+    orders = response.json()
+    assert len(orders) == 2
+
+
+def test_list_orders_400_on_invalid_status(client):
+    shop = _shop_by_name("丙火电玩")
+    response = client.get(
+        f"/taobao/shops/{shop.id}/orders",
+        params={"status": "BOGUS"},
+    )
+    assert response.status_code == 400
+
+
+def test_list_orders_404_when_shop_not_found(client):
+    response = client.get("/taobao/shops/99999/orders")
+    assert response.status_code == 404
+
+
+def test_list_orders_isolated_by_shop(client):
+    """丙火店的订单不会出现在小小店的列表里。"""
+    binghuo = _shop_by_name("丙火电玩")
+    xiaoxiao = _shop_by_name("小小电玩")
+    _seed_orders(binghuo)
+
+    response = client.get(f"/taobao/shops/{xiaoxiao.id}/orders")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
+# /wallets/{wallet_id}/transactions
+# ---------------------------------------------------------------------------
+
+
+def test_wallet_transactions_returns_mature_at(client):
+    shop = _shop_by_name("丙火电玩")
+    now = datetime.now(timezone.utc)
+    _seed_aggregator_frozen_tx(shop, Decimal("100"), now + timedelta(days=5), order_number="MAT_TX_1")
+
+    response = client.get(
+        f"/taobao/shops/{shop.id}/wallets/{shop.aggregator_frozen_wallet_id}/transactions"
+    )
+    assert response.status_code == 200, response.text
+    txs = response.json()
+    assert len(txs) == 1
+    tx = txs[0]
+    assert tx["walletId"] == shop.aggregator_frozen_wallet_id
+    assert Decimal(tx["amount"]) == Decimal("100")
+    assert tx["direction"] == "in"
+    assert tx["matureAt"] is not None
+
+
+def test_wallet_transactions_404_when_wallet_not_in_shop(client):
+    """随便挑一个非该店铺的 wallet_id → 404。"""
+    shop = _shop_by_name("丙火电玩")
+    other = _shop_by_name("小小电玩")
+    other_wallet_id = other.bank_card_wallet_id
+    assert other_wallet_id not in {
+        shop.unconfirmed_alipay_wallet_id,
+        shop.unconfirmed_wechat_wallet_id,
+        shop.aggregator_frozen_wallet_id,
+        shop.aggregator_available_wallet_id,
+        shop.bank_card_wallet_id,
+        shop.payment_wallet_id,
+    }
+    response = client.get(
+        f"/taobao/shops/{shop.id}/wallets/{other_wallet_id}/transactions"
+    )
+    assert response.status_code == 404
+
+
+def test_wallet_transactions_payment_wallet_allowed(client):
+    """payment_wallet（资产支付宝）也应被允许查询。"""
+    shop = _shop_by_name("丙火电玩")
+    # 先 credit 到 payment_wallet
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.payment_wallet_id, Decimal("88"), remark="测试支付宝入账")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.get(
+        f"/taobao/shops/{shop.id}/wallets/{shop.payment_wallet_id}/transactions"
+    )
+    assert response.status_code == 200
+    txs = response.json()
+    assert len(txs) == 1
+    assert Decimal(txs[0]["amount"]) == Decimal("88")
+    assert txs[0]["matureAt"] is None
+
+
+def test_wallet_transactions_404_when_shop_not_found(client):
+    shop = _shop_by_name("丙火电玩")
+    response = client.get(
+        f"/taobao/shops/99999/wallets/{shop.aggregator_frozen_wallet_id}/transactions"
+    )
+    assert response.status_code == 404
+
+
+def test_wallet_transactions_pagination_and_desc(client):
+    """流水按 id desc 倒序 + 分页。"""
+    shop = _shop_by_name("丙火电玩")
+    db = database.SessionLocal()
+    try:
+        for i in range(5):
+            credit(db, shop.bank_card_wallet_id, Decimal("10"), remark=f"种子 {i}")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.get(
+        f"/taobao/shops/{shop.id}/wallets/{shop.bank_card_wallet_id}/transactions",
+        params={"limit": 2, "offset": 0},
+    )
+    assert response.status_code == 200
+    txs = response.json()
+    assert len(txs) == 2
+    # id desc：第一条是最新（最大 id）
+    assert txs[0]["id"] > txs[1]["id"]


### PR DESCRIPTION
## 关联 Issue
Closes #68

## 改动说明

### 新增 5 个端点（src/routers/taobao.py）

1. `POST /taobao/shops/{id}/aggregator/release`
   - 一键解冻所有到期聚合冻结流水
   - 查询条件：`wallet_id == aggregator_frozen_wallet_id` AND `direction == in` AND `mature_at <= now()`
   - 防御性过滤：仅解冻仍被某 `TaobaoOrder.bookkeeping_tx_id` 引用的流水（避免重复解冻已被 reconcile 撤的旧流水）
   - 累加金额一次性 `debit(frozen) → credit(available)`，单一事务
   - 无到期流水时 200 + `maturedCount=0`，不报错
   - 响应 `ReleaseReport`：`maturedCount / maturedAmount / frozenBalanceAfter / availableBalanceAfter`

2. `POST /taobao/shops/{id}/withdraw`
   - 可提现 → 银行卡，body `{ amount, remark? }`
   - 余额不足 400 `"可提现余额不足"`
   - 默认备注 `"提现到银行卡"`，可覆盖

3. `POST /taobao/shops/{id}/transfer-to-asset`
   - 银行卡 → 资产支付宝（仅丙火/小小，兔仔禁用）
   - 兔仔（`payment_wallet_id is None`）→ 400 `"该店铺无关联资产支付宝"`
   - `amount` 字段 `Optional`：不传时默认 = 银行卡当前余额（CEO 一键全转）
   - 银行卡空（默认 amount=0）→ 400
   - 默认备注 `"提现"`（与 CEO 银行端实际备注一致），可覆盖

4. `GET /taobao/shops/{id}/orders`
   - 订单列表，支持 `status` / `payment_method` 过滤、`limit` / `offset` 分页
   - 排序 `last_synced_at DESC, id DESC`
   - 非法枚举值 → 400
   - 响应字段含 `bookkeepingWalletId / bookkeepingTxId / shippedAt / receivedAt / lastSyncedAt / recordedAt`

5. `GET /taobao/shops/{id}/wallets/{wallet_id}/transactions`
   - 单钱包流水（含 `matureAt` 字段）
   - `wallet_id` 必须在该 shop 的 5 个内部钱包 + 可空的 `payment_wallet_id` 集合内，否则 404
   - 倒序分页

### 测试（tests/test_taobao_flow_api.py 新建）
- 解冻：到期累加 / 无到期 / 防御性排除已撤流水 / 404
- 提现：移动金额 / 余额不足 / 默认备注 / 404 / amount<=0
- 转资产：丙火指定 amount / 兔仔禁用 / 默认全额 / 银行卡空 / 自定义备注
- 订单：列表+排序 / status 过滤 / payment_method 过滤 / 分页 / 非法 status / 404 / 跨店铺隔离
- 钱包流水：mature_at 字段 / wallet 不属于本店 404 / payment_wallet 允许 / shop 404 / 分页倒序
- 共 26 个测试，全过

## 自测
- [x] `python -m pytest tests/test_taobao_flow_api.py -v` 26/26 通过
- [x] `python -m pytest tests/` 全模块回归 111/111 通过（85 旧 + 26 新）
- [x] 验收标准 9 个测试场景全覆盖
- [x] 所有金额字段保持 `Decimal` 精度，无 Float
- [x] camelCase 别名风格与 PR #67 保持一致

## 关键技术决定
- **解冻流水"未被冲销"判断**：用 `select(TaobaoOrder.bookkeeping_tx_id).where(in_(matured_tx_ids))` 收集仍活跃的 tx_id，过滤 matured_txs。即使 reconcile 时把同金额从 frozen 钱包 debit 出去，那笔老 in 流水的 mature_at 仍存在；本端点通过 order 引用关系跳过这种情况，避免双倍解冻。
- **transfer-to-asset 默认 amount**：`amount=Optional[Decimal]` + `gt=0` 校验只在传值时生效；不传时取 `bank_card.balance`，余额为 0 时算出来 amount=0，统一在端点内拦截 400。
- **wallet_id 校验**：直接用 `_shop_wallet_ids(shop)` 集合比对，不查 DB，O(1)。

## 遗留点
- 解冻端点目前对所有 5 个钱包做了 `db.refresh(shop.aggregator_frozen_wallet/available_wallet)`，未来如果需要 N+1 优化可考虑用 `select(Wallet)` 一次性取 2 个 balance。
- `scripts/` 目录有上一波员工留下的未追踪文件（inspect_qianniu.py / qianniu_sample.json），与本 PR 无关，已跳过。

---
> 由 ropz 实现，请 PM 审查
