### PR TITLE
[PR] [FEAT] 银行卡转账可选目标支付宝

### DIFF
--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -19,9 +19,11 @@ from src.models.taobao import (
     TaobaoShop,
 )
 from src.models.wallet import (
+    Currency,
     TransactionDirection,
     Wallet,
     WalletTransaction,
+    WalletType,
     credit,
     debit,
 )
@@ -101,6 +103,7 @@ class WithdrawRequest(BaseModel):
 
 
 class TransferToAssetRequest(BaseModel):
+    target_wallet_id: Optional[int] = Field(None, description="可选目标钱包 id；不传则用 shop.store_alipay_wallet 作为默认目标")
     amount: Optional[Decimal] = Field(None, gt=0)
     remark: Optional[str] = Field(None, max_length=500)
 
@@ -434,18 +437,90 @@ def transfer_bank_card_to_store_alipay(
     request: TransferToAssetRequest,
     db: Session = Depends(get_db),
 ) -> FlowReportOut:
-    """银行卡 → 店铺支付宝（A/B 类店铺均可调）。
+    """银行卡 → 目标支付宝（实际金流：银行卡 ↔ 支付宝绑定，钱不经店铺支付宝中转）。
 
-    - 丙火/小小：bank_card debit + 资产支付宝子钱包 credit（实际金流）
-    - 兔仔：bank_card debit + 兔仔电玩支付宝（type=TAOBAO）credit（账面记账）
-    - amount 不传时默认 = 银行卡当前余额
-    - 银行卡余额不足或为 0 → 400
+    body 行为：
+    - target_wallet_id 不传 → 默认目标 = shop.store_alipay_wallet（向后兼容）
+    - target_wallet_id 传 → 校验合法性后用指定目标
+
+    校验：
+    - shop / wallet 存在性
+    - amount > 0；银行卡余额足；
+    - 兔仔（store_alipay_wallet.type==TAOBAO）：传非自身 store_alipay_wallet 的 target → 400
+    - 丙火/小小（store_alipay_wallet.type==ASSET_RMB）：target 必须是 type=ASSET_RMB+currency=CNY+父钱包 name="支付宝钱包" 子钱包
+    - target 不存在 → 404；已软删 → 400；==银行卡本身 → 400；is_group → 400
     """
     shop = _get_shop_or_404(db, shop_id)
 
     bank_card = shop.bank_card_wallet
     store_alipay = shop.store_alipay_wallet
 
+    # 1. 解析目标钱包：传了 → 校验后取，没传 → 用 shop.store_alipay_wallet
+    if request.target_wallet_id is not None:
+        target_wallet = db.get(Wallet, request.target_wallet_id)
+        if target_wallet is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="目标钱包不存在",
+            )
+        if target_wallet.deleted_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="目标钱包已删除",
+            )
+        if target_wallet.id == bank_card.id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="不能转给自己",
+            )
+        if target_wallet.is_group:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="分组钱包不可作为目标",
+            )
+
+        # 兔仔约束：store_alipay_wallet.type==TAOBAO 时只能转回自身 store_alipay_wallet
+        store_type = (
+            store_alipay.type.value
+            if isinstance(store_alipay.type, WalletType)
+            else store_alipay.type
+        )
+        if store_type == WalletType.TAOBAO.value:
+            if target_wallet.id != store_alipay.id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="兔仔店铺只能转回自身店铺支付宝",
+                )
+        elif store_type == WalletType.ASSET_RMB.value:
+            # 丙火/小小约束：target 必须是 type=ASSET_RMB+currency=CNY+父钱包 name="支付宝钱包"
+            target_type = (
+                target_wallet.type.value
+                if isinstance(target_wallet.type, WalletType)
+                else target_wallet.type
+            )
+            target_currency = (
+                target_wallet.currency.value
+                if isinstance(target_wallet.currency, Currency)
+                else target_wallet.currency
+            )
+            parent_ok = False
+            if target_wallet.parent_id is not None:
+                parent = db.get(Wallet, target_wallet.parent_id)
+                if parent is not None and parent.name == "支付宝钱包":
+                    parent_ok = True
+            if (
+                target_type != WalletType.ASSET_RMB.value
+                or target_currency != Currency.CNY.value
+                or not parent_ok
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="目标必须是资产支付宝下的子钱包",
+                )
+    else:
+        target_wallet = store_alipay
+
+    # 2. 金额
     if request.amount is not None:
         amount = Decimal(str(request.amount))
     else:
@@ -457,11 +532,12 @@ def transfer_bank_card_to_store_alipay(
             detail="可转金额必须大于 0",
         )
 
-    remark = request.remark or "提现"
+    # 3. 备注：默认带目标名以便审计；CEO 可覆盖
+    remark = request.remark or f"提现 → {target_wallet.name}"
 
     try:
         debit(db, bank_card.id, amount, remark=remark)
-        credit(db, store_alipay.id, amount, remark=remark)
+        credit(db, target_wallet.id, amount, remark=remark)
         db.commit()
     except ValueError as exc:
         db.rollback()
@@ -474,13 +550,13 @@ def transfer_bank_card_to_store_alipay(
         raise
 
     db.refresh(bank_card)
-    db.refresh(store_alipay)
+    db.refresh(target_wallet)
     return FlowReportOut(
         amount=amount,
         from_wallet_id=bank_card.id,
         from_wallet_balance=Decimal(bank_card.balance),
-        to_wallet_id=store_alipay.id,
-        to_wallet_balance=Decimal(store_alipay.balance),
+        to_wallet_id=target_wallet.id,
+        to_wallet_balance=Decimal(target_wallet.balance),
         remark=remark,
     )
 

--- a/tests/test_taobao_flow_api.py
+++ b/tests/test_taobao_flow_api.py
@@ -275,7 +275,8 @@ def test_transfer_to_store_alipay_a_shop_explicit_amount(client):
     assert Decimal(payload["amount"]) == Decimal("300")
     assert Decimal(payload["fromWalletBalance"]) == Decimal("200.000000")
     assert Decimal(payload["toWalletBalance"]) == Decimal("300.000000")
-    assert payload["remark"] == "提现"
+    # default remark 现在带目标名
+    assert payload["remark"] == "提现 → 丙火网络支付宝"
 
     assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("200.000000")
     assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("300.000000")
@@ -355,6 +356,298 @@ def test_transfer_to_store_alipay_custom_remark(client):
     )
     assert response.status_code == 200
     assert response.json()["remark"] == "5月转资产"
+
+
+# ---------------------------------------------------------------------------
+# /transfer-to-store-alipay - target_wallet_id 扩展（issue #76）
+# ---------------------------------------------------------------------------
+
+
+def _wallet_id_by_name(name: str) -> int:
+    """按 name 取（非软删的）资产钱包 id。仅用于测试，假设 name 唯一。"""
+    db = database.SessionLocal()
+    try:
+        w = db.scalar(select(Wallet).where(Wallet.name == name, Wallet.deleted_at.is_(None)))
+        if w is None:
+            raise AssertionError(f"测试种子里找不到钱包: {name}")
+        return w.id
+    finally:
+        db.close()
+
+
+def test_transfer_default_target_for_a_shop_unchanged(client):
+    """丙火不传 target_wallet_id → 转到 shop.store_alipay_wallet（即丙火网络支付宝）。"""
+    shop = _shop_by_name("丙火电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("100"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"amount": "60"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["toWalletId"] == shop.store_alipay_wallet_id
+    # remark 默认带目标名
+    assert payload["remark"] == "提现 → 丙火网络支付宝"
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("60.000000")
+
+
+def test_transfer_default_target_for_xiaoxiao(client):
+    """小小不传 target_wallet_id → 转到 shop.store_alipay_wallet（小小电玩支付宝）。"""
+    shop = _shop_by_name("小小电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("40"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"amount": "40"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["toWalletId"] == shop.store_alipay_wallet_id
+    assert payload["remark"] == "提现 → 小小电玩支付宝"
+
+
+def test_transfer_default_target_for_tuzai(client):
+    """兔仔不传 target_wallet_id → 转到 shop.store_alipay_wallet（兔仔电玩支付宝,type=TAOBAO）。"""
+    shop = _shop_by_name("兔仔电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("25"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"amount": "25"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["toWalletId"] == shop.store_alipay_wallet_id
+    assert payload["remark"] == "提现 → 兔仔电玩支付宝"
+
+
+def test_transfer_a_shop_to_other_alipay_sub_wallet(client):
+    """丙火显式传 TOM支付宝 ID → 银行卡 debit + TOM支付宝 credit；丙火网络支付宝余额不动。"""
+    shop = _shop_by_name("丙火电玩")
+    tom_id = _wallet_id_by_name("TOM支付宝")
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("400"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    binghuo_alipay_before = _wallet_balance(shop.store_alipay_wallet_id)
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": tom_id, "amount": "150"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["toWalletId"] == tom_id
+    assert payload["remark"] == "提现 → TOM支付宝"
+    assert Decimal(payload["amount"]) == Decimal("150")
+
+    # 银行卡 debit、TOM credit
+    assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("250.000000")
+    assert _wallet_balance(tom_id) == Decimal("150.000000")
+    # 丙火网络支付宝（store_alipay_wallet）余额不动
+    assert _wallet_balance(shop.store_alipay_wallet_id) == binghuo_alipay_before
+
+
+def test_transfer_a_shop_to_boss_alipay(client):
+    """丙火显式传 BOSS支付宝 ID → 银行卡 debit + BOSS支付宝 credit。"""
+    shop = _shop_by_name("丙火电玩")
+    boss_id = _wallet_id_by_name("BOSS支付宝")
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("200"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": boss_id, "amount": "75"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["toWalletId"] == boss_id
+    assert payload["remark"] == "提现 → BOSS支付宝"
+    assert _wallet_balance(boss_id) == Decimal("75.000000")
+
+
+def test_transfer_a_shop_400_when_target_not_alipay_sub_wallet(client):
+    """小小传 RMB 顶级钱包（非支付宝子钱包）→ 400。"""
+    shop = _shop_by_name("小小电玩")
+    rmb_root_id = _wallet_id_by_name("RMB钱包")
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("100"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": rmb_root_id, "amount": "10"},
+    )
+    # RMB 顶级是 is_group=True → 先被 is_group 校验拦下；测试只关 400 即可
+    assert response.status_code == 400
+
+
+def test_transfer_a_shop_400_when_target_is_non_alipay_leaf(client):
+    """小小传非支付宝子钱包的资产叶子（如跳舞姬微信，在 微信钱包 group 下）→ 400。"""
+    shop = _shop_by_name("小小电玩")
+    wechat_leaf_id = _wallet_id_by_name("跳舞姬微信")
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("50"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": wechat_leaf_id, "amount": "5"},
+    )
+    assert response.status_code == 400
+    assert "资产支付宝" in response.json()["detail"]
+
+
+def test_transfer_b_shop_400_when_target_not_self_store_alipay(client):
+    """兔仔传非自身 store_alipay_wallet 的 target → 400 兔仔店铺只能转回自身店铺支付宝。"""
+    shop = _shop_by_name("兔仔电玩")
+    tom_id = _wallet_id_by_name("TOM支付宝")
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("60"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": tom_id, "amount": "10"},
+    )
+    assert response.status_code == 400
+    assert "兔仔" in response.json()["detail"]
+
+
+def test_transfer_b_shop_explicit_self_store_alipay_succeeds(client):
+    """兔仔显式传自身 store_alipay_wallet_id → 200，与默认行为一致。"""
+    shop = _shop_by_name("兔仔电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("33"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": shop.store_alipay_wallet_id, "amount": "33"},
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["toWalletId"] == shop.store_alipay_wallet_id
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("33.000000")
+
+
+def test_transfer_400_when_target_soft_deleted(client):
+    """目标钱包已软删 → 400。"""
+    shop = _shop_by_name("丙火电玩")
+    tom_id = _wallet_id_by_name("TOM支付宝")
+
+    # 先软删 TOM支付宝
+    db = database.SessionLocal()
+    try:
+        tom = db.get(Wallet, tom_id)
+        tom.deleted_at = datetime.now(timezone.utc)
+        credit(db, shop.bank_card_wallet_id, Decimal("100"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": tom_id, "amount": "10"},
+    )
+    assert response.status_code == 400
+    assert "已删除" in response.json()["detail"]
+
+
+def test_transfer_400_when_target_is_group(client):
+    """目标是分组（如 RMB 顶级 group）→ 400 分组钱包不可作为目标。"""
+    shop = _shop_by_name("丙火电玩")
+    rmb_root_id = _wallet_id_by_name("RMB钱包")
+
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("20"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": rmb_root_id, "amount": "10"},
+    )
+    assert response.status_code == 400
+    assert "分组" in response.json()["detail"]
+
+
+def test_transfer_404_when_target_wallet_not_found(client):
+    """目标 wallet_id 不存在 → 404。"""
+    shop = _shop_by_name("丙火电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("10"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": 999999, "amount": "1"},
+    )
+    assert response.status_code == 404
+    assert "目标钱包不存在" in response.json()["detail"]
+
+
+def test_transfer_400_when_target_equals_bank_card(client):
+    """目标 == 银行卡本身 → 400 不能转给自己。"""
+    shop = _shop_by_name("丙火电玩")
+    db = database.SessionLocal()
+    try:
+        credit(db, shop.bank_card_wallet_id, Decimal("10"), remark="种子")
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.post(
+        f"/taobao/shops/{shop.id}/transfer-to-store-alipay",
+        json={"target_wallet_id": shop.bank_card_wallet_id, "amount": "1"},
+    )
+    assert response.status_code == 400
+    assert "不能转给自己" in response.json()["detail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 关联 Issue

Closes #76

## 变更摘要

扩展 `POST /taobao/shops/{id}/transfer-to-store-alipay`：body 新增可选 `target_wallet_id`，把"银行卡 → 店铺支付宝"的固定路径改为"银行卡 → CEO 选定的目标支付宝"，与真实金流（银行卡 ↔ 支付宝绑定，钱不经店铺支付宝中转）对齐。端点名保留以避免再次破坏前端契约。

## 关键改动

### 1. `src/routers/taobao.py`

- `TransferToAssetRequest` 新增 `target_wallet_id: Optional[int] = None`
- handler `transfer_bank_card_to_store_alipay` 重写校验链：
  1. `target_wallet_id` 不传 → 用 `shop.store_alipay_wallet`（向后兼容；丙火/小小/兔仔默认走这条）
  2. 通用校验：不存在 → 404；已软删 → 400；==银行卡本身 → 400 `不能转给自己`；`is_group=True` → 400 `分组钱包不可作为目标`
  3. **兔仔约束**（store_alipay_wallet.type==TAOBAO）：传非自身 store_alipay_wallet 的 target → 400 `兔仔店铺只能转回自身店铺支付宝`
  4. **丙火/小小约束**（store_alipay_wallet.type==ASSET_RMB）：target 必须 type=ASSET_RMB + currency=CNY + 父钱包 name=`支付宝钱包` → 否则 400 `目标必须是资产支付宝下的子钱包`
- 默认 remark 改为 `提现 → {target_wallet.name}`（带目标名以便审计），CEO 可覆盖

### 2. `tests/test_taobao_flow_api.py`

新增 13 个测试覆盖各分支：
- 不传 target → 默认（丙火/小小/兔仔各一）
- 丙火显式 TOM支付宝 / BOSS支付宝 → 银行卡 debit + 目标 credit、丙火网络支付宝不动
- 小小传 RMB 顶级（is_group） → 400
- 小小传跳舞姬微信（非支付宝子钱包）→ 400 提示资产支付宝
- 兔仔传 TOM支付宝 → 400 提示兔仔
- 兔仔显式自身 store_alipay_wallet → 200
- 目标软删 → 400；目标 is_group → 400；目标不存在 → 404；目标==银行卡 → 400
- 同步更新 `test_transfer_to_store_alipay_a_shop_explicit_amount` 的默认 remark 断言为 `提现 → 丙火网络支付宝`

## 测试

- 模块测试：`tests/test_taobao_flow_api.py` 39/39 通过
- 全模块回归：`python -m pytest tests/ -v` → 128/128 通过

## 兼容性

- 不传 `target_wallet_id` 时行为与改造前完全一致（仅默认 remark 文案从 `提现` 改为 `提现 → {目标 name}`）
- 端点名、URL、HTTP 方法、响应 schema 全部保持