### PR TITLE
[PR] [FEAT] 淘宝模块修正 - 店铺支付宝统一/钱包重命名/Excel 店铺校验

### DIFF
--- a/src/models/taobao.py
+++ b/src/models/taobao.py
@@ -29,8 +29,8 @@ class TaobaoShop(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str] = mapped_column(String(120), unique=True, nullable=False)
-    payment_wallet_id: Mapped[Optional[int]] = mapped_column(
-        ForeignKey("wallets.id"), nullable=True
+    store_alipay_wallet_id: Mapped[int] = mapped_column(
+        ForeignKey("wallets.id"), nullable=False
     )
     unconfirmed_alipay_wallet_id: Mapped[int] = mapped_column(
         ForeignKey("wallets.id"), nullable=False
@@ -54,8 +54,8 @@ class TaobaoShop(Base):
         server_default=func.now(),
     )
 
-    payment_wallet: Mapped[Optional[Wallet]] = relationship(
-        foreign_keys=[payment_wallet_id]
+    store_alipay_wallet: Mapped[Wallet] = relationship(
+        foreign_keys=[store_alipay_wallet_id]
     )
     unconfirmed_alipay_wallet: Mapped[Wallet] = relationship(
         foreign_keys=[unconfirmed_alipay_wallet_id]

--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -45,6 +45,7 @@ class TaobaoShopWalletOut(BaseModel):
     id: int
     name: str
     balance: Decimal
+    type: str
 
 
 class TaobaoShopOut(BaseModel):
@@ -52,7 +53,7 @@ class TaobaoShopOut(BaseModel):
 
     id: int
     name: str
-    payment_wallet: Optional[TaobaoShopWalletOut] = Field(default=None)
+    store_alipay_wallet: TaobaoShopWalletOut
     unconfirmed_alipay: TaobaoShopWalletOut
     unconfirmed_wechat: TaobaoShopWalletOut
     aggregator_frozen: TaobaoShopWalletOut
@@ -151,10 +152,12 @@ class WalletTransactionOut(BaseModel):
 
 
 def _serialize_wallet(wallet: Wallet) -> TaobaoShopWalletOut:
+    wallet_type = wallet.type.value if hasattr(wallet.type, "value") else str(wallet.type)
     return TaobaoShopWalletOut(
         id=wallet.id,
         name=wallet.name,
         balance=wallet.balance,
+        type=wallet_type,
     )
 
 
@@ -162,11 +165,7 @@ def serialize_shop(shop: TaobaoShop) -> TaobaoShopOut:
     return TaobaoShopOut(
         id=shop.id,
         name=shop.name,
-        payment_wallet=(
-            _serialize_wallet(shop.payment_wallet)
-            if shop.payment_wallet is not None
-            else None
-        ),
+        store_alipay_wallet=_serialize_wallet(shop.store_alipay_wallet),
         unconfirmed_alipay=_serialize_wallet(shop.unconfirmed_alipay_wallet),
         unconfirmed_wechat=_serialize_wallet(shop.unconfirmed_wechat_wallet),
         aggregator_frozen=_serialize_wallet(shop.aggregator_frozen_wallet),
@@ -238,17 +237,15 @@ def _get_shop_or_404(db: Session, shop_id: int) -> TaobaoShop:
 
 
 def _shop_wallet_ids(shop: TaobaoShop) -> set[int]:
-    """该 shop 关联的所有钱包 id（5 内部 + 可空的 payment_wallet）。"""
-    ids = {
+    """该 shop 关联的所有钱包 id（5 内部 + store_alipay_wallet,共 6 个）。"""
+    return {
         shop.unconfirmed_alipay_wallet_id,
         shop.unconfirmed_wechat_wallet_id,
         shop.aggregator_frozen_wallet_id,
         shop.aggregator_available_wallet_id,
         shop.bank_card_wallet_id,
+        shop.store_alipay_wallet_id,
     }
-    if shop.payment_wallet_id is not None:
-        ids.add(shop.payment_wallet_id)
-    return ids
 
 
 # ---------------------------------------------------------------------------
@@ -428,31 +425,26 @@ def withdraw_to_bank_card(
 
 
 @router.post(
-    "/shops/{shop_id}/transfer-to-asset",
+    "/shops/{shop_id}/transfer-to-store-alipay",
     response_model=FlowReportOut,
     response_model_by_alias=True,
 )
-def transfer_bank_card_to_asset(
+def transfer_bank_card_to_store_alipay(
     shop_id: int,
     request: TransferToAssetRequest,
     db: Session = Depends(get_db),
 ) -> FlowReportOut:
-    """银行卡 → 资产支付宝（仅丙火/小小，兔仔禁用）。
+    """银行卡 → 店铺支付宝（A/B 类店铺均可调）。
 
+    - 丙火/小小：bank_card debit + 资产支付宝子钱包 credit（实际金流）
+    - 兔仔：bank_card debit + 兔仔电玩支付宝（type=TAOBAO）credit（账面记账）
     - amount 不传时默认 = 银行卡当前余额
-    - 兔仔（payment_wallet_id 为空）→ 400
     - 银行卡余额不足或为 0 → 400
     """
     shop = _get_shop_or_404(db, shop_id)
-    if shop.payment_wallet_id is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="该店铺无关联资产支付宝",
-        )
 
     bank_card = shop.bank_card_wallet
-    payment_wallet = shop.payment_wallet
-    assert payment_wallet is not None  # payment_wallet_id 非空时一定有
+    store_alipay = shop.store_alipay_wallet
 
     if request.amount is not None:
         amount = Decimal(str(request.amount))
@@ -469,7 +461,7 @@ def transfer_bank_card_to_asset(
 
     try:
         debit(db, bank_card.id, amount, remark=remark)
-        credit(db, payment_wallet.id, amount, remark=remark)
+        credit(db, store_alipay.id, amount, remark=remark)
         db.commit()
     except ValueError as exc:
         db.rollback()
@@ -482,13 +474,13 @@ def transfer_bank_card_to_asset(
         raise
 
     db.refresh(bank_card)
-    db.refresh(payment_wallet)
+    db.refresh(store_alipay)
     return FlowReportOut(
         amount=amount,
         from_wallet_id=bank_card.id,
         from_wallet_balance=Decimal(bank_card.balance),
-        to_wallet_id=payment_wallet.id,
-        to_wallet_balance=Decimal(payment_wallet.balance),
+        to_wallet_id=store_alipay.id,
+        to_wallet_balance=Decimal(store_alipay.balance),
         remark=remark,
     )
 

--- a/src/services/taobao.py
+++ b/src/services/taobao.py
@@ -12,19 +12,22 @@ from src.models.wallet import Currency, Wallet, WalletType, create_wallet
 
 # 每店铺自动建的 5 个 TAOBAO 钱包后缀
 TAOBAO_SHOP_WALLET_SUFFIXES = (
-    "支付宝在途",
-    "微信在途",
+    "支付宝支付在途",
+    "微信支付在途",
     "聚合支付·冻结中",
     "聚合支付·可提现",
     "银行卡",
 )
 
+# 兔仔的店铺支付宝钱包名（type=TAOBAO 顶级,非资产页可见）
+TUZAI_STORE_ALIPAY_WALLET_NAME = "兔仔电玩支付宝"
+
 # 3 个店铺的初始化配置
-# payment_wallet_name 为支付宝钱包分组下的子钱包名（兔仔电玩为 None）
+# store_alipay_wallet_name 为支付宝钱包分组下的子钱包名（兔仔为 None,改为单建 TAOBAO 钱包）
 DEFAULT_TAOBAO_SHOPS = (
-    {"name": "丙火电玩", "payment_wallet_name": "丙火网络支付宝"},
-    {"name": "兔仔电玩", "payment_wallet_name": None},
-    {"name": "小小电玩", "payment_wallet_name": "小小电玩支付宝"},
+    {"name": "丙火电玩", "store_alipay_wallet_name": "丙火网络支付宝"},
+    {"name": "兔仔电玩", "store_alipay_wallet_name": None},
+    {"name": "小小电玩", "store_alipay_wallet_name": "小小电玩支付宝"},
 )
 
 
@@ -92,7 +95,9 @@ def ensure_default_taobao_wallets(session: Session) -> None:
     Run order:
       1. 在资产支付宝下补建 '小小电玩支付宝' 子钱包（如缺失）
       2. 创建 3 个 TaobaoShop（已存在则跳过）
-      3. 每店铺自动建 5 个 TAOBAO 钱包
+      3. 每店铺自动建 5 个 TAOBAO 钱包（支付宝支付在途/微信支付在途/聚合冻结/聚合可提现/银行卡）
+      4. 兔仔的 store_alipay_wallet 指向独立的 type=TAOBAO 顶级钱包"兔仔电玩支付宝"
+         （账面记账,不在 GET /wallets/assets 树中可见）
     """
     # 1. 先确保 "小小电玩支付宝" 在 支付宝钱包 分组下存在
     _ensure_alipay_sub_wallet(session, "小小电玩支付宝")
@@ -100,7 +105,7 @@ def ensure_default_taobao_wallets(session: Session) -> None:
     # 2. 创建/复用 3 个店铺
     for shop_config in DEFAULT_TAOBAO_SHOPS:
         shop_name: str = shop_config["name"]
-        payment_wallet_name: Optional[str] = shop_config["payment_wallet_name"]
+        store_alipay_wallet_name: Optional[str] = shop_config["store_alipay_wallet_name"]
 
         existing_shop = session.scalar(
             select(TaobaoShop).where(TaobaoShop.name == shop_name)
@@ -114,15 +119,17 @@ def ensure_default_taobao_wallets(session: Session) -> None:
             wallet = _ensure_taobao_wallet(session, f"{shop_name} {suffix}")
             wallets.append(wallet)
 
-        # payment_wallet：若配置了名称则在支付宝钱包下找；否则保持 None
-        payment_wallet_id: Optional[int] = None
-        if payment_wallet_name:
-            payment_wallet = _ensure_alipay_sub_wallet(session, payment_wallet_name)
-            payment_wallet_id = payment_wallet.id
+        # 4. 解析店铺支付宝钱包：
+        #    - A 类（丙火/小小）：在资产支付宝下找/建
+        #    - B 类（兔仔）：单建 type=TAOBAO 顶级钱包"兔仔电玩支付宝"
+        if store_alipay_wallet_name:
+            store_alipay_wallet = _ensure_alipay_sub_wallet(session, store_alipay_wallet_name)
+        else:
+            store_alipay_wallet = _ensure_taobao_wallet(session, TUZAI_STORE_ALIPAY_WALLET_NAME)
 
         shop = TaobaoShop(
             name=shop_name,
-            payment_wallet_id=payment_wallet_id,
+            store_alipay_wallet_id=store_alipay_wallet.id,
             unconfirmed_alipay_wallet_id=wallets[0].id,
             unconfirmed_wechat_wallet_id=wallets[1].id,
             aggregator_frozen_wallet_id=wallets[2].id,

--- a/src/services/taobao_import.py
+++ b/src/services/taobao_import.py
@@ -233,29 +233,25 @@ def _resolve_target_wallet(
     payment_method: TaobaoOrderPaymentMethod,
     system_status: TaobaoOrderStatus,
 ) -> Optional[int]:
-    """三维分流（支付方式 × 系统状态 × 店铺类型）→ 目标钱包 id。
+    """三维分流（支付方式 × 系统状态）→ 目标钱包 id。
 
     返回 None 表示该状态不入账（如 closed）。
 
-    分流矩阵：
-    - alipay/shipped_unconfirmed → unconfirmed_alipay  (A/B 一致)
-    - alipay/received            → A 类: payment_wallet  | B 类: bank_card
-    - wechat/shipped_unconfirmed → unconfirmed_wechat  (A/B 一致)
-    - wechat/received            → aggregator_frozen   (A/B 一致;聚合支付独立于店铺归属)
+    分流矩阵（A/B 已统一,不再分流）：
+    - alipay/shipped_unconfirmed → unconfirmed_alipay
+    - alipay/received            → store_alipay_wallet（A: 资产支付宝子钱包 / B: 兔仔电玩支付宝）
+    - wechat/shipped_unconfirmed → unconfirmed_wechat
+    - wechat/received            → aggregator_frozen（聚合支付独立于店铺归属）
     - closed                     → None (不入账)
     """
     if system_status == TaobaoOrderStatus.CLOSED:
         return None
 
-    is_b_type = shop.payment_wallet_id is None  # 兔仔电玩
-
     if payment_method == TaobaoOrderPaymentMethod.ALIPAY:
         if system_status == TaobaoOrderStatus.SHIPPED_UNCONFIRMED:
             return shop.unconfirmed_alipay_wallet_id
         if system_status == TaobaoOrderStatus.RECEIVED:
-            if is_b_type:
-                return shop.bank_card_wallet_id  # 兔仔停在银行卡
-            return shop.payment_wallet_id
+            return shop.store_alipay_wallet_id
     elif payment_method == TaobaoOrderPaymentMethod.WECHAT:
         if system_status == TaobaoOrderStatus.SHIPPED_UNCONFIRMED:
             return shop.unconfirmed_wechat_wallet_id
@@ -330,17 +326,42 @@ def import_qianniu_workbook(
 
     调用方负责 commit / rollback。本函数只 add + flush，**不 commit**。
     任何 SQLAlchemy 异常会向上抛，调用方应 rollback。
+
+    解析时会先把所有数据行解析一次，校验"店铺名称"列与上传 ``shop.name`` 一致，
+    任何一行不匹配（含空字符串）→ 抛 TaobaoImportError，路由层翻译为 400 整体回滚。
     """
     rows = parse_workbook(file_obj)
     report = ImportReport(shop_name=shop.name)
 
+    # 第一遍：解析所有数据行 + 校验店铺名称
+    parsed_rows: list[tuple[int, ParsedRow]] = []
+    parse_errors: list[str] = []
+    mismatched_shop_names: set[str] = set()
     for row_index, raw_row in enumerate(rows[1:], start=2):
-        report.total_rows_parsed += 1
         try:
             parsed = _parse_row(row_index, raw_row)
         except Exception as exc:
-            report.errors.append(f"行 {row_index} 解析异常: {exc}")
+            parse_errors.append(f"行 {row_index} 解析异常: {exc}")
             continue
+        parsed_rows.append((row_index, parsed))
+        # 行级店铺名校验：空字符串视为不匹配
+        if parsed.shop_name_in_row != shop.name:
+            mismatched_shop_names.add(parsed.shop_name_in_row)
+
+    if mismatched_shop_names:
+        # 排序后展示,稳定输出便于测试
+        names = ", ".join(sorted(mismatched_shop_names))
+        raise TaobaoImportError(
+            f"Excel 包含其他店铺数据：{names}，请上传匹配 {shop.name} 的 Excel"
+        )
+
+    # 第二遍：实际入账（解析阶段的解析异常仍写到 report.errors）
+    for err in parse_errors:
+        report.errors.append(err)
+        report.total_rows_parsed += 1
+
+    for row_index, parsed in parsed_rows:
+        report.total_rows_parsed += 1
 
         # 跳过未付款 / 未发货
         if parsed.is_pending_pay_or_unshipped:

--- a/tests/test_taobao_flow_api.py
+++ b/tests/test_taobao_flow_api.py
@@ -3,7 +3,7 @@
 覆盖：
 - /aggregator/release：到期累计、无到期、防御性排除已撤流水
 - /withdraw：可提现 → 银行卡 / 余额不足 / amount<=0
-- /transfer-to-asset：丙火 / 兔仔禁用 / amount 默认全额 / 银行卡空
+- /transfer-to-store-alipay：丙火 / 兔仔均成功 / amount 默认全额 / 银行卡空
 - /orders：列表 + status/payment_method 过滤 + 分页 + 排序
 - /wallets/{id}/transactions：mature_at 字段、wallet_id 校验
 """
@@ -250,14 +250,13 @@ def test_withdraw_400_when_amount_not_positive(client):
 
 
 # ---------------------------------------------------------------------------
-# /transfer-to-asset
+# /transfer-to-store-alipay
 # ---------------------------------------------------------------------------
 
 
-def test_transfer_to_asset_a_shop_explicit_amount(client):
-    """丙火电玩：bank_card → 丙火网络支付宝，指定 amount。"""
+def test_transfer_to_store_alipay_a_shop_explicit_amount(client):
+    """丙火电玩：bank_card → 丙火网络支付宝（资产支付宝子钱包），指定 amount。"""
     shop = _shop_by_name("丙火电玩")
-    assert shop.payment_wallet_id is not None
 
     db = database.SessionLocal()
     try:
@@ -267,7 +266,7 @@ def test_transfer_to_asset_a_shop_explicit_amount(client):
         db.close()
 
     response = client.post(
-        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
         json={"amount": "300"},
     )
     assert response.status_code == 200, response.text
@@ -279,26 +278,38 @@ def test_transfer_to_asset_a_shop_explicit_amount(client):
     assert payload["remark"] == "提现"
 
     assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("200.000000")
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("300.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("300.000000")
 
 
-def test_transfer_to_asset_b_shop_400(client):
-    """兔仔电玩无 payment_wallet → 400。"""
+def test_transfer_to_store_alipay_b_shop_succeeds(client):
+    """兔仔电玩：bank_card → 兔仔电玩支付宝（type=TAOBAO,账面记账）→ 成功。"""
     shop = _shop_by_name("兔仔电玩")
-    assert shop.payment_wallet_id is None
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("80"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
 
     response = client.post(
-        f"/taobao/shops/{shop.id}/transfer-to-asset",
-        json={"amount": "10"},
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"amount": "30"},
     )
-    assert response.status_code == 400
-    assert "支付宝" in response.json()["detail"]
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert Decimal(payload["amount"]) == Decimal("30")
+    assert Decimal(payload["fromWalletBalance"]) == Decimal("50.000000")
+    assert Decimal(payload["toWalletBalance"]) == Decimal("30.000000")
+
+    assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("50.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("30.000000")
 
 
-def test_transfer_to_asset_default_amount_is_full_bank_balance(client):
+def test_transfer_to_store_alipay_default_amount_is_full_bank_balance(client):
     """amount 不传 → 默认转走银行卡全余额。"""
     shop = _shop_by_name("小小电玩")
-    assert shop.payment_wallet_id is not None
 
     db = database.SessionLocal()
     try:
@@ -308,7 +319,7 @@ def test_transfer_to_asset_default_amount_is_full_bank_balance(client):
         db.close()
 
     response = client.post(
-        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
         json={},
     )
     assert response.status_code == 200, response.text
@@ -319,17 +330,17 @@ def test_transfer_to_asset_default_amount_is_full_bank_balance(client):
     assert Decimal(payload["toWalletBalance"]) == Decimal("777.000000")
 
 
-def test_transfer_to_asset_400_when_bank_card_empty(client):
+def test_transfer_to_store_alipay_400_when_bank_card_empty(client):
     """银行卡余额为 0 时 amount 默认 0 → 400。"""
     shop = _shop_by_name("丙火电玩")
     response = client.post(
-        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
         json={},
     )
     assert response.status_code == 400
 
 
-def test_transfer_to_asset_custom_remark(client):
+def test_transfer_to_store_alipay_custom_remark(client):
     shop = _shop_by_name("丙火电玩")
     db = database.SessionLocal()
     try:
@@ -339,7 +350,7 @@ def test_transfer_to_asset_custom_remark(client):
         db.close()
 
     response = client.post(
-        f"/taobao/shops/{shop.id}/transfer-to-asset",
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
         json={"amount": "50", "remark": "5月转资产"},
     )
     assert response.status_code == 200
@@ -492,7 +503,7 @@ def test_wallet_transactions_404_when_wallet_not_in_shop(client):
         shop.aggregator_frozen_wallet_id,
         shop.aggregator_available_wallet_id,
         shop.bank_card_wallet_id,
-        shop.payment_wallet_id,
+        shop.store_alipay_wallet_id,
     }
     response = client.get(
         f"/taobao/shops/{shop.id}/wallets/{other_wallet_id}/transactions"
@@ -500,19 +511,19 @@ def test_wallet_transactions_404_when_wallet_not_in_shop(client):
     assert response.status_code == 404
 
 
-def test_wallet_transactions_payment_wallet_allowed(client):
-    """payment_wallet（资产支付宝）也应被允许查询。"""
+def test_wallet_transactions_store_alipay_wallet_allowed(client):
+    """store_alipay_wallet（店铺支付宝）也应被允许查询。"""
     shop = _shop_by_name("丙火电玩")
-    # 先 credit 到 payment_wallet
+    # 先 credit 到 store_alipay_wallet
     db = database.SessionLocal()
     try:
-        credit(db, shop.payment_wallet_id, Decimal("88"), remark="测试支付宝入账")
+        credit(db, shop.store_alipay_wallet_id, Decimal("88"), remark="测试支付宝入账")
         db.commit()
     finally:
         db.close()
 
     response = client.get(
-        f"/taobao/shops/{shop.id}/wallets/{shop.payment_wallet_id}/transactions"
+        f"/taobao/shops/{shop.id}/wallets/{shop.store_alipay_wallet_id}/transactions"
     )
     assert response.status_code == 200
     txs = response.json()

--- a/tests/test_taobao_import_api.py
+++ b/tests/test_taobao_import_api.py
@@ -177,6 +177,70 @@ def test_import_400_when_columns_too_few(client):
     assert response.status_code == 400
 
 
+def test_import_400_when_row_shop_name_mismatched(client):
+    """行内店铺名 != 上传 shop.name → 400 + 错误信息含两个店铺名 + 整体回滚。"""
+    shop = _shop_by_name("丙火电玩")
+    rows = [
+        [
+            "ROW_OK",
+            "PAY_OK",
+            _alipay_detail("PAY_OK", "10.00"),
+            "10.00",
+            "交易成功",
+            "2026-04-29 23:00:00",
+            "丙火电玩",
+            "2026-04-30 00:00:00",
+            "10.00",
+        ],
+        [
+            "ROW_BAD",
+            "PAY_BAD",
+            _alipay_detail("PAY_BAD", "20.00"),
+            "20.00",
+            "交易成功",
+            "2026-04-29 23:00:00",
+            "兔仔电玩",  # 不匹配上传的丙火电玩
+            "2026-04-30 00:00:00",
+            "20.00",
+        ],
+    ]
+    response = _post_import(client, shop.id, _build_xlsx(rows))
+    assert response.status_code == 400, response.text
+    detail = response.json()["detail"]
+    assert "兔仔电玩" in detail
+    assert "丙火电玩" in detail
+
+    # 整体回滚：第一行也不应入账
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
+
+    db = database.SessionLocal()
+    try:
+        orders = db.scalars(select(TaobaoOrder)).all()
+        assert orders == []
+    finally:
+        db.close()
+
+
+def test_import_400_when_row_shop_name_empty(client):
+    """行内店铺名为空 → 视为不匹配 → 400。"""
+    shop = _shop_by_name("丙火电玩")
+    rows = [
+        [
+            "ROW_EMPTY_SHOP",
+            "PAY_X",
+            _alipay_detail("PAY_X", "10.00"),
+            "10.00",
+            "交易成功",
+            "2026-04-29 23:00:00",
+            "",  # 空店铺名
+            "2026-04-30 00:00:00",
+            "10.00",
+        ],
+    ]
+    response = _post_import(client, shop.id, _build_xlsx(rows))
+    assert response.status_code == 400
+
+
 def test_import_400_when_file_empty(client):
     shop = _shop_by_name("丙火电玩")
     response = client.post(
@@ -197,8 +261,8 @@ def test_import_400_when_file_empty(client):
 # ---------------------------------------------------------------------------
 
 
-def test_new_alipay_received_a_shop_to_payment_wallet(client):
-    """A 类店铺（丙火电玩）alipay/received → payment_wallet。"""
+def test_new_alipay_received_a_shop_to_store_alipay_wallet(client):
+    """A 类店铺（丙火电玩）alipay/received → store_alipay_wallet（资产支付宝子钱包）。"""
     shop = _shop_by_name("丙火电玩")
     rows = [[
         "ORDER_A1",
@@ -207,7 +271,7 @@ def test_new_alipay_received_a_shop_to_payment_wallet(client):
         "100.00",
         "交易成功",
         "2026-04-29 23:57:43",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:03:21",
         "100.00",
     ]]
@@ -216,14 +280,13 @@ def test_new_alipay_received_a_shop_to_payment_wallet(client):
     payload = response.json()
     assert payload["createdOrders"] == 1
 
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("100.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("100.000000")
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
 
 
-def test_new_alipay_received_b_shop_to_bank_card(client):
-    """B 类店铺（兔仔电玩）alipay/received → bank_card（不进 payment_wallet,因为没有）。"""
+def test_new_alipay_received_b_shop_to_store_alipay_wallet(client):
+    """B 类店铺（兔仔电玩）alipay/received → store_alipay_wallet（兔仔电玩支付宝,type=TAOBAO）,不再进 bank_card。"""
     shop = _shop_by_name("兔仔电玩")
-    assert shop.payment_wallet_id is None
     rows = [[
         "ORDER_B1",
         "PAY_B1",
@@ -237,7 +300,8 @@ def test_new_alipay_received_b_shop_to_bank_card(client):
     ]]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
-    assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("50.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("50.000000")
+    assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("0.000000")
 
 
 def test_new_wechat_received_to_aggregator_frozen_with_mature_at(client):
@@ -251,7 +315,7 @@ def test_new_wechat_received_to_aggregator_frozen_with_mature_at(client):
         "200.00",
         "交易成功",
         "2026-04-29 23:57:43",
-        "丙火网络",
+        "丙火电玩",
         received_at_str,
         "200.00",
     ]]
@@ -296,14 +360,14 @@ def test_new_alipay_shipped_unconfirmed_to_unconfirmed_alipay(client):
         "27.50",
         "卖家已发货，等待买家确认",
         "2026-04-29 23:46:25",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:10:45",
         "0.00",
     ]]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("27.500000")
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("0.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
 
 def test_new_wechat_shipped_unconfirmed_to_unconfirmed_wechat(client):
@@ -316,7 +380,7 @@ def test_new_wechat_shipped_unconfirmed_to_unconfirmed_wechat(client):
         "33.00",
         "卖家已发货，等待买家确认",
         "2026-04-29 23:46:25",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:10:45",
         "0.00",
     ]]
@@ -341,7 +405,7 @@ def test_skip_pending_pay_and_paid_unshipped(client):
             "0.00",
             "等待买家付款",
             "",
-            "丙火网络",
+            "丙火电玩",
             "",
             "0.00",
         ],
@@ -352,7 +416,7 @@ def test_skip_pending_pay_and_paid_unshipped(client):
             "10.00",
             "买家已付款,等待卖家发货",
             "2026-04-29 23:00:00",
-            "丙火网络",
+            "丙火电玩",
             "",
             "0.00",
         ],
@@ -363,7 +427,7 @@ def test_skip_pending_pay_and_paid_unshipped(client):
     assert payload["skippedUnpaidOrUnshipped"] == 2
     assert payload["createdOrders"] == 0
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("0.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
     db = database.SessionLocal()
     try:
@@ -383,7 +447,7 @@ def test_skip_unknown_payment_method(client):
         "50.00",
         "交易成功",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "50.00",
     ]]
@@ -404,7 +468,7 @@ def test_new_closed_order_no_credit(client):
         "0.00",
         "交易关闭",
         "",
-        "丙火网络",
+        "丙火电玩",
         "",
         "0.00",
     ]]
@@ -412,7 +476,7 @@ def test_new_closed_order_no_credit(client):
     assert response.status_code == 200
     payload = response.json()
     assert payload["createdOrders"] == 1
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("0.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
 
     db = database.SessionLocal()
@@ -432,7 +496,7 @@ def test_new_closed_order_no_credit(client):
 
 
 def test_reconcile_shipped_unconfirmed_to_received(client):
-    """状态从 shipped_unconfirmed → received：撤老钱包(unconfirmed_alipay) + 入新钱包(payment_wallet)。"""
+    """状态从 shipped_unconfirmed → received：撤老钱包(unconfirmed_alipay) + 入新钱包(store_alipay_wallet)。"""
     shop = _shop_by_name("丙火电玩")
     # 第一次导入：shipped_unconfirmed
     rows1 = [[
@@ -442,14 +506,14 @@ def test_reconcile_shipped_unconfirmed_to_received(client):
         "100.00",
         "卖家已发货，等待买家确认",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "0.00",
     ]]
     response = _post_import(client, shop.id, _build_xlsx(rows1))
     assert response.status_code == 200
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("100.000000")
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("0.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
     # 第二次导入：同一订单变成 received
     rows2 = [[
@@ -459,7 +523,7 @@ def test_reconcile_shipped_unconfirmed_to_received(client):
         "100.00",
         "交易成功",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "100.00",
     ]]
@@ -471,8 +535,8 @@ def test_reconcile_shipped_unconfirmed_to_received(client):
 
     # 老钱包（unconfirmed_alipay）应该被 debit 100,余额回 0
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
-    # 新钱包（payment_wallet）应该 +100
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("100.000000")
+    # 新钱包（store_alipay_wallet）应该 +100
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("100.000000")
 
     # 老钱包应该有 1 in + 1 out = 2 笔流水
     assert _wallet_tx_count(shop.unconfirmed_alipay_wallet_id) == 2
@@ -491,7 +555,7 @@ def test_reconcile_shipped_unconfirmed_to_received(client):
         )
         status_value = order.status.value if hasattr(order.status, "value") else order.status
         assert status_value == TaobaoOrderStatus.RECEIVED.value
-        assert order.bookkeeping_wallet_id == shop.payment_wallet_id
+        assert order.bookkeeping_wallet_id == shop.store_alipay_wallet_id
     finally:
         db.close()
 
@@ -506,7 +570,7 @@ def test_reconcile_to_closed_no_new_credit(client):
         "80.00",
         "卖家已发货，等待买家确认",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "0.00",
     ]]
@@ -520,7 +584,7 @@ def test_reconcile_to_closed_no_new_credit(client):
         "80.00",
         "交易关闭",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "0.00",
     ]]
@@ -530,7 +594,7 @@ def test_reconcile_to_closed_no_new_credit(client):
     assert payload["closedReverted"] == 1
 
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("0.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
     db = database.SessionLocal()
     try:
@@ -554,7 +618,7 @@ def test_reconcile_no_change_skipped(client):
         "55.00",
         "卖家已发货，等待买家确认",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "0.00",
     ]]
@@ -581,7 +645,7 @@ def test_reconcile_skip_jump_unconfirmed_to_received(client):
         "120.00",
         "卖家已发货，等待买家确认",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "0.00",
     ]]
@@ -596,7 +660,7 @@ def test_reconcile_skip_jump_unconfirmed_to_received(client):
         "120.00",
         "交易成功",
         "2026-04-29 23:00:00",
-        "丙火网络",
+        "丙火电玩",
         "2026-04-30 00:00:00",
         "120.00",
     ]]
@@ -628,7 +692,7 @@ def test_full_report_counts(client):
             "10.00",
             "交易成功",
             "2026-04-29 23:00:00",
-            "丙火网络",
+            "丙火电玩",
             "2026-04-30 00:00:00",
             "10.00",
         ],
@@ -640,7 +704,7 @@ def test_full_report_counts(client):
             "20.00",
             "卖家已发货，等待买家确认",
             "2026-04-29 23:00:00",
-            "丙火网络",
+            "丙火电玩",
             "2026-04-30 00:00:00",
             "0.00",
         ],
@@ -652,7 +716,7 @@ def test_full_report_counts(client):
             "0.00",
             "等待买家付款",
             "",
-            "丙火网络",
+            "丙火电玩",
             "",
             "0.00",
         ],
@@ -664,7 +728,7 @@ def test_full_report_counts(client):
             "30.00",
             "交易成功",
             "2026-04-29 23:00:00",
-            "丙火网络",
+            "丙火电玩",
             "2026-04-30 00:00:00",
             "30.00",
         ],
@@ -676,7 +740,7 @@ def test_full_report_counts(client):
             "0.00",
             "交易关闭",
             "",
-            "丙火网络",
+            "丙火电玩",
             "",
             "0.00",
         ],
@@ -707,7 +771,7 @@ def test_atomic_transaction_no_partial_on_db_error(client, monkeypatch):
             "10.00",
             "交易成功",
             "2026-04-29 23:00:00",
-            "丙火网络",
+            "丙火电玩",
             "2026-04-30 00:00:00",
             "10.00",
         ],
@@ -718,7 +782,7 @@ def test_atomic_transaction_no_partial_on_db_error(client, monkeypatch):
             "20.00",
             "交易成功",
             "2026-04-29 23:00:00",
-            "丙火网络",
+            "丙火电玩",
             "2026-04-30 00:00:00",
             "20.00",
         ],
@@ -753,7 +817,7 @@ def test_atomic_transaction_no_partial_on_db_error(client, monkeypatch):
     assert response.status_code == 500
 
     # 第一笔应该被 rollback,余额仍为 0
-    assert _wallet_balance(shop.payment_wallet_id) == Decimal("0.000000")
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
     db = database.SessionLocal()
     try:
@@ -805,7 +869,7 @@ def test_large_sample_distribution(client):
             str(amount),
             status,
             pay_time,
-            "丙火网络",
+            "丙火电玩",
             ship_time,
             confirm_amount,
         ])

--- a/tests/test_taobao_shops_api.py
+++ b/tests/test_taobao_shops_api.py
@@ -40,29 +40,41 @@ def test_get_shops_returns_three_shops_with_six_wallets(client):
         assert "aggregatorFrozen" in shop
         assert "aggregatorAvailable" in shop
         assert "bankCard" in shop
-        assert "paymentWallet" in shop  # may be null for 兔仔
+        assert "storeAlipayWallet" in shop  # 每店铺都有,不再可空
+        assert shop["storeAlipayWallet"] is not None
         assert "createdAt" in shop
-        # 5 个内部钱包都应该带 id / name / balance
-        for key in ("unconfirmedAlipay", "unconfirmedWechat", "aggregatorFrozen", "aggregatorAvailable", "bankCard"):
+        # 5 个内部钱包 + 店铺支付宝都应该带 id / name / balance / type
+        for key in (
+            "unconfirmedAlipay",
+            "unconfirmedWechat",
+            "aggregatorFrozen",
+            "aggregatorAvailable",
+            "bankCard",
+            "storeAlipayWallet",
+        ):
             assert shop[key]["id"]
             assert shop[key]["name"]
+            assert "type" in shop[key]
             assert Decimal(shop[key]["balance"]) == Decimal("0.000000")
 
 
-def test_payment_wallet_mapping(client):
+def test_store_alipay_wallet_mapping(client):
     response = client.get("/taobao/shops")
     shops = {shop["name"]: shop for shop in response.json()}
 
+    # 丙火/小小指向资产支付宝下的子钱包（type=asset_rmb）
     binghuo = shops["丙火电玩"]
-    assert binghuo["paymentWallet"] is not None
-    assert binghuo["paymentWallet"]["name"] == "丙火网络支付宝"
-
-    tuzai = shops["兔仔电玩"]
-    assert tuzai["paymentWallet"] is None
+    assert binghuo["storeAlipayWallet"]["name"] == "丙火网络支付宝"
+    assert binghuo["storeAlipayWallet"]["type"] == WalletType.ASSET_RMB.value
 
     xiaoxiao = shops["小小电玩"]
-    assert xiaoxiao["paymentWallet"] is not None
-    assert xiaoxiao["paymentWallet"]["name"] == "小小电玩支付宝"
+    assert xiaoxiao["storeAlipayWallet"]["name"] == "小小电玩支付宝"
+    assert xiaoxiao["storeAlipayWallet"]["type"] == WalletType.ASSET_RMB.value
+
+    # 兔仔指向独立的 type=TAOBAO 顶级钱包"兔仔电玩支付宝"（账面记账,不在资产页）
+    tuzai = shops["兔仔电玩"]
+    assert tuzai["storeAlipayWallet"]["name"] == "兔仔电玩支付宝"
+    assert tuzai["storeAlipayWallet"]["type"] == WalletType.TAOBAO.value
 
 
 def test_each_shop_has_five_taobao_wallets_in_db(client, tmp_path):
@@ -71,11 +83,12 @@ def test_each_shop_has_five_taobao_wallets_in_db(client, tmp_path):
         shops = db.scalars(select(TaobaoShop)).all()
         assert len(shops) == 3
         for shop in shops:
+            # 5 个店铺钱包：支付宝支付在途/微信支付在途/聚合冻结/聚合可提现/银行卡
             taobao_wallets = db.scalars(
                 select(Wallet).where(
                     Wallet.parent_id.is_(None),
                     Wallet.type == WalletType.TAOBAO.value,
-                    Wallet.name.like(f"{shop.name}%"),
+                    Wallet.name.like(f"{shop.name} %"),
                 )
             ).all()
             assert len(taobao_wallets) == 5
@@ -87,9 +100,6 @@ def test_each_shop_has_five_taobao_wallets_in_db(client, tmp_path):
 def test_ensure_default_taobao_wallets_is_idempotent(client):
     db = database.SessionLocal()
     try:
-        before_shops = db.scalar(
-            select(Wallet).where(Wallet.type == WalletType.TAOBAO.value)
-        )
         before_taobao_count = len(
             db.scalars(select(Wallet).where(Wallet.type == WalletType.TAOBAO.value)).all()
         )
@@ -104,8 +114,56 @@ def test_ensure_default_taobao_wallets_is_idempotent(client):
         )
         after_shop_count = len(db.scalars(select(TaobaoShop)).all())
 
-        assert before_taobao_count == after_taobao_count == 15  # 3 shops * 5 wallets
+        # 3 shops * 5 wallets + 兔仔电玩支付宝(type=TAOBAO) = 16
+        assert before_taobao_count == after_taobao_count == 16
         assert before_shop_count == after_shop_count == 3
+    finally:
+        db.close()
+
+
+def test_tuzai_store_alipay_is_not_in_asset_tree(client):
+    """兔仔的店铺支付宝是 type=TAOBAO,不应出现在 GET /wallets/assets 树中。"""
+    response = client.get("/wallets/assets")
+    assert response.status_code == 200
+    assets = response.json()
+
+    def collect_names(nodes: list) -> set[str]:
+        names: set[str] = set()
+        for node in nodes:
+            names.add(node["name"])
+            children = node.get("children") or []
+            names |= collect_names(children)
+        return names
+
+    all_names = collect_names(assets)
+    assert "兔仔电玩支付宝" not in all_names
+
+
+def test_taobao_wallet_names_use_renamed_suffixes(client):
+    """钱包名称使用新的后缀：支付宝支付在途 / 微信支付在途。"""
+    db = database.SessionLocal()
+    try:
+        names = {
+            w.name
+            for w in db.scalars(
+                select(Wallet).where(
+                    Wallet.parent_id.is_(None),
+                    Wallet.type == WalletType.TAOBAO.value,
+                )
+            ).all()
+        }
+        # 新后缀必须存在
+        assert "丙火电玩 支付宝支付在途" in names
+        assert "丙火电玩 微信支付在途" in names
+        assert "兔仔电玩 支付宝支付在途" in names
+        assert "小小电玩 微信支付在途" in names
+        # 旧后缀不应再出现
+        for old_name in (
+            "丙火电玩 支付宝在途",
+            "丙火电玩 微信在途",
+            "兔仔电玩 支付宝在途",
+        ):
+            assert old_name not in names
     finally:
         db.close()
 


### PR DESCRIPTION
## 关联 Issue
Closes #72

## 改动说明

### 1. TaobaoShop 字段重命名 + NOT NULL
- `payment_wallet_id` → `store_alipay_wallet_id`（语义：店铺支付宝钱包），改 NOT NULL
- relationship `payment_wallet` → `store_alipay_wallet`

### 2. 新增 "兔仔电玩支付宝" 钱包（type=TAOBAO 顶级）
- `ensure_default_taobao_wallets` 中：兔仔的 `store_alipay_wallet_id` 指向新建的 type=TAOBAO 顶级钱包，账面记账，不在 `GET /wallets/assets` 树中可见
- 丙火/小小继续指向资产支付宝下的子钱包（行为不变）

### 3. 钱包重命名
- `"{shop} 支付宝在途"` → `"{shop} 支付宝支付在途"`
- `"{shop} 微信在途"` → `"{shop} 微信支付在途"`

### 4. _resolve_target_wallet 矩阵更新
| 支付方式 | 系统状态 | 入哪 |
|---|---|---|
| alipay | shipped_unconfirmed | unconfirmed_alipay |
| alipay | received | **store_alipay_wallet（A/B 统一,不再分流到 bank_card）** |
| wechat | shipped_unconfirmed | unconfirmed_wechat |
| wechat | received | aggregator_frozen |
| any | closed | None |

### 5. Excel 导入店铺名校验
- `import_qianniu_workbook` 第一遍解析所有数据行,校验"店铺名称"列 == 上传 `shop.name`
- 任何一行不匹配（含空字符串）→ 抛 `TaobaoImportError("Excel 包含其他店铺数据：{names}，请上传匹配 {shop.name} 的 Excel")` → 路由翻译为 400 整体回滚

### 6. transfer-to-asset → transfer-to-store-alipay
- 端点 path 改名 `POST /taobao/shops/{id}/transfer-to-store-alipay`
- 移除"兔仔禁用"，兔仔也能调（实现仍是 bank_card debit + store_alipay credit；对兔仔等于"银行卡 → 兔仔电玩支付宝"账面记账）

### 7. Pydantic Schema
- `TaobaoShopOut.payment_wallet`(可空) → `store_alipay_wallet`(必填)
- `TaobaoShopWalletOut` 新增 `type` 字段（前端区分 ASSET_RMB 子钱包 vs TAOBAO 钱包）

### 8. 数据库
按指示直接删 `finance.db` 重建,lifespan 启动后按新规则建结构

## 测试改造与新增

- 改写 `tests/test_taobao_shops_api.py`：
  - 兔仔的 `storeAlipayWallet` 不再 null,指向 type=TAOBAO 钱包"兔仔电玩支付宝"
  - 钱包总数 15 → 16（兔仔多 1 个 type=TAOBAO 顶级钱包）
  - 新增 `test_tuzai_store_alipay_is_not_in_asset_tree`：兔仔店铺支付宝不在资产树
  - 新增 `test_taobao_wallet_names_use_renamed_suffixes`：钱包名重命名后幂等
- 改写 `tests/test_taobao_import_api.py`：
  - B 类店铺 alipay/received 进 `store_alipay_wallet`（不再 bank_card）
  - 全部样本行店铺名"丙火网络" → "丙火电玩"以匹配 shop.name
  - 新增 `test_import_400_when_row_shop_name_mismatched`：行内店铺名不一致 → 400 + 信息含两个店铺名 + DB 零变化
  - 新增 `test_import_400_when_row_shop_name_empty`：空店铺名也视为不匹配
- 改写 `tests/test_taobao_flow_api.py`：
  - `transfer-to-store-alipay`：丙火/兔仔均成功
  - 兔仔成功用例：bank_card debit + store_alipay credit

## 自测
- [x] `python -m pytest tests/ -v` 全部通过（115 passed）
- [x] 验收标准已逐条满足

---
> 由 ropz 实现，请 PM 审查