### PR TITLE
[PR] [FEAT-F12] 淘宝页同步后端契约修正

### DIFF
--- a/frontend/components/taobao-page.tsx
+++ b/frontend/components/taobao-page.tsx
@@ -6,7 +6,6 @@ import {
   Banknote,
   CheckCircle2,
   FileSpreadsheet,
-  Info,
   ListOrdered,
   Loader2,
   RefreshCcw,
@@ -14,7 +13,7 @@ import {
   Wallet,
   X
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -23,7 +22,7 @@ import {
   getTaobaoWalletTransactions,
   importTaobaoExcel,
   releaseAggregator,
-  transferTaobaoToAsset,
+  transferTaobaoToStoreAlipay,
   withdrawTaobao
 } from "@/lib/api";
 import { formatMoney } from "@/lib/money";
@@ -63,14 +62,14 @@ function getWalletRows(shop: TaobaoShop): WalletRowDef[] {
   return [
     {
       kind: "unconfirmed-alipay",
-      label: "支付宝在途",
+      label: "支付宝支付在途",
       wallet: shop.unconfirmedAlipay,
       icon: <Wallet className="h-4 w-4 text-muted-foreground" aria-hidden="true" />,
       tone: "neutral"
     },
     {
       kind: "unconfirmed-wechat",
-      label: "微信在途",
+      label: "微信支付在途",
       wallet: shop.unconfirmedWechat,
       icon: <Wallet className="h-4 w-4 text-muted-foreground" aria-hidden="true" />,
       tone: "neutral"
@@ -267,14 +266,23 @@ function WithdrawModal({ shop, onClose }: { shop: TaobaoShop; onClose: () => voi
 }
 
 // ---------------------------------------------------------------------------
-// 转资产支付宝（仅丙火/小小）
+// 转店铺支付宝（3 店铺都可调；兔仔为账面记账，成功后 inline 提示"已记账"）
 // ---------------------------------------------------------------------------
 
-function TransferToAssetModal({ shop, onClose }: { shop: TaobaoShop; onClose: () => void }) {
+function TransferToStoreAlipayModal({
+  shop,
+  onClose,
+  onBookkeepingSuccess
+}: {
+  shop: TaobaoShop;
+  onClose: () => void;
+  onBookkeepingSuccess: (message: string) => void;
+}) {
   const queryClient = useQueryClient();
   const [amount, setAmount] = useState("");
   const [remark, setRemark] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const isBookkeeping = shop.storeAlipayWallet.type === "TAOBAO";
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -286,7 +294,7 @@ function TransferToAssetModal({ shop, onClose }: { shop: TaobaoShop; onClose: ()
         }
         amountValue = amount;
       }
-      return transferTaobaoToAsset(shop.id, {
+      return transferTaobaoToStoreAlipay(shop.id, {
         amount: amountValue,
         remark: remark.trim() === "" ? undefined : remark.trim()
       });
@@ -296,6 +304,9 @@ function TransferToAssetModal({ shop, onClose }: { shop: TaobaoShop; onClose: ()
       await queryClient.invalidateQueries({ queryKey: ["taobao-wallet-transactions", shop.id] });
       await queryClient.invalidateQueries({ queryKey: ["asset-wallets"] });
       await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+      if (isBookkeeping) {
+        onBookkeepingSuccess(`${shop.name}：已记账（实际钱不在手中）`);
+      }
       onClose();
     },
     onError: (err) => {
@@ -303,7 +314,7 @@ function TransferToAssetModal({ shop, onClose }: { shop: TaobaoShop; onClose: ()
     }
   });
 
-  const targetName = shop.paymentWallet?.name ?? "资产支付宝";
+  const targetName = shop.storeAlipayWallet.name;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
@@ -312,6 +323,12 @@ function TransferToAssetModal({ shop, onClose }: { shop: TaobaoShop; onClose: ()
           <CardTitle>
             转账到 {targetName} · {shop.name}
           </CardTitle>
+          {isBookkeeping ? (
+            <div className="mt-2 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 p-2 text-xs text-amber-700">
+              <Badge tone="warning">账面记账</Badge>
+              <span>本店铺为兔仔，转账仅做账面记录，实际钱不在我手。</span>
+            </div>
+          ) : null}
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
@@ -516,20 +533,18 @@ function ReportRow({
 // ---------------------------------------------------------------------------
 
 function WalletRow({
-  shop,
   row,
   onShowTransactions,
   onWithdraw,
-  onTransferToAsset,
+  onTransferToStoreAlipay,
   releasing,
   releaseReport,
   onRelease
 }: {
-  shop: TaobaoShop;
   row: WalletRowDef;
   onShowTransactions: (wallet: TaobaoShopWallet, label: string) => void;
   onWithdraw: () => void;
-  onTransferToAsset: () => void;
+  onTransferToStoreAlipay: () => void;
   releasing: boolean;
   releaseReport: TaobaoReleaseReport | null;
   onRelease: () => void;
@@ -537,8 +552,6 @@ function WalletRow({
   const isBankCard = row.kind === "bank-card";
   const isFrozen = row.kind === "aggregator-frozen";
   const isAvailable = row.kind === "aggregator-available";
-  const showTransferToAsset = isBankCard && shop.paymentWallet !== null;
-  const showRabbitNote = isBankCard && shop.paymentWallet === null;
 
   const balanceColor =
     row.tone === "available"
@@ -553,15 +566,7 @@ function WalletRow({
     <div className="flex flex-col gap-2 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="flex items-center gap-2">
         {row.icon}
-        <div>
-          <div className="text-sm font-medium">{row.label}</div>
-          {showRabbitNote ? (
-            <div className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
-              <Info className="h-3 w-3" aria-hidden="true" />
-              账面记账，钱不在我手
-            </div>
-          ) : null}
-        </div>
+        <div className="text-sm font-medium">{row.label}</div>
       </div>
       <div className="flex items-center justify-between gap-3 sm:justify-end">
         <div className={cn("tabular-nums text-base font-semibold", balanceColor)}>
@@ -595,10 +600,10 @@ function WalletRow({
               提现
             </Button>
           ) : null}
-          {showTransferToAsset ? (
-            <Button variant="outline" size="sm" onClick={onTransferToAsset}>
+          {isBankCard ? (
+            <Button variant="outline" size="sm" onClick={onTransferToStoreAlipay}>
               <ArrowRightLeft className="h-3.5 w-3.5" aria-hidden="true" />
-              转资产支付宝
+              转店铺支付宝
             </Button>
           ) : null}
           <Button
@@ -623,13 +628,13 @@ function ShopCard({
   shop,
   onShowTransactions,
   onWithdraw,
-  onTransferToAsset,
+  onTransferToStoreAlipay,
   onImport
 }: {
   shop: TaobaoShop;
   onShowTransactions: (wallet: TaobaoShopWallet, label: string) => void;
   onWithdraw: () => void;
-  onTransferToAsset: () => void;
+  onTransferToStoreAlipay: () => void;
   onImport: () => void;
 }) {
   const queryClient = useQueryClient();
@@ -651,19 +656,17 @@ function ShopCard({
   });
 
   const rows = getWalletRows(shop);
-  const paymentLabel =
-    shop.paymentWallet === null
-      ? "无（钱止于银行卡）"
-      : `${shop.paymentWallet.name}（余额 ${formatMoney(shop.paymentWallet.balanceMinor, "CNY")}）`;
+  const isBookkeeping = shop.storeAlipayWallet.type === "TAOBAO";
 
   return (
     <Card className="border">
       <CardHeader>
         <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <div>
+          <div className="min-w-0 flex-1">
             <CardTitle className="text-lg">{shop.name}</CardTitle>
-            <div className="mt-1 text-xs text-muted-foreground">
-              关联资产支付宝：{paymentLabel}
+            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+              <span>店铺支付宝：{shop.storeAlipayWallet.name}</span>
+              {isBookkeeping ? <Badge tone="warning">账面</Badge> : null}
             </div>
             {shop.remark ? (
               <div className="mt-1 text-xs text-muted-foreground">{shop.remark}</div>
@@ -676,15 +679,62 @@ function ShopCard({
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        <div
+          className={cn(
+            "flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center sm:justify-between",
+            isBookkeeping
+              ? "border-amber-200 bg-amber-50/60"
+              : "border-emerald-200 bg-emerald-50/60"
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Wallet
+              className={cn(
+                "h-4 w-4",
+                isBookkeeping ? "text-amber-700" : "text-emerald-700"
+              )}
+              aria-hidden="true"
+            />
+            <div>
+              <div className="flex items-center gap-1.5 text-sm font-medium">
+                <span>店铺支付宝</span>
+                {isBookkeeping ? <Badge tone="warning">账面记账</Badge> : null}
+              </div>
+              <div className="mt-0.5 text-xs text-muted-foreground">
+                {shop.storeAlipayWallet.name}
+                {isBookkeeping ? "（钱不在我手）" : ""}
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 sm:justify-end">
+            <div
+              className={cn(
+                "tabular-nums text-xl font-bold",
+                isBookkeeping ? "text-amber-700" : "text-emerald-700"
+              )}
+            >
+              {formatMoney(shop.storeAlipayWallet.balanceMinor, "CNY")}
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                onShowTransactions(shop.storeAlipayWallet, "店铺支付宝")
+              }
+            >
+              <ListOrdered className="h-3.5 w-3.5" aria-hidden="true" />
+              流水
+            </Button>
+          </div>
+        </div>
         <div className="divide-y divide-border rounded-md border border-border">
           {rows.map((row) => (
             <WalletRow
               key={row.kind}
-              shop={shop}
               row={row}
               onShowTransactions={onShowTransactions}
               onWithdraw={onWithdraw}
-              onTransferToAsset={onTransferToAsset}
+              onTransferToStoreAlipay={onTransferToStoreAlipay}
               releasing={releaseMutation.isPending}
               releaseReport={releaseReport}
               onRelease={() => releaseMutation.mutate()}
@@ -749,6 +799,14 @@ export function TaobaoPage() {
     wallet: TaobaoShopWallet;
     label: string;
   } | null>(null);
+  const [bookkeepingToast, setBookkeepingToast] = useState<string | null>(null);
+
+  // 兔仔账面记账成功 toast：4 秒自动消失
+  useEffect(() => {
+    if (bookkeepingToast === null) return;
+    const timer = window.setTimeout(() => setBookkeepingToast(null), 4000);
+    return () => window.clearTimeout(timer);
+  }, [bookkeepingToast]);
 
   return (
     <div className="space-y-5">
@@ -756,8 +814,8 @@ export function TaobaoPage() {
         <div>
           <h2 className="text-2xl font-semibold tracking-normal">淘宝店铺</h2>
           <p className="mt-1 text-sm text-muted-foreground">
-            3 店铺 × 5 钱包：支付宝在途 / 微信在途 / 聚合冻结 / 聚合可提现 / 银行卡。导入千牛 Excel
-            自动入账，T+7 解冻；银行卡余额可提回资产支付宝（兔仔账面记账除外）。
+            3 店铺 × 5 钱包：支付宝支付在途 / 微信支付在途 / 聚合冻结 / 聚合可提现 / 银行卡。导入千牛
+            Excel 自动入账，T+7 解冻；银行卡余额可转入店铺支付宝（兔仔为账面记账）。
           </p>
         </div>
         <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
@@ -782,7 +840,7 @@ export function TaobaoPage() {
                 setTransactionsTarget({ shop, wallet, label })
               }
               onWithdraw={() => setWithdrawShop(shop)}
-              onTransferToAsset={() => setTransferShop(shop)}
+              onTransferToStoreAlipay={() => setTransferShop(shop)}
               onImport={() => setImportShop(shop)}
             />
           ))}
@@ -793,7 +851,11 @@ export function TaobaoPage() {
         <WithdrawModal shop={withdrawShop} onClose={() => setWithdrawShop(null)} />
       ) : null}
       {transferShop ? (
-        <TransferToAssetModal shop={transferShop} onClose={() => setTransferShop(null)} />
+        <TransferToStoreAlipayModal
+          shop={transferShop}
+          onClose={() => setTransferShop(null)}
+          onBookkeepingSuccess={(message) => setBookkeepingToast(message)}
+        />
       ) : null}
       {importShop ? (
         <ImportExcelModal shop={importShop} onClose={() => setImportShop(null)} />
@@ -805,6 +867,24 @@ export function TaobaoPage() {
           walletLabel={transactionsTarget.label}
           onClose={() => setTransactionsTarget(null)}
         />
+      ) : null}
+
+      {bookkeepingToast ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-6 right-6 z-50 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 shadow-lg"
+        >
+          <Badge tone="warning">账面</Badge>
+          <div>{bookkeepingToast}</div>
+          <button
+            onClick={() => setBookkeepingToast(null)}
+            className="ml-2 text-amber-700/70 hover:text-amber-900"
+            aria-label="关闭提示"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
       ) : null}
     </div>
   );

--- a/frontend/components/ui/badge.tsx
+++ b/frontend/components/ui/badge.tsx
@@ -1,13 +1,14 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-type BadgeTone = "neutral" | "success" | "danger" | "transfer";
+type BadgeTone = "neutral" | "success" | "danger" | "transfer" | "warning";
 
 const tones: Record<BadgeTone, string> = {
   neutral: "border-border bg-muted text-muted-foreground",
   success: "border-emerald-200 bg-emerald-50 text-emerald-700",
   danger: "border-red-200 bg-red-50 text-red-700",
-  transfer: "border-blue-200 bg-blue-50 text-blue-700"
+  transfer: "border-blue-200 bg-blue-50 text-blue-700",
+  warning: "border-amber-200 bg-amber-50 text-amber-700"
 };
 
 export function Badge({

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   AssetTransaction,
   Currency,
   DashboardData,
+  StoreAlipayType,
   TaiwanSummary,
   TaiwanTransaction,
   TaiwanWallet,
@@ -29,6 +30,7 @@ import type {
   TaobaoReleaseReport,
   TaobaoShop,
   TaobaoShopWallet,
+  TaobaoStoreAlipayWallet,
   TaobaoWalletTransaction,
   Vendor,
   VendorTransaction,
@@ -466,20 +468,21 @@ export async function getXboxSummary(): Promise<XboxSummary> {
 }
 
 // ---------------------------------------------------------------------------
-// Taobao（PR #65/#67/#69）—— 3 店铺 × 5 钱包 + paymentWallet 可空 + Excel 导入
+// Taobao（PR #65/#67/#69/#73）—— 3 店铺 × 5 钱包 + storeAlipayWallet 必填带 type + Excel 导入
 // ---------------------------------------------------------------------------
 
 type TaobaoShopWalletResponse = {
   id: string | number;
   name: string;
   balance: string | number;
+  type?: string;
 };
 
 type TaobaoShopResponse = {
   id: string | number;
   name: string;
-  paymentWallet?: TaobaoShopWalletResponse | null;
-  payment_wallet?: TaobaoShopWalletResponse | null;
+  storeAlipayWallet?: TaobaoShopWalletResponse;
+  store_alipay_wallet?: TaobaoShopWalletResponse;
   unconfirmedAlipay?: TaobaoShopWalletResponse;
   unconfirmed_alipay?: TaobaoShopWalletResponse;
   unconfirmedWechat?: TaobaoShopWalletResponse;
@@ -582,22 +585,42 @@ function normalizeTaobaoShopWallet(wallet: TaobaoShopWalletResponse): TaobaoShop
   };
 }
 
+function normalizeStoreAlipayType(rawType: string | undefined): StoreAlipayType {
+  // 后端返回大写 WalletType 枚举值，淘宝店铺支付宝只可能是 ASSET_RMB（丙火/小小）或 TAOBAO（兔仔）
+  const upper = (rawType ?? "").toUpperCase();
+  return upper === "TAOBAO" ? "TAOBAO" : "ASSET_RMB";
+}
+
+function normalizeStoreAlipayWallet(wallet: TaobaoShopWalletResponse): TaobaoStoreAlipayWallet {
+  return {
+    ...normalizeTaobaoShopWallet(wallet),
+    type: normalizeStoreAlipayType(wallet.type)
+  };
+}
+
 function normalizeTaobaoShop(shop: TaobaoShopResponse): TaobaoShop {
-  const paymentWallet = shop.paymentWallet ?? shop.payment_wallet ?? null;
+  const storeAlipayWallet = shop.storeAlipayWallet ?? shop.store_alipay_wallet;
   const unconfirmedAlipay = shop.unconfirmedAlipay ?? shop.unconfirmed_alipay;
   const unconfirmedWechat = shop.unconfirmedWechat ?? shop.unconfirmed_wechat;
   const aggregatorFrozen = shop.aggregatorFrozen ?? shop.aggregator_frozen;
   const aggregatorAvailable = shop.aggregatorAvailable ?? shop.aggregator_available;
   const bankCard = shop.bankCard ?? shop.bank_card;
 
-  if (!unconfirmedAlipay || !unconfirmedWechat || !aggregatorFrozen || !aggregatorAvailable || !bankCard) {
+  if (
+    !storeAlipayWallet ||
+    !unconfirmedAlipay ||
+    !unconfirmedWechat ||
+    !aggregatorFrozen ||
+    !aggregatorAvailable ||
+    !bankCard
+  ) {
     throw new Error("淘宝店铺响应字段不完整");
   }
 
   return {
     id: String(shop.id),
     name: shop.name,
-    paymentWallet: paymentWallet ? normalizeTaobaoShopWallet(paymentWallet) : null,
+    storeAlipayWallet: normalizeStoreAlipayWallet(storeAlipayWallet),
     unconfirmedAlipay: normalizeTaobaoShopWallet(unconfirmedAlipay),
     unconfirmedWechat: normalizeTaobaoShopWallet(unconfirmedWechat),
     aggregatorFrozen: normalizeTaobaoShopWallet(aggregatorFrozen),
@@ -737,7 +760,7 @@ export async function withdrawTaobao(
   return normalizeFlowReport(data);
 }
 
-export async function transferTaobaoToAsset(
+export async function transferTaobaoToStoreAlipay(
   shopId: string,
   payload: { amount?: string; remark?: string }
 ): Promise<TaobaoFlowReport> {
@@ -749,7 +772,7 @@ export async function transferTaobaoToAsset(
     body.remark = payload.remark;
   }
   const data = (await postJson(
-    `/api/taobao/shops/${shopId}/transfer-to-asset`,
+    `/api/taobao/shops/${shopId}/transfer-to-store-alipay`,
     body
   )) as TaobaoFlowReportResponse;
   return normalizeFlowReport(data);

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -402,16 +402,16 @@ export const mockXboxSummary: XboxSummary = {
 };
 
 // ---------------------------------------------------------------------------
-// Taobao mock（API 失败时回退）—— 3 店铺 × 5 钱包 + 兔仔无 paymentWallet
+// Taobao mock（API 失败时回退）—— PR #73 后：storeAlipayWallet 必填带 type
 // ---------------------------------------------------------------------------
 
 export const mockTaobaoShops: TaobaoShop[] = [
   {
     id: "1",
     name: "丙火电玩",
-    paymentWallet: { id: "3", name: "丙火网络支付宝", balanceMinor: 0 },
-    unconfirmedAlipay: { id: "12", name: "丙火电玩 支付宝在途", balanceMinor: 18_400_00 },
-    unconfirmedWechat: { id: "13", name: "丙火电玩 微信在途", balanceMinor: 6_280_00 },
+    storeAlipayWallet: { id: "3", name: "丙火网络支付宝", balanceMinor: 0, type: "ASSET_RMB" },
+    unconfirmedAlipay: { id: "12", name: "丙火电玩 支付宝支付在途", balanceMinor: 18_400_00 },
+    unconfirmedWechat: { id: "13", name: "丙火电玩 微信支付在途", balanceMinor: 6_280_00 },
     aggregatorFrozen: { id: "14", name: "丙火电玩 聚合支付·冻结中", balanceMinor: 42_500_00 },
     aggregatorAvailable: { id: "15", name: "丙火电玩 聚合支付·可提现", balanceMinor: 12_350_00 },
     bankCard: { id: "16", name: "丙火电玩 银行卡", balanceMinor: 80_000_00 },
@@ -421,9 +421,9 @@ export const mockTaobaoShops: TaobaoShop[] = [
   {
     id: "2",
     name: "兔仔电玩",
-    paymentWallet: null,
-    unconfirmedAlipay: { id: "17", name: "兔仔电玩 支付宝在途", balanceMinor: 5_200_00 },
-    unconfirmedWechat: { id: "18", name: "兔仔电玩 微信在途", balanceMinor: 1_800_00 },
+    storeAlipayWallet: { id: "22", name: "兔仔电玩支付宝", balanceMinor: 0, type: "TAOBAO" },
+    unconfirmedAlipay: { id: "17", name: "兔仔电玩 支付宝支付在途", balanceMinor: 5_200_00 },
+    unconfirmedWechat: { id: "18", name: "兔仔电玩 微信支付在途", balanceMinor: 1_800_00 },
     aggregatorFrozen: { id: "19", name: "兔仔电玩 聚合支付·冻结中", balanceMinor: 22_000_00 },
     aggregatorAvailable: { id: "20", name: "兔仔电玩 聚合支付·可提现", balanceMinor: 4_500_00 },
     bankCard: { id: "21", name: "兔仔电玩 银行卡", balanceMinor: 30_000_00 },
@@ -433,12 +433,12 @@ export const mockTaobaoShops: TaobaoShop[] = [
   {
     id: "3",
     name: "小小电玩",
-    paymentWallet: { id: "11", name: "小小电玩支付宝", balanceMinor: 0 },
-    unconfirmedAlipay: { id: "22", name: "小小电玩 支付宝在途", balanceMinor: 9_300_00 },
-    unconfirmedWechat: { id: "23", name: "小小电玩 微信在途", balanceMinor: 3_500_00 },
-    aggregatorFrozen: { id: "24", name: "小小电玩 聚合支付·冻结中", balanceMinor: 28_000_00 },
-    aggregatorAvailable: { id: "25", name: "小小电玩 聚合支付·可提现", balanceMinor: 7_200_00 },
-    bankCard: { id: "26", name: "小小电玩 银行卡", balanceMinor: 50_000_00 },
+    storeAlipayWallet: { id: "11", name: "小小电玩支付宝", balanceMinor: 0, type: "ASSET_RMB" },
+    unconfirmedAlipay: { id: "23", name: "小小电玩 支付宝支付在途", balanceMinor: 9_300_00 },
+    unconfirmedWechat: { id: "24", name: "小小电玩 微信支付在途", balanceMinor: 3_500_00 },
+    aggregatorFrozen: { id: "25", name: "小小电玩 聚合支付·冻结中", balanceMinor: 28_000_00 },
+    aggregatorAvailable: { id: "26", name: "小小电玩 聚合支付·可提现", balanceMinor: 7_200_00 },
+    bankCard: { id: "27", name: "小小电玩 银行卡", balanceMinor: 50_000_00 },
     remark: null,
     createdAt: "2026-05-05T11:17:14"
   }

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -108,8 +108,13 @@ export type TaiwanSummary = {
 };
 
 // ---------------------------------------------------------------------------
-// Taobao（PR #65/#67/#69 后的新结构：3 店铺 × 5 钱包 + paymentWallet 可空）
+// Taobao（PR #65/#67/#69/#73 后的新结构：3 店铺 × 5 钱包 + storeAlipayWallet 必填带 type）
 // ---------------------------------------------------------------------------
+
+// PR #73：storeAlipayWallet.type 表示该"店铺支付宝"挂在哪一类资产树
+// - "ASSET_RMB"：丙火/小小，子钱包挂在资产支付宝下，是真实金流
+// - "TAOBAO"：兔仔，子钱包挂在淘宝模块下，账面记账（钱不在我手）
+export type StoreAlipayType = "ASSET_RMB" | "TAOBAO";
 
 export type TaobaoShopWallet = {
   id: string;
@@ -117,10 +122,14 @@ export type TaobaoShopWallet = {
   balanceMinor: number;
 };
 
+export type TaobaoStoreAlipayWallet = TaobaoShopWallet & {
+  type: StoreAlipayType;
+};
+
 export type TaobaoShop = {
   id: string;
   name: string;
-  paymentWallet: TaobaoShopWallet | null;
+  storeAlipayWallet: TaobaoStoreAlipayWallet;
   unconfirmedAlipay: TaobaoShopWallet;
   unconfirmedWechat: TaobaoShopWallet;
   aggregatorFrozen: TaobaoShopWallet;


### PR DESCRIPTION
## 关联 Issue
Closes #74

## 改动说明（前端同步后端 PR #73 的 4 件契约修正）

### 1. 字段重命名 `paymentWallet` → `storeAlipayWallet`（不再可空，带 type）
- `types.ts`：新增 `StoreAlipayType = "ASSET_RMB" | "TAOBAO"` 与 `TaobaoStoreAlipayWallet`；`TaobaoShop.paymentWallet: TaobaoShopWallet | null` → `storeAlipayWallet: TaobaoStoreAlipayWallet`
- `lib/api.ts`：`normalizeTaobaoShop` 改读 `storeAlipayWallet`/`store_alipay_wallet`，新增 `normalizeStoreAlipayType()` 把后端大写 WalletType 枚举值（`ASSET_RMB` / `TAOBAO`）映射到前端的 `StoreAlipayType`。注意：Issue 描述里写的是小写 `asset_rmb`/`taobao`，但实际后端 curl 返回大写枚举值，前端按大写处理
- `lib/mock-data.ts`：3 店铺都改为带 `storeAlipayWallet` + `type` 的对象，兔仔 type=TAOBAO，丙火/小小 type=ASSET_RMB

### 2. 钱包名重命名 `支付宝/微信在途` → `支付宝/微信支付在途`
- `taobao-page.tsx` 钱包行 label
- `mock-data.ts` 钱包名
- 主页文案"3 店铺 × 5 钱包"列表

### 3. 端点重命名 `transfer-to-asset` → `transfer-to-store-alipay`
- `lib/api.ts` `transferTaobaoToAsset` → `transferTaobaoToStoreAlipay`
- 移除"仅丙火/小小有此按钮"逻辑：3 店铺都显示"转店铺支付宝"按钮（兔仔走账面记账）

### 4. Excel 上传 400 错误 inline 红框
- 既有 `importTaobaoExcel` 已解析 400 detail 抛 Error，`ImportExcelModal` `onError` 已 setError 渲染 inline 红框，无需新逻辑（验证后端"Excel 包含其他店铺数据：xxx"会从 detail 透传）

### 5. UI 重构（按 Issue 验收标准）
- **卡片头**：`关联资产支付宝：xxx` → `店铺支付宝：xxx`，兔仔加 `Badge tone="warning">账面</Badge>`
- **店铺支付宝单独突出行**：在 5 钱包行上方加一块"第 6 行"卡片，大字突出余额；兔仔背景琥珀色 + `Badge "账面记账"` + 副文案"（钱不在我手）"；丙火/小小绿色背景
- **转店铺支付宝弹窗**：兔仔进入时顶部加 `Badge "账面记账"` + 提示文案
- **兔仔成功 toast**：兔仔点确认后右下角弹 `账面 / xxx：已记账（实际钱不在手中）`，4 秒自动消失，可手动关闭
- 移除 WalletRow 旧的"showRabbitNote"内联文字（账面提示已上移到卡片头部 + 突出行）
- `Badge` 组件新增 `warning` tone（`border-amber-200 bg-amber-50 text-amber-700`）

### 6. 删除未用 import
- 删除 `Info` 图标 import（旧的 showRabbitNote 已移除）

## 自测
- [x] `npm run typecheck` 全过
- [x] `curl http://localhost:8000/taobao/shops` 返回 `storeAlipayWallet` + `type` 字段（大写枚举值），前端 `normalizeStoreAlipayType` 正确识别
- [x] `Grep paymentWallet|transferTaobaoToAsset|transfer-to-asset` 在 frontend/ 内 0 残留
- [x] mock 三店铺都改成新结构

## 视觉决策
- 兔仔账面用 amber（琥珀色）系，与 bankCard 行 amber 区分（卡片用 amber-200/50/60，行用 amber-600/700），提供视觉对比
- 丙火/小小用 emerald，强调"真实金流"
- toast 用右下角 fixed，避免遮挡卡片内容

---
> 由 broky 实现，请 PM 审查