### PR TITLE
[PR] [FEAT-F11] 淘宝页彻底重写

### DIFF
--- a/frontend/components/taobao-page.tsx
+++ b/frontend/components/taobao-page.tsx
@@ -2,201 +2,213 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
-  ArrowDownLeft,
-  ArrowUpRight,
+  ArrowRightLeft,
+  Banknote,
+  CheckCircle2,
+  FileSpreadsheet,
+  Info,
   ListOrdered,
-  Plus,
+  Loader2,
   RefreshCcw,
-  ShoppingBag,
-  Wallet
+  Snowflake,
+  Wallet,
+  X
 } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
-  createTaobaoAccount,
-  creditTaobaoSettled,
-  creditTaobaoUnsettled,
-  debitTaobaoSettled,
-  getTaobaoAccounts,
-  getTaobaoTransactions
+  getTaobaoShops,
+  getTaobaoWalletTransactions,
+  importTaobaoExcel,
+  releaseAggregator,
+  transferTaobaoToAsset,
+  withdrawTaobao
 } from "@/lib/api";
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
-import type { TaobaoAccount } from "@/types";
+import type {
+  TaobaoImportReport,
+  TaobaoReleaseReport,
+  TaobaoShop,
+  TaobaoShopWallet
+} from "@/types";
 
-type MutationKind = "unsettled-credit" | "settled-credit" | "settled-debit";
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
-const MUTATION_META: Record<MutationKind, { title: string; submit: string; success: string }> = {
-  "unsettled-credit": { title: "未结算入账", submit: "确认入账", success: "入账成功" },
-  "settled-credit": { title: "已结算入账", submit: "确认入账", success: "入账成功" },
-  "settled-debit": { title: "已结算出账", submit: "确认出账", success: "出账成功" }
-};
-
-function formatDateTime(value: string) {
+function formatDateTime(value: string | null | undefined): string {
   if (!value) return "-";
   return value.length >= 16 ? value.slice(0, 16).replace("T", " ") : value;
 }
 
-function SummaryCards({ accounts }: { accounts: TaobaoAccount[] }) {
-  const unsettledTotal = accounts.reduce((sum, acc) => sum + acc.unsettledBalanceMinor, 0);
-  const settledTotal = accounts.reduce((sum, acc) => sum + acc.settledBalanceMinor, 0);
-  const accountCount = accounts.length;
+type WalletRowKind =
+  | "unconfirmed-alipay"
+  | "unconfirmed-wechat"
+  | "aggregator-frozen"
+  | "aggregator-available"
+  | "bank-card";
 
-  return (
-    <div className="grid gap-3 md:grid-cols-3">
-      <Card className="border border-muted-foreground/30">
-        <CardContent className="flex items-center justify-between gap-4 p-5">
-          <div>
-            <div className="text-sm text-muted-foreground">未结算总额</div>
-            <div className="mt-1 tabular-nums text-2xl font-semibold text-muted-foreground">
-              {formatMoney(unsettledTotal, "CNY")}
-            </div>
-          </div>
-          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted text-muted-foreground">
-            <Wallet className="h-5 w-5" aria-hidden="true" />
-          </div>
-        </CardContent>
-      </Card>
-      <Card className="border border-emerald-500/40">
-        <CardContent className="flex items-center justify-between gap-4 p-5">
-          <div>
-            <div className="text-sm text-muted-foreground">已结算总额</div>
-            <div className="mt-1 tabular-nums text-2xl font-semibold text-emerald-600">
-              {formatMoney(settledTotal, "CNY")}
-            </div>
-          </div>
-          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-emerald-50 text-emerald-600">
-            <ArrowDownLeft className="h-5 w-5" aria-hidden="true" />
-          </div>
-        </CardContent>
-      </Card>
-      <Card className="border">
-        <CardContent className="flex items-center justify-between gap-4 p-5">
-          <div>
-            <div className="text-sm text-muted-foreground">账号总数</div>
-            <div className="mt-1 tabular-nums text-2xl font-semibold">{accountCount}</div>
-          </div>
-          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
-            <ShoppingBag className="h-5 w-5" aria-hidden="true" />
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
+type WalletRowDef = {
+  kind: WalletRowKind;
+  label: string;
+  wallet: TaobaoShopWallet;
+  icon: React.ReactNode;
+  tone: "neutral" | "frozen" | "available" | "bank";
+};
+
+function getWalletRows(shop: TaobaoShop): WalletRowDef[] {
+  return [
+    {
+      kind: "unconfirmed-alipay",
+      label: "支付宝在途",
+      wallet: shop.unconfirmedAlipay,
+      icon: <Wallet className="h-4 w-4 text-muted-foreground" aria-hidden="true" />,
+      tone: "neutral"
+    },
+    {
+      kind: "unconfirmed-wechat",
+      label: "微信在途",
+      wallet: shop.unconfirmedWechat,
+      icon: <Wallet className="h-4 w-4 text-muted-foreground" aria-hidden="true" />,
+      tone: "neutral"
+    },
+    {
+      kind: "aggregator-frozen",
+      label: "聚合支付·冻结中",
+      wallet: shop.aggregatorFrozen,
+      icon: <Snowflake className="h-4 w-4 text-blue-600" aria-hidden="true" />,
+      tone: "frozen"
+    },
+    {
+      kind: "aggregator-available",
+      label: "聚合支付·可提现",
+      wallet: shop.aggregatorAvailable,
+      icon: <CheckCircle2 className="h-4 w-4 text-emerald-600" aria-hidden="true" />,
+      tone: "available"
+    },
+    {
+      kind: "bank-card",
+      label: "银行卡",
+      wallet: shop.bankCard,
+      icon: <Banknote className="h-4 w-4 text-amber-600" aria-hidden="true" />,
+      tone: "bank"
+    }
+  ];
 }
 
-function CreateAccountModal({ onClose }: { onClose: () => void }) {
-  const queryClient = useQueryClient();
-  const [name, setName] = useState("");
-  const [remark, setRemark] = useState("");
-  const [error, setError] = useState<string | null>(null);
+// ---------------------------------------------------------------------------
+// 流水抽屉
+// ---------------------------------------------------------------------------
 
-  const mutation = useMutation({
-    mutationFn: async () => {
-      if (!name.trim()) {
-        throw new Error("账号名不能为空");
-      }
-      return createTaobaoAccount({
-        name: name.trim(),
-        remark: remark.trim() === "" ? undefined : remark.trim()
-      });
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["taobao-accounts"] });
-      onClose();
-    },
-    onError: (err) => {
-      setError(err instanceof Error ? err.message : "创建失败");
-    }
+function TransactionsModal({
+  shop,
+  wallet,
+  walletLabel,
+  onClose
+}: {
+  shop: TaobaoShop;
+  wallet: TaobaoShopWallet;
+  walletLabel: string;
+  onClose: () => void;
+}) {
+  const { data: transactions = [], isFetching } = useQuery({
+    queryKey: ["taobao-wallet-transactions", shop.id, wallet.id],
+    queryFn: () => getTaobaoWalletTransactions(shop.id, wallet.id)
   });
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <Card className="w-full max-w-md">
+      <Card className="flex max-h-[80vh] w-full max-w-3xl flex-col">
         <CardHeader>
-          <CardTitle>新建淘宝账号</CardTitle>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle>
+              {shop.name} · {walletLabel} · 流水
+            </CardTitle>
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              <X className="h-4 w-4" aria-hidden="true" />
+              关闭
+            </Button>
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            当前余额 <span className="tabular-nums">{formatMoney(wallet.balanceMinor, "CNY")}</span>
+          </div>
         </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="space-y-1">
-            <div className="text-sm text-muted-foreground">账号名</div>
-            <input
-              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder="账号名"
-              autoFocus
-            />
-          </div>
-          <div className="space-y-1">
-            <div className="text-sm text-muted-foreground">备注（选填）</div>
-            <textarea
-              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
-              value={remark}
-              onChange={(event) => setRemark(event.target.value)}
-              placeholder="备注"
-            />
-          </div>
-          {error ? (
-            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
-              {error}
+        <CardContent className="flex-1 overflow-y-auto">
+          {transactions.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+              {isFetching ? "加载中..." : "暂无流水"}
             </div>
-          ) : null}
-          <div className="flex justify-end gap-2 pt-2">
-            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
-              取消
-            </Button>
-            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
-              {mutation.isPending ? "创建中..." : "创建"}
-            </Button>
-          </div>
+          ) : (
+            <div className="divide-y divide-border rounded-md border border-border">
+              {transactions.map((tx) => {
+                const isIn = tx.direction === "in";
+                return (
+                  <div key={tx.id} className="flex items-start justify-between gap-3 px-3 py-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <Badge tone={isIn ? "success" : "danger"}>{isIn ? "入账" : "出账"}</Badge>
+                        <span
+                          className={cn(
+                            "tabular-nums font-semibold",
+                            isIn ? "text-green-600" : "text-red-600"
+                          )}
+                        >
+                          {isIn ? "+" : "-"}
+                          {formatMoney(tx.amountMinor, "CNY")}
+                        </span>
+                        {tx.matureAt ? (
+                          <Badge tone="transfer">到期 {formatDateTime(tx.matureAt)}</Badge>
+                        ) : null}
+                      </div>
+                      {tx.remark ? (
+                        <div className="mt-1 truncate text-xs text-muted-foreground">{tx.remark}</div>
+                      ) : null}
+                    </div>
+                    <div className="shrink-0 text-xs text-muted-foreground">
+                      {formatDateTime(tx.createdAt)}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>
   );
 }
 
-function MovementModal({
-  account,
-  kind,
-  onClose
-}: {
-  account: TaobaoAccount;
-  kind: MutationKind;
-  onClose: () => void;
-}) {
+// ---------------------------------------------------------------------------
+// 提现弹窗（可提现 → 银行卡）
+// ---------------------------------------------------------------------------
+
+function WithdrawModal({ shop, onClose }: { shop: TaobaoShop; onClose: () => void }) {
   const queryClient = useQueryClient();
   const [amount, setAmount] = useState("");
   const [remark, setRemark] = useState("");
   const [error, setError] = useState<string | null>(null);
-  const meta = MUTATION_META[kind];
 
   const mutation = useMutation({
     mutationFn: async () => {
-      if (!amount || Number(amount) <= 0) {
+      const numAmount = Number.parseFloat(amount);
+      if (!amount || Number.isNaN(numAmount) || numAmount <= 0) {
         throw new Error("金额必须大于 0");
       }
-      const payload = {
+      return withdrawTaobao(shop.id, {
         amount,
         remark: remark.trim() === "" ? undefined : remark.trim()
-      };
-      if (kind === "unsettled-credit") {
-        return creditTaobaoUnsettled(account.id, payload);
-      }
-      if (kind === "settled-credit") {
-        return creditTaobaoSettled(account.id, payload);
-      }
-      return debitTaobaoSettled(account.id, payload);
+      });
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["taobao-accounts"] });
-      await queryClient.invalidateQueries({ queryKey: ["taobao-transactions", account.id] });
+      await queryClient.invalidateQueries({ queryKey: ["taobao-shops"] });
+      await queryClient.invalidateQueries({ queryKey: ["taobao-wallet-transactions", shop.id] });
       onClose();
     },
     onError: (err) => {
-      setError(err instanceof Error ? err.message : `${meta.title}失败`);
+      setError(err instanceof Error ? err.message : "提现失败");
     }
   });
 
@@ -204,18 +216,22 @@ function MovementModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
       <Card className="w-full max-w-md">
         <CardHeader>
-          <CardTitle>
-            {meta.title} · {account.name}
-          </CardTitle>
+          <CardTitle>提现到银行卡 · {shop.name}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
+          <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
+            <div className="text-xs text-muted-foreground">可提现余额</div>
+            <div className="mt-1 tabular-nums text-base font-semibold text-emerald-600">
+              {formatMoney(shop.aggregatorAvailable.balanceMinor, "CNY")}
+            </div>
+          </div>
           <div className="space-y-1">
             <div className="text-sm text-muted-foreground">金额（CNY）</div>
             <input
               className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
               value={amount}
               onChange={(event) => setAmount(event.target.value)}
-              placeholder="金额"
+              placeholder="提现金额"
               type="number"
               min="0"
               step="0.01"
@@ -225,10 +241,10 @@ function MovementModal({
           <div className="space-y-1">
             <div className="text-sm text-muted-foreground">备注（选填）</div>
             <textarea
-              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              className="min-h-[60px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
               value={remark}
               onChange={(event) => setRemark(event.target.value)}
-              placeholder="备注"
+              placeholder="备注，默认为「提现到银行卡」"
             />
           </div>
           {error ? (
@@ -241,7 +257,7 @@ function MovementModal({
               取消
             </Button>
             <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
-              {mutation.isPending ? "提交中..." : meta.submit}
+              {mutation.isPending ? "提交中..." : "确认提现"}
             </Button>
           </div>
         </CardContent>
@@ -250,195 +266,545 @@ function MovementModal({
   );
 }
 
-function TransactionsModal({ account, onClose }: { account: TaobaoAccount; onClose: () => void }) {
-  const { data: transactions = [], isFetching } = useQuery({
-    queryKey: ["taobao-transactions", account.id],
-    queryFn: () => getTaobaoTransactions(account.id)
+// ---------------------------------------------------------------------------
+// 转资产支付宝（仅丙火/小小）
+// ---------------------------------------------------------------------------
+
+function TransferToAssetModal({ shop, onClose }: { shop: TaobaoShop; onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [amount, setAmount] = useState("");
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      let amountValue: string | undefined;
+      if (amount.trim() !== "") {
+        const num = Number.parseFloat(amount);
+        if (Number.isNaN(num) || num <= 0) {
+          throw new Error("金额必须大于 0");
+        }
+        amountValue = amount;
+      }
+      return transferTaobaoToAsset(shop.id, {
+        amount: amountValue,
+        remark: remark.trim() === "" ? undefined : remark.trim()
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["taobao-shops"] });
+      await queryClient.invalidateQueries({ queryKey: ["taobao-wallet-transactions", shop.id] });
+      await queryClient.invalidateQueries({ queryKey: ["asset-wallets"] });
+      await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "转账失败");
+    }
   });
 
-  const sorted = [...transactions].sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  const targetName = shop.paymentWallet?.name ?? "资产支付宝";
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <Card className="w-full max-w-3xl">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>
+            转账到 {targetName} · {shop.name}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
+            <div className="text-xs text-muted-foreground">银行卡余额</div>
+            <div className="mt-1 tabular-nums text-base font-semibold text-amber-600">
+              {formatMoney(shop.bankCard.balanceMinor, "CNY")}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">金额（CNY，留空 = 全部余额）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="留空 = 全部银行卡余额"
+              type="number"
+              min="0"
+              step="0.01"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[60px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注，默认为「提现」"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "提交中..." : "确认转账"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 导入 Excel
+// ---------------------------------------------------------------------------
+
+function ImportExcelModal({ shop, onClose }: { shop: TaobaoShop; onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<TaobaoImportReport | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!file) {
+        throw new Error("请选择 .xlsx 文件");
+      }
+      if (!file.name.toLowerCase().endsWith(".xlsx")) {
+        throw new Error("仅支持 .xlsx 文件");
+      }
+      return importTaobaoExcel(shop.id, file);
+    },
+    onSuccess: async (result) => {
+      setReport(result);
+      setError(null);
+      await queryClient.invalidateQueries({ queryKey: ["taobao-shops"] });
+      await queryClient.invalidateQueries({ queryKey: ["taobao-wallet-transactions", shop.id] });
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "导入失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="flex max-h-[85vh] w-full max-w-lg flex-col">
         <CardHeader>
           <div className="flex items-center justify-between gap-3">
-            <CardTitle>{account.name} · 流水</CardTitle>
+            <CardTitle>导入今日千牛 Excel · {shop.name}</CardTitle>
             <Button variant="ghost" size="sm" onClick={onClose}>
+              <X className="h-4 w-4" aria-hidden="true" />
               关闭
             </Button>
           </div>
         </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>钱包</TableHead>
-                <TableHead>方向</TableHead>
-                <TableHead className="text-right">金额</TableHead>
-                <TableHead>备注</TableHead>
-                <TableHead>时间</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {sorted.map((tx) => {
-                const isIn = tx.direction === "in";
-                const isSettled = tx.walletScope === "settled";
-                return (
-                  <TableRow key={tx.id}>
-                    <TableCell>
-                      <Badge tone={isSettled ? "success" : "neutral"}>
-                        {isSettled ? "已结算" : "未结算"}
-                      </Badge>
-                    </TableCell>
-                    <TableCell>
-                      <Badge tone={isIn ? "success" : "danger"}>{isIn ? "入账" : "出账"}</Badge>
-                    </TableCell>
-                    <TableCell
-                      className={cn(
-                        "text-right tabular-nums font-semibold",
-                        isIn ? "text-green-600" : "text-red-600"
-                      )}
-                    >
-                      {formatMoney(tx.amountMinor, "CNY")}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">{tx.remark ?? "-"}</TableCell>
-                    <TableCell className="text-muted-foreground">{formatDateTime(tx.createdAt)}</TableCell>
-                  </TableRow>
-                );
-              })}
-              {sorted.length === 0 ? (
-                <TableRow>
-                  <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
-                    {isFetching ? "加载中..." : "暂无流水"}
-                  </TableCell>
-                </TableRow>
+        <CardContent className="flex-1 space-y-3 overflow-y-auto">
+          {report ? (
+            <div className="space-y-2">
+              <div className="rounded-md border border-emerald-500/40 bg-emerald-50/60 p-3 text-sm text-emerald-700">
+                导入完成 · {report.shopName}
+              </div>
+              <div className="divide-y divide-border rounded-md border border-border text-sm">
+                <ReportRow label="总解析行数" value={report.totalRowsParsed} />
+                <ReportRow label="新建订单" value={report.createdOrders} highlight={report.createdOrders > 0} />
+                <ReportRow
+                  label="状态变化订单"
+                  value={report.statusChangedOrders}
+                  highlight={report.statusChangedOrders > 0}
+                />
+                <ReportRow label="撤销关闭" value={report.closedReverted} />
+                <ReportRow label="跳过（无变化）" value={report.skippedNoChange} />
+                <ReportRow label="跳过（未付款/未发货）" value={report.skippedUnpaidOrUnshipped} />
+                <ReportRow label="跳过（未知支付方式）" value={report.skippedUnknownPayment} />
+              </div>
+              {report.errors.length > 0 ? (
+                <div className="space-y-1 rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm">
+                  <div className="font-medium text-red-700">错误 {report.errors.length} 条</div>
+                  <ul className="list-inside list-disc space-y-1 text-xs text-red-700">
+                    {report.errors.map((msg, idx) => (
+                      <li key={idx}>{msg}</li>
+                    ))}
+                  </ul>
+                </div>
               ) : null}
-            </TableBody>
-          </Table>
+            </div>
+          ) : (
+            <>
+              <div className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
+                上传千牛后台导出的 .xlsx 文件，按规则入账每条订单并对老订单做 reconcile。
+              </div>
+              <div className="space-y-1">
+                <div className="text-sm text-muted-foreground">选择 Excel 文件</div>
+                <input
+                  type="file"
+                  accept=".xlsx"
+                  onChange={(event) => {
+                    const f = event.target.files?.[0] ?? null;
+                    setFile(f);
+                    setError(null);
+                  }}
+                  className="block w-full text-sm file:mr-3 file:rounded-md file:border-0 file:bg-primary file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-primary-foreground hover:file:bg-primary/90"
+                />
+                {file ? (
+                  <div className="text-xs text-muted-foreground">
+                    已选：{file.name}（{Math.round(file.size / 1024)} KB）
+                  </div>
+                ) : null}
+              </div>
+              {error ? (
+                <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+                  {error}
+                </div>
+              ) : null}
+            </>
+          )}
         </CardContent>
+        <div className="flex justify-end gap-2 border-t border-border px-6 py-3">
+          {report ? (
+            <Button onClick={onClose}>完成</Button>
+          ) : (
+            <>
+              <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+                取消
+              </Button>
+              <Button
+                onClick={() => mutation.mutate()}
+                disabled={mutation.isPending || !file}
+              >
+                {mutation.isPending ? "导入中..." : "开始导入"}
+              </Button>
+            </>
+          )}
+        </div>
       </Card>
     </div>
   );
 }
 
-function AccountCard({
-  account,
-  onMovement,
-  onTransactions
+function ReportRow({
+  label,
+  value,
+  highlight
 }: {
-  account: TaobaoAccount;
-  onMovement: (account: TaobaoAccount, kind: MutationKind) => void;
-  onTransactions: (account: TaobaoAccount) => void;
+  label: string;
+  value: number;
+  highlight?: boolean;
 }) {
+  return (
+    <div className="flex items-center justify-between px-3 py-2">
+      <span className="text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          "tabular-nums font-semibold",
+          highlight ? "text-emerald-600" : "text-foreground"
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 钱包行
+// ---------------------------------------------------------------------------
+
+function WalletRow({
+  shop,
+  row,
+  onShowTransactions,
+  onWithdraw,
+  onTransferToAsset,
+  releasing,
+  releaseReport,
+  onRelease
+}: {
+  shop: TaobaoShop;
+  row: WalletRowDef;
+  onShowTransactions: (wallet: TaobaoShopWallet, label: string) => void;
+  onWithdraw: () => void;
+  onTransferToAsset: () => void;
+  releasing: boolean;
+  releaseReport: TaobaoReleaseReport | null;
+  onRelease: () => void;
+}) {
+  const isBankCard = row.kind === "bank-card";
+  const isFrozen = row.kind === "aggregator-frozen";
+  const isAvailable = row.kind === "aggregator-available";
+  const showTransferToAsset = isBankCard && shop.paymentWallet !== null;
+  const showRabbitNote = isBankCard && shop.paymentWallet === null;
+
+  const balanceColor =
+    row.tone === "available"
+      ? "text-emerald-600"
+      : row.tone === "frozen"
+        ? "text-blue-600"
+        : row.tone === "bank"
+          ? "text-amber-700"
+          : "text-foreground";
+
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex items-center gap-2">
+        {row.icon}
+        <div>
+          <div className="text-sm font-medium">{row.label}</div>
+          {showRabbitNote ? (
+            <div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+              <Info className="h-3 w-3" aria-hidden="true" />
+              账面记账，钱不在我手
+            </div>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-3 sm:justify-end">
+        <div className={cn("tabular-nums text-base font-semibold", balanceColor)}>
+          {formatMoney(row.wallet.balanceMinor, "CNY")}
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5">
+          {isFrozen ? (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={onRelease}
+              disabled={releasing}
+              className={cn(
+                releaseReport && releaseReport.maturedCount > 0
+                  ? "border-emerald-500/50 bg-emerald-50/60 text-emerald-700"
+                  : ""
+              )}
+              title="一键解冻所有到期"
+            >
+              {releasing ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              ) : (
+                <Snowflake className="h-3.5 w-3.5" aria-hidden="true" />
+              )}
+              一键解冻到期
+            </Button>
+          ) : null}
+          {isAvailable ? (
+            <Button variant="outline" size="sm" onClick={onWithdraw}>
+              <ArrowRightLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              提现
+            </Button>
+          ) : null}
+          {showTransferToAsset ? (
+            <Button variant="outline" size="sm" onClick={onTransferToAsset}>
+              <ArrowRightLeft className="h-3.5 w-3.5" aria-hidden="true" />
+              转资产支付宝
+            </Button>
+          ) : null}
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onShowTransactions(row.wallet, row.label)}
+          >
+            <ListOrdered className="h-3.5 w-3.5" aria-hidden="true" />
+            流水
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 店铺卡片
+// ---------------------------------------------------------------------------
+
+function ShopCard({
+  shop,
+  onShowTransactions,
+  onWithdraw,
+  onTransferToAsset,
+  onImport
+}: {
+  shop: TaobaoShop;
+  onShowTransactions: (wallet: TaobaoShopWallet, label: string) => void;
+  onWithdraw: () => void;
+  onTransferToAsset: () => void;
+  onImport: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [releaseReport, setReleaseReport] = useState<TaobaoReleaseReport | null>(null);
+  const [releaseError, setReleaseError] = useState<string | null>(null);
+
+  const releaseMutation = useMutation({
+    mutationFn: () => releaseAggregator(shop.id),
+    onSuccess: async (report) => {
+      setReleaseReport(report);
+      setReleaseError(null);
+      await queryClient.invalidateQueries({ queryKey: ["taobao-shops"] });
+      await queryClient.invalidateQueries({ queryKey: ["taobao-wallet-transactions", shop.id] });
+    },
+    onError: (err) => {
+      setReleaseError(err instanceof Error ? err.message : "解冻失败");
+      setReleaseReport(null);
+    }
+  });
+
+  const rows = getWalletRows(shop);
+  const paymentLabel =
+    shop.paymentWallet === null
+      ? "无（钱止于银行卡）"
+      : `${shop.paymentWallet.name}（余额 ${formatMoney(shop.paymentWallet.balanceMinor, "CNY")}）`;
+
   return (
     <Card className="border">
       <CardHeader>
-        <CardTitle className="text-base">{account.name}</CardTitle>
-        {account.remark ? (
-          <div className="text-sm text-muted-foreground">{account.remark}</div>
-        ) : null}
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <CardTitle className="text-lg">{shop.name}</CardTitle>
+            <div className="mt-1 text-xs text-muted-foreground">
+              关联资产支付宝：{paymentLabel}
+            </div>
+            {shop.remark ? (
+              <div className="mt-1 text-xs text-muted-foreground">{shop.remark}</div>
+            ) : null}
+          </div>
+          <Button variant="outline" size="sm" onClick={onImport}>
+            <FileSpreadsheet className="h-4 w-4" aria-hidden="true" />
+            导入今日千牛 Excel
+          </Button>
+        </div>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <div className="grid grid-cols-2 gap-2">
-          <div className="rounded-md border border-muted-foreground/20 bg-muted/40 p-3">
-            <div className="text-xs text-muted-foreground">未结算</div>
-            <div className="mt-1 tabular-nums text-lg font-semibold text-muted-foreground">
-              {formatMoney(account.unsettledBalanceMinor, "CNY")}
+      <CardContent className="space-y-3">
+        <div className="divide-y divide-border rounded-md border border-border">
+          {rows.map((row) => (
+            <WalletRow
+              key={row.kind}
+              shop={shop}
+              row={row}
+              onShowTransactions={onShowTransactions}
+              onWithdraw={onWithdraw}
+              onTransferToAsset={onTransferToAsset}
+              releasing={releaseMutation.isPending}
+              releaseReport={releaseReport}
+              onRelease={() => releaseMutation.mutate()}
+            />
+          ))}
+        </div>
+        {releaseError ? (
+          <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+            解冻失败：{releaseError}
+          </div>
+        ) : null}
+        {releaseReport ? (
+          <div className="rounded-md border border-emerald-500/40 bg-emerald-50/60 p-3 text-sm">
+            <div className="flex items-center gap-2 font-medium text-emerald-700">
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+              {releaseReport.maturedCount > 0
+                ? `已解冻 ${releaseReport.maturedCount} 笔到期`
+                : "暂无到期可解冻"}
+            </div>
+            <div className="mt-1 grid grid-cols-2 gap-2 text-xs text-emerald-700/90">
+              <div>
+                累计解冻
+                <span className="ml-1 tabular-nums font-semibold">
+                  {formatMoney(releaseReport.maturedAmountMinor, "CNY")}
+                </span>
+              </div>
+              <div>
+                冻结余额
+                <span className="ml-1 tabular-nums font-semibold">
+                  {formatMoney(releaseReport.frozenBalanceAfterMinor, "CNY")}
+                </span>
+              </div>
+              <div className="col-span-2">
+                可提现余额
+                <span className="ml-1 tabular-nums font-semibold">
+                  {formatMoney(releaseReport.availableBalanceAfterMinor, "CNY")}
+                </span>
+              </div>
             </div>
           </div>
-          <div className="rounded-md border border-emerald-500/40 bg-emerald-50/50 p-3">
-            <div className="text-xs text-emerald-700">已结算</div>
-            <div className="mt-1 tabular-nums text-lg font-semibold text-emerald-600">
-              {formatMoney(account.settledBalanceMinor, "CNY")}
-            </div>
-          </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button size="sm" variant="outline" onClick={() => onMovement(account, "unsettled-credit")}>
-            <ArrowDownLeft className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-            未结算入账
-          </Button>
-          <Button size="sm" variant="outline" onClick={() => onMovement(account, "settled-credit")}>
-            <ArrowDownLeft className="h-4 w-4 text-green-600" aria-hidden="true" />
-            已结算入账
-          </Button>
-          <Button size="sm" variant="outline" onClick={() => onMovement(account, "settled-debit")}>
-            <ArrowUpRight className="h-4 w-4 text-red-600" aria-hidden="true" />
-            已结算出账
-          </Button>
-          <Button size="sm" variant="ghost" onClick={() => onTransactions(account)}>
-            <ListOrdered className="h-4 w-4" aria-hidden="true" />
-            查看流水
-          </Button>
-        </div>
+        ) : null}
       </CardContent>
     </Card>
   );
 }
 
-export function TaobaoPage() {
-  const [showCreate, setShowCreate] = useState(false);
-  const [movementTarget, setMovementTarget] = useState<{ account: TaobaoAccount; kind: MutationKind } | null>(null);
-  const [transactionsTarget, setTransactionsTarget] = useState<TaobaoAccount | null>(null);
+// ---------------------------------------------------------------------------
+// 主页
+// ---------------------------------------------------------------------------
 
-  const { data: accounts = [], isFetching, refetch } = useQuery({
-    queryKey: ["taobao-accounts"],
-    queryFn: getTaobaoAccounts
+export function TaobaoPage() {
+  const { data: shops = [], isFetching, refetch } = useQuery({
+    queryKey: ["taobao-shops"],
+    queryFn: getTaobaoShops
   });
+
+  const [withdrawShop, setWithdrawShop] = useState<TaobaoShop | null>(null);
+  const [transferShop, setTransferShop] = useState<TaobaoShop | null>(null);
+  const [importShop, setImportShop] = useState<TaobaoShop | null>(null);
+  const [transactionsTarget, setTransactionsTarget] = useState<{
+    shop: TaobaoShop;
+    wallet: TaobaoShopWallet;
+    label: string;
+  } | null>(null);
 
   return (
     <div className="space-y-5">
       <div className="flex flex-col justify-between gap-3 md:flex-row md:items-end">
         <div>
-          <h2 className="text-2xl font-semibold tracking-normal">淘宝账号</h2>
+          <h2 className="text-2xl font-semibold tracking-normal">淘宝店铺</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            管理淘宝账号的未结算 / 已结算两个钱包，记录入出账流水。
+            3 店铺 × 5 钱包：支付宝在途 / 微信在途 / 聚合冻结 / 聚合可提现 / 银行卡。导入千牛 Excel
+            自动入账，T+7 解冻；银行卡余额可提回资产支付宝（兔仔账面记账除外）。
           </p>
         </div>
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
-            <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-            刷新
-          </Button>
-          <Button onClick={() => setShowCreate(true)}>
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            新建账号
-          </Button>
-        </div>
+        <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
+          <RefreshCcw className={cn("h-4 w-4", isFetching && "animate-spin")} aria-hidden="true" />
+          刷新
+        </Button>
       </div>
 
-      <SummaryCards accounts={accounts} />
-
-      {accounts.length === 0 ? (
+      {shops.length === 0 ? (
         <Card>
           <CardContent className="py-10 text-center text-muted-foreground">
-            {isFetching ? "加载中..." : "暂无淘宝账号，点击右上角「+ 新建账号」开始"}
+            {isFetching ? "加载中..." : "暂无淘宝店铺"}
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-          {accounts.map((account) => (
-            <AccountCard
-              key={account.id}
-              account={account}
-              onMovement={(acc, kind) => setMovementTarget({ account: acc, kind })}
-              onTransactions={setTransactionsTarget}
+        <div className="space-y-3">
+          {shops.map((shop) => (
+            <ShopCard
+              key={shop.id}
+              shop={shop}
+              onShowTransactions={(wallet, label) =>
+                setTransactionsTarget({ shop, wallet, label })
+              }
+              onWithdraw={() => setWithdrawShop(shop)}
+              onTransferToAsset={() => setTransferShop(shop)}
+              onImport={() => setImportShop(shop)}
             />
           ))}
         </div>
       )}
 
-      {showCreate ? <CreateAccountModal onClose={() => setShowCreate(false)} /> : null}
-      {movementTarget ? (
-        <MovementModal
-          account={movementTarget.account}
-          kind={movementTarget.kind}
-          onClose={() => setMovementTarget(null)}
-        />
+      {withdrawShop ? (
+        <WithdrawModal shop={withdrawShop} onClose={() => setWithdrawShop(null)} />
+      ) : null}
+      {transferShop ? (
+        <TransferToAssetModal shop={transferShop} onClose={() => setTransferShop(null)} />
+      ) : null}
+      {importShop ? (
+        <ImportExcelModal shop={importShop} onClose={() => setImportShop(null)} />
       ) : null}
       {transactionsTarget ? (
-        <TransactionsModal account={transactionsTarget} onClose={() => setTransactionsTarget(null)} />
+        <TransactionsModal
+          shop={transactionsTarget.shop}
+          wallet={transactionsTarget.wallet}
+          walletLabel={transactionsTarget.label}
+          onClose={() => setTransactionsTarget(null)}
+        />
       ) : null}
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -4,8 +4,9 @@ import {
   mockTaiwanSummary,
   mockTaiwanTransactions,
   mockTaiwanWallets,
-  mockTaobaoAccounts,
-  mockTaobaoTransactions,
+  mockTaobaoOrders,
+  mockTaobaoShops,
+  mockTaobaoWalletTransactions,
   mockVendors,
   mockVendorTransactions,
   mockXboxAccounts,
@@ -20,9 +21,15 @@ import type {
   TaiwanSummary,
   TaiwanTransaction,
   TaiwanWallet,
-  TaobaoAccount,
-  TaobaoTransaction,
-  TaobaoWalletScope,
+  TaobaoFlowReport,
+  TaobaoImportReport,
+  TaobaoOrder,
+  TaobaoOrderPaymentMethod,
+  TaobaoOrderStatus,
+  TaobaoReleaseReport,
+  TaobaoShop,
+  TaobaoShopWallet,
+  TaobaoWalletTransaction,
   Vendor,
   VendorTransaction,
   WalletBalance,
@@ -458,133 +465,333 @@ export async function getXboxSummary(): Promise<XboxSummary> {
   }
 }
 
-type TaobaoAccountResponse = {
+// ---------------------------------------------------------------------------
+// Taobao（PR #65/#67/#69）—— 3 店铺 × 5 钱包 + paymentWallet 可空 + Excel 导入
+// ---------------------------------------------------------------------------
+
+type TaobaoShopWalletResponse = {
   id: string | number;
   name: string;
-  unsettled_wallet_id?: string | number;
-  unsettledWalletId?: string | number;
-  settled_wallet_id?: string | number;
-  settledWalletId?: string | number;
-  unsettled_balance?: string | number;
-  unsettledBalance?: string | number;
-  settled_balance?: string | number;
-  settledBalance?: string | number;
-  remark?: string | null;
-  created_at?: string;
-  createdAt?: string;
+  balance: string | number;
 };
 
-type TaobaoTransactionResponse = {
+type TaobaoShopResponse = {
   id: string | number;
-  wallet_id?: string | number;
+  name: string;
+  paymentWallet?: TaobaoShopWalletResponse | null;
+  payment_wallet?: TaobaoShopWalletResponse | null;
+  unconfirmedAlipay?: TaobaoShopWalletResponse;
+  unconfirmed_alipay?: TaobaoShopWalletResponse;
+  unconfirmedWechat?: TaobaoShopWalletResponse;
+  unconfirmed_wechat?: TaobaoShopWalletResponse;
+  aggregatorFrozen?: TaobaoShopWalletResponse;
+  aggregator_frozen?: TaobaoShopWalletResponse;
+  aggregatorAvailable?: TaobaoShopWalletResponse;
+  aggregator_available?: TaobaoShopWalletResponse;
+  bankCard?: TaobaoShopWalletResponse;
+  bank_card?: TaobaoShopWalletResponse;
+  remark?: string | null;
+  createdAt?: string;
+  created_at?: string;
+};
+
+type TaobaoOrderResponse = {
+  id: string | number;
+  orderNumber?: string;
+  order_number?: string;
+  paymentMethod?: string;
+  payment_method?: string;
+  amount: string | number;
+  status: string;
+  bookkeepingWalletId?: string | number | null;
+  bookkeeping_wallet_id?: string | number | null;
+  bookkeepingTxId?: string | number | null;
+  bookkeeping_tx_id?: string | number | null;
+  shippedAt?: string | null;
+  shipped_at?: string | null;
+  receivedAt?: string | null;
+  received_at?: string | null;
+  lastSyncedAt?: string;
+  last_synced_at?: string;
+  recordedAt?: string;
+  recorded_at?: string;
+};
+
+type TaobaoWalletTransactionResponse = {
+  id: string | number;
   walletId?: string | number;
-  wallet_scope?: string;
-  walletScope?: string;
+  wallet_id?: string | number;
   amount: string | number;
   direction: "in" | "out";
   remark?: string | null;
-  created_at?: string;
   createdAt?: string;
+  created_at?: string;
+  matureAt?: string | null;
+  mature_at?: string | null;
 };
 
-function normalizeTaobaoAccount(account: TaobaoAccountResponse): TaobaoAccount {
+type TaobaoImportReportResponse = {
+  shopName?: string;
+  shop_name?: string;
+  totalRowsParsed?: number;
+  total_rows_parsed?: number;
+  createdOrders?: number;
+  created_orders?: number;
+  statusChangedOrders?: number;
+  status_changed_orders?: number;
+  closedReverted?: number;
+  closed_reverted?: number;
+  skippedNoChange?: number;
+  skipped_no_change?: number;
+  skippedUnpaidOrUnshipped?: number;
+  skipped_unpaid_or_unshipped?: number;
+  skippedUnknownPayment?: number;
+  skipped_unknown_payment?: number;
+  errors?: string[];
+};
+
+type TaobaoReleaseReportResponse = {
+  maturedCount?: number;
+  matured_count?: number;
+  maturedAmount?: string | number;
+  matured_amount?: string | number;
+  frozenBalanceAfter?: string | number;
+  frozen_balance_after?: string | number;
+  availableBalanceAfter?: string | number;
+  available_balance_after?: string | number;
+};
+
+type TaobaoFlowReportResponse = {
+  amount: string | number;
+  fromWalletId?: string | number;
+  from_wallet_id?: string | number;
+  fromWalletBalance?: string | number;
+  from_wallet_balance?: string | number;
+  toWalletId?: string | number;
+  to_wallet_id?: string | number;
+  toWalletBalance?: string | number;
+  to_wallet_balance?: string | number;
+  remark: string;
+};
+
+function normalizeTaobaoShopWallet(wallet: TaobaoShopWalletResponse): TaobaoShopWallet {
   return {
-    id: String(account.id),
-    name: account.name,
-    unsettledWalletId: String(account.unsettled_wallet_id ?? account.unsettledWalletId ?? ""),
-    settledWalletId: String(account.settled_wallet_id ?? account.settledWalletId ?? ""),
-    unsettledBalanceMinor: decimalToMinor(account.unsettled_balance ?? account.unsettledBalance ?? 0, "CNY"),
-    settledBalanceMinor: decimalToMinor(account.settled_balance ?? account.settledBalance ?? 0, "CNY"),
-    remark: account.remark ?? null,
-    createdAt: account.created_at ?? account.createdAt ?? ""
+    id: String(wallet.id),
+    name: wallet.name,
+    balanceMinor: decimalToMinor(wallet.balance, "CNY")
   };
 }
 
-function normalizeTaobaoTransaction(transaction: TaobaoTransactionResponse): TaobaoTransaction {
-  const scopeRaw = transaction.wallet_scope ?? transaction.walletScope ?? "unsettled";
-  const walletScope: TaobaoWalletScope = scopeRaw === "settled" ? "settled" : "unsettled";
+function normalizeTaobaoShop(shop: TaobaoShopResponse): TaobaoShop {
+  const paymentWallet = shop.paymentWallet ?? shop.payment_wallet ?? null;
+  const unconfirmedAlipay = shop.unconfirmedAlipay ?? shop.unconfirmed_alipay;
+  const unconfirmedWechat = shop.unconfirmedWechat ?? shop.unconfirmed_wechat;
+  const aggregatorFrozen = shop.aggregatorFrozen ?? shop.aggregator_frozen;
+  const aggregatorAvailable = shop.aggregatorAvailable ?? shop.aggregator_available;
+  const bankCard = shop.bankCard ?? shop.bank_card;
+
+  if (!unconfirmedAlipay || !unconfirmedWechat || !aggregatorFrozen || !aggregatorAvailable || !bankCard) {
+    throw new Error("淘宝店铺响应字段不完整");
+  }
+
   return {
-    id: String(transaction.id),
-    walletId: String(transaction.wallet_id ?? transaction.walletId ?? ""),
-    walletScope,
-    amountMinor: decimalToMinor(transaction.amount, "CNY"),
-    direction: transaction.direction,
-    remark: transaction.remark ?? null,
-    createdAt: transaction.created_at ?? transaction.createdAt ?? ""
+    id: String(shop.id),
+    name: shop.name,
+    paymentWallet: paymentWallet ? normalizeTaobaoShopWallet(paymentWallet) : null,
+    unconfirmedAlipay: normalizeTaobaoShopWallet(unconfirmedAlipay),
+    unconfirmedWechat: normalizeTaobaoShopWallet(unconfirmedWechat),
+    aggregatorFrozen: normalizeTaobaoShopWallet(aggregatorFrozen),
+    aggregatorAvailable: normalizeTaobaoShopWallet(aggregatorAvailable),
+    bankCard: normalizeTaobaoShopWallet(bankCard),
+    remark: shop.remark ?? null,
+    createdAt: shop.createdAt ?? shop.created_at ?? ""
   };
 }
 
-export async function getTaobaoAccounts(): Promise<TaobaoAccount[]> {
+function normalizeTaobaoOrder(order: TaobaoOrderResponse): TaobaoOrder {
+  const paymentMethod = (order.paymentMethod ?? order.payment_method ?? "alipay") as TaobaoOrderPaymentMethod;
+  const status = order.status as TaobaoOrderStatus;
+  const walletId = order.bookkeepingWalletId ?? order.bookkeeping_wallet_id;
+  const txId = order.bookkeepingTxId ?? order.bookkeeping_tx_id;
+  return {
+    id: String(order.id),
+    orderNumber: order.orderNumber ?? order.order_number ?? "",
+    paymentMethod,
+    amountMinor: decimalToMinor(order.amount, "CNY"),
+    status,
+    bookkeepingWalletId: walletId == null ? null : String(walletId),
+    bookkeepingTxId: txId == null ? null : String(txId),
+    shippedAt: order.shippedAt ?? order.shipped_at ?? null,
+    receivedAt: order.receivedAt ?? order.received_at ?? null,
+    lastSyncedAt: order.lastSyncedAt ?? order.last_synced_at ?? "",
+    recordedAt: order.recordedAt ?? order.recorded_at ?? ""
+  };
+}
+
+function normalizeTaobaoWalletTransaction(tx: TaobaoWalletTransactionResponse): TaobaoWalletTransaction {
+  return {
+    id: String(tx.id),
+    walletId: String(tx.walletId ?? tx.wallet_id ?? ""),
+    amountMinor: decimalToMinor(tx.amount, "CNY"),
+    direction: tx.direction,
+    remark: tx.remark ?? null,
+    createdAt: tx.createdAt ?? tx.created_at ?? "",
+    matureAt: tx.matureAt ?? tx.mature_at ?? null
+  };
+}
+
+function normalizeImportReport(data: TaobaoImportReportResponse): TaobaoImportReport {
+  return {
+    shopName: data.shopName ?? data.shop_name ?? "",
+    totalRowsParsed: Number(data.totalRowsParsed ?? data.total_rows_parsed ?? 0),
+    createdOrders: Number(data.createdOrders ?? data.created_orders ?? 0),
+    statusChangedOrders: Number(data.statusChangedOrders ?? data.status_changed_orders ?? 0),
+    closedReverted: Number(data.closedReverted ?? data.closed_reverted ?? 0),
+    skippedNoChange: Number(data.skippedNoChange ?? data.skipped_no_change ?? 0),
+    skippedUnpaidOrUnshipped: Number(data.skippedUnpaidOrUnshipped ?? data.skipped_unpaid_or_unshipped ?? 0),
+    skippedUnknownPayment: Number(data.skippedUnknownPayment ?? data.skipped_unknown_payment ?? 0),
+    errors: data.errors ?? []
+  };
+}
+
+function normalizeReleaseReport(data: TaobaoReleaseReportResponse): TaobaoReleaseReport {
+  return {
+    maturedCount: Number(data.maturedCount ?? data.matured_count ?? 0),
+    maturedAmountMinor: decimalToMinor(data.maturedAmount ?? data.matured_amount ?? 0, "CNY"),
+    frozenBalanceAfterMinor: decimalToMinor(data.frozenBalanceAfter ?? data.frozen_balance_after ?? 0, "CNY"),
+    availableBalanceAfterMinor: decimalToMinor(data.availableBalanceAfter ?? data.available_balance_after ?? 0, "CNY")
+  };
+}
+
+function normalizeFlowReport(data: TaobaoFlowReportResponse): TaobaoFlowReport {
+  return {
+    amountMinor: decimalToMinor(data.amount, "CNY"),
+    fromWalletId: String(data.fromWalletId ?? data.from_wallet_id ?? ""),
+    fromWalletBalanceMinor: decimalToMinor(data.fromWalletBalance ?? data.from_wallet_balance ?? 0, "CNY"),
+    toWalletId: String(data.toWalletId ?? data.to_wallet_id ?? ""),
+    toWalletBalanceMinor: decimalToMinor(data.toWalletBalance ?? data.to_wallet_balance ?? 0, "CNY"),
+    remark: data.remark
+  };
+}
+
+export async function getTaobaoShops(): Promise<TaobaoShop[]> {
   try {
-    const data = await fetchJson<TaobaoAccountResponse[]>("/api/taobao/accounts");
-    return data.map(normalizeTaobaoAccount);
+    const data = await fetchJson<TaobaoShopResponse[]>("/api/taobao/shops");
+    return data.map(normalizeTaobaoShop);
   } catch {
-    return mockTaobaoAccounts;
+    return mockTaobaoShops;
   }
 }
 
-export async function createTaobaoAccount(payload: { name: string; remark?: string }): Promise<TaobaoAccount> {
-  const body: Record<string, unknown> = { name: payload.name };
-  if (payload.remark) {
-    body.remark = payload.remark;
+export async function importTaobaoExcel(shopId: string, file: File): Promise<TaobaoImportReport> {
+  const form = new FormData();
+  form.append("file", file);
+
+  const response = await fetch(`/api/taobao/shops/${shopId}/import`, {
+    method: "POST",
+    headers: {
+      accept: "application/json"
+    },
+    body: form
+  });
+
+  const text = await response.text();
+
+  if (!response.ok) {
+    let message = `/api/taobao/shops/${shopId}/import returned ${response.status}`;
+    if (text) {
+      try {
+        const parsed = JSON.parse(text) as { detail?: string; message?: string; error?: string };
+        message = parsed.detail ?? parsed.message ?? parsed.error ?? text;
+      } catch {
+        message = text;
+      }
+    }
+    throw new Error(message);
   }
-  const data = (await postJson("/api/taobao/accounts", body)) as TaobaoAccountResponse;
-  return normalizeTaobaoAccount(data);
+
+  const data = (text ? JSON.parse(text) : {}) as TaobaoImportReportResponse;
+  return normalizeImportReport(data);
 }
 
-export async function creditTaobaoUnsettled(
-  accountId: string,
+export async function releaseAggregator(shopId: string): Promise<TaobaoReleaseReport> {
+  const data = (await postJson(
+    `/api/taobao/shops/${shopId}/aggregator/release`,
+    {}
+  )) as TaobaoReleaseReportResponse;
+  return normalizeReleaseReport(data);
+}
+
+export async function withdrawTaobao(
+  shopId: string,
   payload: { amount: string; remark?: string }
-): Promise<TaobaoTransaction> {
+): Promise<TaobaoFlowReport> {
   const body: Record<string, unknown> = { amount: payload.amount };
   if (payload.remark) {
     body.remark = payload.remark;
   }
   const data = (await postJson(
-    `/api/taobao/accounts/${accountId}/unsettled/credit`,
+    `/api/taobao/shops/${shopId}/withdraw`,
     body
-  )) as TaobaoTransactionResponse;
-  return normalizeTaobaoTransaction(data);
+  )) as TaobaoFlowReportResponse;
+  return normalizeFlowReport(data);
 }
 
-export async function creditTaobaoSettled(
-  accountId: string,
-  payload: { amount: string; remark?: string }
-): Promise<TaobaoTransaction> {
-  const body: Record<string, unknown> = { amount: payload.amount };
+export async function transferTaobaoToAsset(
+  shopId: string,
+  payload: { amount?: string; remark?: string }
+): Promise<TaobaoFlowReport> {
+  const body: Record<string, unknown> = {};
+  if (payload.amount) {
+    body.amount = payload.amount;
+  }
   if (payload.remark) {
     body.remark = payload.remark;
   }
   const data = (await postJson(
-    `/api/taobao/accounts/${accountId}/settled/credit`,
+    `/api/taobao/shops/${shopId}/transfer-to-asset`,
     body
-  )) as TaobaoTransactionResponse;
-  return normalizeTaobaoTransaction(data);
+  )) as TaobaoFlowReportResponse;
+  return normalizeFlowReport(data);
 }
 
-export async function debitTaobaoSettled(
-  accountId: string,
-  payload: { amount: string; remark?: string }
-): Promise<TaobaoTransaction> {
-  const body: Record<string, unknown> = { amount: payload.amount };
-  if (payload.remark) {
-    body.remark = payload.remark;
+export async function getTaobaoOrders(
+  shopId: string,
+  filters?: {
+    status?: TaobaoOrderStatus;
+    paymentMethod?: TaobaoOrderPaymentMethod;
+    limit?: number;
+    offset?: number;
   }
-  const data = (await postJson(
-    `/api/taobao/accounts/${accountId}/settled/debit`,
-    body
-  )) as TaobaoTransactionResponse;
-  return normalizeTaobaoTransaction(data);
-}
-
-export async function getTaobaoTransactions(accountId: string): Promise<TaobaoTransaction[]> {
+): Promise<TaobaoOrder[]> {
   try {
-    const data = await fetchJson<TaobaoTransactionResponse[]>(
-      `/api/taobao/accounts/${accountId}/transactions`
+    const params = new URLSearchParams();
+    if (filters?.status) params.set("status", filters.status);
+    if (filters?.paymentMethod) params.set("payment_method", filters.paymentMethod);
+    if (filters?.limit !== undefined) params.set("limit", String(filters.limit));
+    if (filters?.offset !== undefined) params.set("offset", String(filters.offset));
+    const query = params.toString();
+    const path = query
+      ? `/api/taobao/shops/${shopId}/orders?${query}`
+      : `/api/taobao/shops/${shopId}/orders`;
+    const data = await fetchJson<TaobaoOrderResponse[]>(path);
+    return data.map(normalizeTaobaoOrder);
+  } catch {
+    return mockTaobaoOrders[shopId] ?? [];
+  }
+}
+
+export async function getTaobaoWalletTransactions(
+  shopId: string,
+  walletId: string
+): Promise<TaobaoWalletTransaction[]> {
+  try {
+    const data = await fetchJson<TaobaoWalletTransactionResponse[]>(
+      `/api/taobao/shops/${shopId}/wallets/${walletId}/transactions`
     );
-    return data.map(normalizeTaobaoTransaction);
+    return data.map(normalizeTaobaoWalletTransaction);
   } catch {
-    return mockTaobaoTransactions[accountId] ?? [];
+    return mockTaobaoWalletTransactions[walletId] ?? [];
   }
 }
 

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -4,8 +4,9 @@ import type {
   TaiwanSummary,
   TaiwanTransaction,
   TaiwanWallet,
-  TaobaoAccount,
-  TaobaoTransaction,
+  TaobaoOrder,
+  TaobaoShop,
+  TaobaoWalletTransaction,
   Vendor,
   VendorTransaction,
   WalletBalance,
@@ -400,77 +401,101 @@ export const mockXboxSummary: XboxSummary = {
   }
 };
 
-export const mockTaobaoAccounts: TaobaoAccount[] = [
+// ---------------------------------------------------------------------------
+// Taobao mock（API 失败时回退）—— 3 店铺 × 5 钱包 + 兔仔无 paymentWallet
+// ---------------------------------------------------------------------------
+
+export const mockTaobaoShops: TaobaoShop[] = [
   {
-    id: "taobao-acc-1",
-    name: "丙火淘宝主号",
-    unsettledWalletId: "taobao-w-1u",
-    settledWalletId: "taobao-w-1s",
-    unsettledBalanceMinor: 58_400_00,
-    settledBalanceMinor: 32_100_00,
-    remark: "主营店铺",
-    createdAt: "2026-03-18T08:00:00.000Z"
+    id: "1",
+    name: "丙火电玩",
+    paymentWallet: { id: "3", name: "丙火网络支付宝", balanceMinor: 0 },
+    unconfirmedAlipay: { id: "12", name: "丙火电玩 支付宝在途", balanceMinor: 18_400_00 },
+    unconfirmedWechat: { id: "13", name: "丙火电玩 微信在途", balanceMinor: 6_280_00 },
+    aggregatorFrozen: { id: "14", name: "丙火电玩 聚合支付·冻结中", balanceMinor: 42_500_00 },
+    aggregatorAvailable: { id: "15", name: "丙火电玩 聚合支付·可提现", balanceMinor: 12_350_00 },
+    bankCard: { id: "16", name: "丙火电玩 银行卡", balanceMinor: 80_000_00 },
+    remark: null,
+    createdAt: "2026-05-05T11:17:14"
   },
   {
-    id: "taobao-acc-2",
-    name: "TOM淘宝小号",
-    unsettledWalletId: "taobao-w-2u",
-    settledWalletId: "taobao-w-2s",
-    unsettledBalanceMinor: 35_000_00,
-    settledBalanceMinor: 9_150_00,
+    id: "2",
+    name: "兔仔电玩",
+    paymentWallet: null,
+    unconfirmedAlipay: { id: "17", name: "兔仔电玩 支付宝在途", balanceMinor: 5_200_00 },
+    unconfirmedWechat: { id: "18", name: "兔仔电玩 微信在途", balanceMinor: 1_800_00 },
+    aggregatorFrozen: { id: "19", name: "兔仔电玩 聚合支付·冻结中", balanceMinor: 22_000_00 },
+    aggregatorAvailable: { id: "20", name: "兔仔电玩 聚合支付·可提现", balanceMinor: 4_500_00 },
+    bankCard: { id: "21", name: "兔仔电玩 银行卡", balanceMinor: 30_000_00 },
     remark: null,
-    createdAt: "2026-04-05T05:00:00.000Z"
+    createdAt: "2026-05-05T11:17:14"
+  },
+  {
+    id: "3",
+    name: "小小电玩",
+    paymentWallet: { id: "11", name: "小小电玩支付宝", balanceMinor: 0 },
+    unconfirmedAlipay: { id: "22", name: "小小电玩 支付宝在途", balanceMinor: 9_300_00 },
+    unconfirmedWechat: { id: "23", name: "小小电玩 微信在途", balanceMinor: 3_500_00 },
+    aggregatorFrozen: { id: "24", name: "小小电玩 聚合支付·冻结中", balanceMinor: 28_000_00 },
+    aggregatorAvailable: { id: "25", name: "小小电玩 聚合支付·可提现", balanceMinor: 7_200_00 },
+    bankCard: { id: "26", name: "小小电玩 银行卡", balanceMinor: 50_000_00 },
+    remark: null,
+    createdAt: "2026-05-05T11:17:14"
   }
 ];
 
-export const mockTaobaoTransactions: Record<string, TaobaoTransaction[]> = {
-  "taobao-acc-1": [
+export const mockTaobaoOrders: Record<string, TaobaoOrder[]> = {
+  "1": [
     {
-      id: "taobao-tx-1-1",
-      walletId: "taobao-w-1u",
-      walletScope: "unsettled",
-      amountMinor: 58_400_00,
-      direction: "in",
-      remark: "本周订单未结",
-      createdAt: "2026-04-22T03:00:00.000Z"
+      id: "1001",
+      orderNumber: "TB202605040001",
+      paymentMethod: "alipay",
+      amountMinor: 1_280_00,
+      status: "shipped_unconfirmed",
+      bookkeepingWalletId: "12",
+      bookkeepingTxId: "tx-1001",
+      shippedAt: "2026-05-04T03:20:00.000Z",
+      receivedAt: null,
+      lastSyncedAt: "2026-05-05T08:00:00.000Z",
+      recordedAt: "2026-05-04T05:00:00.000Z"
     },
     {
-      id: "taobao-tx-1-2",
-      walletId: "taobao-w-1s",
-      walletScope: "settled",
-      amountMinor: 40_000_00,
-      direction: "in",
-      remark: "上周结算到账",
-      createdAt: "2026-04-23T09:00:00.000Z"
-    },
+      id: "1002",
+      orderNumber: "TB202605030099",
+      paymentMethod: "wechat",
+      amountMinor: 680_00,
+      status: "received",
+      bookkeepingWalletId: "14",
+      bookkeepingTxId: "tx-1002",
+      shippedAt: "2026-05-03T03:20:00.000Z",
+      receivedAt: "2026-05-04T11:00:00.000Z",
+      lastSyncedAt: "2026-05-05T08:00:00.000Z",
+      recordedAt: "2026-05-03T05:00:00.000Z"
+    }
+  ]
+};
+
+export const mockTaobaoWalletTransactions: Record<string, TaobaoWalletTransaction[]> = {
+  "14": [
     {
-      id: "taobao-tx-1-3",
-      walletId: "taobao-w-1s",
-      walletScope: "settled",
-      amountMinor: 7_900_00,
-      direction: "out",
-      remark: "提现到支付宝",
-      createdAt: "2026-04-25T11:30:00.000Z"
+      id: "tx-1002",
+      walletId: "14",
+      amountMinor: 680_00,
+      direction: "in",
+      remark: "TB202605030099 已签收·冻结",
+      createdAt: "2026-05-04T11:00:00.000Z",
+      matureAt: "2026-05-11T11:00:00.000Z"
     }
   ],
-  "taobao-acc-2": [
+  "12": [
     {
-      id: "taobao-tx-2-1",
-      walletId: "taobao-w-2u",
-      walletScope: "unsettled",
-      amountMinor: 35_000_00,
+      id: "tx-1001",
+      walletId: "12",
+      amountMinor: 1_280_00,
       direction: "in",
-      remark: "新增订单",
-      createdAt: "2026-04-20T08:00:00.000Z"
-    },
-    {
-      id: "taobao-tx-2-2",
-      walletId: "taobao-w-2s",
-      walletScope: "settled",
-      amountMinor: 9_150_00,
-      direction: "in",
-      remark: null,
-      createdAt: "2026-04-21T08:00:00.000Z"
+      remark: "TB202605040001 已发货未确认",
+      createdAt: "2026-05-04T05:00:00.000Z",
+      matureAt: null
     }
   ]
 };

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -107,27 +107,86 @@ export type TaiwanSummary = {
   walletCount: number;
 };
 
-export type TaobaoWalletScope = "unsettled" | "settled";
+// ---------------------------------------------------------------------------
+// Taobao（PR #65/#67/#69 后的新结构：3 店铺 × 5 钱包 + paymentWallet 可空）
+// ---------------------------------------------------------------------------
 
-export type TaobaoAccount = {
+export type TaobaoShopWallet = {
   id: string;
   name: string;
-  unsettledWalletId: string;
-  settledWalletId: string;
-  unsettledBalanceMinor: number;
-  settledBalanceMinor: number;
+  balanceMinor: number;
+};
+
+export type TaobaoShop = {
+  id: string;
+  name: string;
+  paymentWallet: TaobaoShopWallet | null;
+  unconfirmedAlipay: TaobaoShopWallet;
+  unconfirmedWechat: TaobaoShopWallet;
+  aggregatorFrozen: TaobaoShopWallet;
+  aggregatorAvailable: TaobaoShopWallet;
+  bankCard: TaobaoShopWallet;
   remark: string | null;
   createdAt: string;
 };
 
-export type TaobaoTransaction = {
+export type TaobaoOrderPaymentMethod = "alipay" | "wechat";
+
+export type TaobaoOrderStatus =
+  | "shipped_unconfirmed"
+  | "received"
+  | "closed";
+
+export type TaobaoOrder = {
+  id: string;
+  orderNumber: string;
+  paymentMethod: TaobaoOrderPaymentMethod;
+  amountMinor: number;
+  status: TaobaoOrderStatus;
+  bookkeepingWalletId: string | null;
+  bookkeepingTxId: string | null;
+  shippedAt: string | null;
+  receivedAt: string | null;
+  lastSyncedAt: string;
+  recordedAt: string;
+};
+
+export type TaobaoWalletTransaction = {
   id: string;
   walletId: string;
-  walletScope: TaobaoWalletScope;
   amountMinor: number;
   direction: "in" | "out";
   remark: string | null;
   createdAt: string;
+  matureAt: string | null;
+};
+
+export type TaobaoImportReport = {
+  shopName: string;
+  totalRowsParsed: number;
+  createdOrders: number;
+  statusChangedOrders: number;
+  closedReverted: number;
+  skippedNoChange: number;
+  skippedUnpaidOrUnshipped: number;
+  skippedUnknownPayment: number;
+  errors: string[];
+};
+
+export type TaobaoReleaseReport = {
+  maturedCount: number;
+  maturedAmountMinor: number;
+  frozenBalanceAfterMinor: number;
+  availableBalanceAfterMinor: number;
+};
+
+export type TaobaoFlowReport = {
+  amountMinor: number;
+  fromWalletId: string;
+  fromWalletBalanceMinor: number;
+  toWalletId: string;
+  toWalletBalanceMinor: number;
+  remark: string;
 };
 
 export type ModuleSection = {


### PR DESCRIPTION
## 关联 Issue
Closes #70

## 改动说明

按 PR #65/#67/#69 上线的后端 3 店铺 × 5 钱包契约，彻底重写淘宝页。

### types.ts
- **删除**：`TaobaoAccount` / `TaobaoTransaction` / `TaobaoWalletScope`（旧版）
- **加**：
  - `TaobaoShop`（含 paymentWallet 可空 + 5 内部钱包）
  - `TaobaoShopWallet` / `TaobaoOrder` / `TaobaoWalletTransaction`
  - `TaobaoImportReport` / `TaobaoReleaseReport` / `TaobaoFlowReport`
  - `TaobaoOrderPaymentMethod` / `TaobaoOrderStatus` 枚举

### lib/api.ts
- **删除** 6 个旧函数
- **加** 7 个新函数：
  - `getTaobaoShops()`
  - `importTaobaoExcel(shopId, file)` — FormData multipart
  - `releaseAggregator(shopId)`
  - `withdrawTaobao(shopId, {amount, remark?})`
  - `transferTaobaoToAsset(shopId, {amount?, remark?})`
  - `getTaobaoOrders(shopId, filters?)`
  - `getTaobaoWalletTransactions(shopId, walletId)`
- 失败 fallback 仅 GET shops/orders/transactions；写操作（import/release/withdraw/transfer）失败抛错

### lib/mock-data.ts
- **删除** `mockTaobaoAccounts` / `mockTaobaoTransactions`
- **加**：
  - `mockTaobaoShops`（丙火电玩 / 兔仔电玩 / 小小电玩，5 钱包余额示意，兔仔 paymentWallet=null）
  - `mockTaobaoOrders` / `mockTaobaoWalletTransactions`

### components/taobao-page.tsx —— 完全重写
- 顶部：标题 + 刷新按钮
- 3 店铺卡片**垂直排列**，每张：
  - Header：店铺名 + 关联资产支付宝（兔仔显示\"无（钱止于银行卡）\"）+ \"导入今日千牛 Excel\" 按钮
  - 5 钱包行（浅边框分隔，金额 `tabular-nums`）：
    | 钱包 | 按钮 |
    |------|------|
    | 支付宝在途 | 流水 |
    | 微信在途 | 流水 |
    | 聚合支付·冻结中 | 一键解冻到期 + 流水 |
    | 聚合支付·可提现 | 提现 + 流水 |
    | 银行卡 | 转资产支付宝（兔仔无）+ 流水 |
  - 兔仔银行卡行：附带 \"账面记账，钱不在我手\" 小提示
  - 解冻成功后，卡片底部显示 ReleaseReport 卡片（解冻笔数 / 累计金额 / 冻结余额 / 可提现余额）；maturedCount>0 时按钮 emerald 高亮

### 4 个交互弹窗
1. **导入 Excel**：`<input type=\"file\" accept=\".xlsx\">` 原生文件选择 + FormData POST；成功后展示 ImportReport 8 个数字 + errors 列表（红框 + 项目符号）
2. **解冻**（聚合冻结行的按钮）：直接调用 release 不弹窗，loading 显示 spinner，结果内嵌在卡片底部
3. **提现**：金额必填 + 备注选填，显示当前可提现余额作参考
4. **转资产支付宝**（仅丙火/小小）：金额选填（留空 = 全部银行卡余额）+ 备注，显示当前银行卡余额

### 复用模式
- F-8 弹窗 `fixed inset-0 + Card`
- `postJson` / `sendJson` / `fetchJson` helper
- 错误统一红色 inline 框

## 自测
- [x] `npm run typecheck` 全过（无错误无警告）
- [x] `curl http://localhost:8000/taobao/shops` 返回 3 店铺，前端 normalize 字段正确
- [x] 兔仔（paymentWallet=null）UI 路径正确：无\"转资产\"按钮 + 显示\"账面记账\"提示
- [x] mockTaobaoShops 与真实 API 字段结构一致，API 失败时页面不白屏

## 视觉决定
- 5 钱包行用 `divide-y` 浅边框分隔，左右两端对齐
- 钱包颜色映射：在途 muted / 冻结 blue / 可提现 emerald / 银行卡 amber
- 流水抽屉的 matureAt 用 `transfer` tone Badge 蓝色显示
- 解冻按钮 maturedCount>0 后高亮 emerald 边框 + 浅绿背景，作为视觉反馈

## 遗留点
- `mockTaobaoOrders` / `mockTaobaoWalletTransactions` 仅塞了 1-2 条示意数据；订单页本期未做（后端有 `/orders` 端点但前端不展示）
- `ImportReport.errors` 数组目前用 `<li>` 列表展示，未做折叠或导出；条数多时滚动条
- 流水抽屉的 `matureAt` 仅展示，未做\"未到期/已到期\" 颜色区分
- 后端 PID 22228 未重启，目前只有 GET /taobao/shops 路由；其他写操作端点 curl 测试 404，但代码已合到 main 应该没问题（按任务说明不要重启后端）

---
> 由 broky 实现，请 PM 审查