### PR TITLE
[PR] [FEAT-F13] 转账目标选择 UI

### DIFF
--- a/frontend/components/assets-page.tsx
+++ b/frontend/components/assets-page.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowDownLeft,
+  ArrowLeftRight,
   ArrowUpRight,
   ChevronDown,
   ChevronRight,
@@ -24,7 +25,8 @@ import {
   deleteAssetWallet,
   getAssetTransactions,
   getAssetWallets,
-  patchAssetWallet
+  patchAssetWallet,
+  transferAssetWallets
 } from "@/lib/api";
 import { formatMoney, sumMinor } from "@/lib/money";
 import { cn } from "@/lib/utils";
@@ -66,6 +68,27 @@ function collectGroupIds(wallets: WalletBalance[]): string[] {
 
 function isTopLevelWallet(wallet: WalletBalance): boolean {
   return !wallet.parentId && wallet.isGroup;
+}
+
+// 找资产支付宝下子钱包：递归 wallets 树，找 type === "ASSET_RMB" 且父钱包 name === "支付宝钱包" 的叶子节点
+function findAlipaySubWallets(wallets: WalletBalance[]): WalletBalance[] {
+  const result: WalletBalance[] = [];
+  const visit = (nodes: WalletBalance[], parentName: string | null) => {
+    for (const node of nodes) {
+      if (
+        !node.isGroup &&
+        node.type === "ASSET_RMB" &&
+        parentName === "支付宝钱包"
+      ) {
+        result.push(node);
+      }
+      if (node.children && node.children.length > 0) {
+        visit(node.children, node.name);
+      }
+    }
+  };
+  visit(wallets, null);
+  return result;
 }
 
 function AssetSummaryCards({ wallets, currency }: { wallets: WalletBalance[]; currency: Currency }) {
@@ -416,26 +439,164 @@ function DeleteWalletModal({
   );
 }
 
+function AssetTransferModal({
+  fromWallet,
+  candidates,
+  onClose
+}: {
+  fromWallet: WalletBalance;
+  candidates: WalletBalance[];
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const otherCandidates = candidates.filter((wallet) => wallet.id !== fromWallet.id);
+  const [toWalletId, setToWalletId] = useState<string>(otherCandidates[0]?.id ?? "");
+  const [amount, setAmount] = useState("");
+  const [remark, setRemark] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!toWalletId) {
+        throw new Error("请选择目标钱包");
+      }
+      if (toWalletId === fromWallet.id) {
+        throw new Error("不能转账给自己");
+      }
+      const num = Number.parseFloat(amount);
+      if (!amount || Number.isNaN(num) || num <= 0) {
+        throw new Error("金额必须大于 0");
+      }
+      // 校验：金额不超过 from 余额（以 minor 单位换算粗校验，最终以后端为准）
+      const amountMinor = Math.round(num * 100);
+      if (amountMinor > fromWallet.balanceMinor) {
+        throw new Error("金额超过当前钱包余额");
+      }
+      return transferAssetWallets(
+        fromWallet.id,
+        toWalletId,
+        amount,
+        remark.trim() === "" ? undefined : remark.trim()
+      );
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["assets"] });
+      await queryClient.invalidateQueries({ queryKey: ["asset-wallets"] });
+      await queryClient.invalidateQueries({ queryKey: ["asset-transactions"] });
+      await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
+      onClose();
+    },
+    onError: (err) => {
+      setError(err instanceof Error ? err.message : "转账失败");
+    }
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>支付宝子钱包间转账</CardTitle>
+          <div className="mt-1 text-xs text-muted-foreground">
+            本期仅支持同币种（CNY ↔ CNY），跨币种暂不支持。
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
+            <div className="text-xs text-muted-foreground">从（不可改）</div>
+            <div className="mt-1 flex items-center justify-between gap-3">
+              <div className="font-medium">{fromWallet.name}</div>
+              <div className="tabular-nums text-base font-semibold">
+                {formatMoney(fromWallet.balanceMinor, "CNY")}
+              </div>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">目标钱包</div>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm tabular-nums outline-none focus:ring-2 focus:ring-primary"
+              value={toWalletId}
+              onChange={(event) => setToWalletId(event.target.value)}
+              disabled={otherCandidates.length === 0}
+            >
+              {otherCandidates.length === 0 ? (
+                <option value="">无其他支付宝子钱包</option>
+              ) : (
+                otherCandidates.map((wallet) => (
+                  <option key={wallet.id} value={wallet.id}>
+                    {`${wallet.name}（${formatMoney(wallet.balanceMinor, "CNY")}）`}
+                  </option>
+                ))
+              )}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">金额（CNY）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={amount}
+              onChange={(event) => setAmount(event.target.value)}
+              placeholder="转账金额"
+              type="number"
+              min="0"
+              step="0.01"
+              autoFocus
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填）</div>
+            <textarea
+              className="min-h-[60px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+              placeholder="备注"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button
+              onClick={() => mutation.mutate()}
+              disabled={mutation.isPending || otherCandidates.length === 0}
+            >
+              {mutation.isPending ? "提交中..." : "确认转账"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 function AssetTree({
   wallets,
   expandedIds,
   selectedWalletId,
+  alipaySubWalletIds,
   onToggle,
   onSelectLeaf,
   onSelectGroup,
   onShowTransactions,
   onEdit,
-  onDelete
+  onDelete,
+  onTransfer
 }: {
   wallets: WalletBalance[];
   expandedIds: Set<string>;
   selectedWalletId: string;
+  alipaySubWalletIds: Set<string>;
   onToggle: (walletId: string) => void;
   onSelectLeaf: (walletId: string, mode?: MovementMode) => void;
   onSelectGroup: (walletId: string) => void;
   onShowTransactions: (walletId: string) => void;
   onEdit: (wallet: WalletBalance) => void;
   onDelete: (wallet: WalletBalance) => void;
+  onTransfer: (wallet: WalletBalance) => void;
 }) {
   const renderNode = (wallet: WalletBalance, depth: number) => {
     const hasChildren = Boolean(wallet.children?.length);
@@ -504,6 +665,12 @@ function AssetTree({
                       <List className="h-4 w-4" />
                       流水
                     </Button>
+                    {alipaySubWalletIds.has(wallet.id) ? (
+                      <Button variant="ghost" size="sm" onClick={() => onTransfer(wallet)}>
+                        <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+                        转账
+                      </Button>
+                    ) : null}
                   </>
                 )}
                 <Button variant="outline" size="sm" onClick={() => onEdit(wallet)}>
@@ -600,6 +767,7 @@ export function AssetsPage() {
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [editTarget, setEditTarget] = useState<WalletBalance | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<WalletBalance | null>(null);
+  const [transferTarget, setTransferTarget] = useState<WalletBalance | null>(null);
   const { data: wallets = [], isFetching, refetch } = useQuery({
     queryKey: ["assets"],
     queryFn: getAssetWallets
@@ -611,6 +779,11 @@ export function AssetsPage() {
   );
   const leafWallets = useMemo(() => flattenLeafWallets(scopedWallets), [scopedWallets]);
   const groupWallets = useMemo(() => flattenGroupWallets(scopedWallets), [scopedWallets]);
+  const alipaySubWallets = useMemo(() => findAlipaySubWallets(wallets), [wallets]);
+  const alipaySubWalletIds = useMemo(
+    () => new Set(alipaySubWallets.map((wallet) => wallet.id)),
+    [alipaySubWallets]
+  );
 
   useEffect(() => {
     const groupIds = collectGroupIds(scopedWallets);
@@ -675,6 +848,7 @@ export function AssetsPage() {
         wallets={scopedWallets}
         expandedIds={expandedIds}
         selectedWalletId={selectedWallet?.id ?? ""}
+        alipaySubWalletIds={alipaySubWalletIds}
         onToggle={(walletId) =>
           setExpandedIds((current) => {
             const next = new Set(current);
@@ -699,6 +873,7 @@ export function AssetsPage() {
         }}
         onEdit={setEditTarget}
         onDelete={setDeleteTarget}
+        onTransfer={setTransferTarget}
       />
       <AssetActions
         leafWallets={leafWallets}
@@ -716,6 +891,13 @@ export function AssetsPage() {
       ) : null}
       {deleteTarget ? (
         <DeleteWalletModal wallet={deleteTarget} onClose={() => setDeleteTarget(null)} />
+      ) : null}
+      {transferTarget ? (
+        <AssetTransferModal
+          fromWallet={transferTarget}
+          candidates={alipaySubWallets}
+          onClose={() => setTransferTarget(null)}
+        />
       ) : null}
     </div>
   );

--- a/frontend/components/taobao-page.tsx
+++ b/frontend/components/taobao-page.tsx
@@ -18,6 +18,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
+  getAssetWallets,
   getTaobaoShops,
   getTaobaoWalletTransactions,
   importTaobaoExcel,
@@ -31,8 +32,30 @@ import type {
   TaobaoImportReport,
   TaobaoReleaseReport,
   TaobaoShop,
-  TaobaoShopWallet
+  TaobaoShopWallet,
+  WalletBalance
 } from "@/types";
+
+// 找资产支付宝下子钱包：递归 wallets 树，找 type === "ASSET_RMB" 且父钱包 name === "支付宝钱包" 的叶子节点
+function findAlipaySubWallets(wallets: WalletBalance[]): WalletBalance[] {
+  const result: WalletBalance[] = [];
+  const visit = (nodes: WalletBalance[], parentName: string | null) => {
+    for (const node of nodes) {
+      if (
+        !node.isGroup &&
+        node.type === "ASSET_RMB" &&
+        parentName === "支付宝钱包"
+      ) {
+        result.push(node);
+      }
+      if (node.children && node.children.length > 0) {
+        visit(node.children, node.name);
+      }
+    }
+  };
+  visit(wallets, null);
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -284,6 +307,27 @@ function TransferToStoreAlipayModal({
   const [error, setError] = useState<string | null>(null);
   const isBookkeeping = shop.storeAlipayWallet.type === "TAOBAO";
 
+  // 仅丙火/小小（type === "ASSET_RMB"）需要加目标下拉，从资产支付宝下子钱包加载
+  const { data: assetWallets = [] } = useQuery({
+    queryKey: ["asset-wallets"],
+    queryFn: getAssetWallets,
+    enabled: !isBookkeeping
+  });
+
+  const alipaySubWallets = !isBookkeeping ? findAlipaySubWallets(assetWallets) : [];
+
+  // 默认选当前 storeAlipayWallet
+  const [targetWalletId, setTargetWalletId] = useState<string>(shop.storeAlipayWallet.id);
+
+  // 资产钱包加载完成后，确认默认目标存在；如不存在则 fallback 到第一个候选
+  useEffect(() => {
+    if (isBookkeeping) return;
+    if (alipaySubWallets.length === 0) return;
+    if (!alipaySubWallets.find((w) => w.id === targetWalletId)) {
+      setTargetWalletId(alipaySubWallets[0].id);
+    }
+  }, [alipaySubWallets, isBookkeeping, targetWalletId]);
+
   const mutation = useMutation({
     mutationFn: async () => {
       let amountValue: string | undefined;
@@ -294,15 +338,22 @@ function TransferToStoreAlipayModal({
         }
         amountValue = amount;
       }
-      return transferTaobaoToStoreAlipay(shop.id, {
+      // 兔仔：不传 target_wallet_id（后端走 shop.storeAlipayWallet）
+      // 丙火/小小：传选中的 targetWalletId
+      const payload: { amount?: string; remark?: string; targetWalletId?: string } = {
         amount: amountValue,
         remark: remark.trim() === "" ? undefined : remark.trim()
-      });
+      };
+      if (!isBookkeeping && targetWalletId) {
+        payload.targetWalletId = targetWalletId;
+      }
+      return transferTaobaoToStoreAlipay(shop.id, payload);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["taobao-shops"] });
       await queryClient.invalidateQueries({ queryKey: ["taobao-wallet-transactions", shop.id] });
       await queryClient.invalidateQueries({ queryKey: ["asset-wallets"] });
+      await queryClient.invalidateQueries({ queryKey: ["assets"] });
       await queryClient.invalidateQueries({ queryKey: ["dashboard"] });
       if (isBookkeeping) {
         onBookkeepingSuccess(`${shop.name}：已记账（实际钱不在手中）`);
@@ -314,7 +365,9 @@ function TransferToStoreAlipayModal({
     }
   });
 
-  const targetName = shop.storeAlipayWallet.name;
+  const targetName = isBookkeeping
+    ? shop.storeAlipayWallet.name
+    : alipaySubWallets.find((w) => w.id === targetWalletId)?.name ?? shop.storeAlipayWallet.name;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
@@ -337,6 +390,34 @@ function TransferToStoreAlipayModal({
               {formatMoney(shop.bankCard.balanceMinor, "CNY")}
             </div>
           </div>
+          {isBookkeeping ? (
+            <div className="rounded-md border border-amber-200 bg-amber-50/60 p-3 text-sm">
+              <div className="text-xs text-muted-foreground">将转入</div>
+              <div className="mt-1 text-sm font-medium text-amber-700">
+                {shop.storeAlipayWallet.name}（账面）
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <div className="text-sm text-muted-foreground">目标支付宝</div>
+              <select
+                className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm tabular-nums outline-none focus:ring-2 focus:ring-primary"
+                value={targetWalletId}
+                onChange={(event) => setTargetWalletId(event.target.value)}
+                disabled={alipaySubWallets.length === 0}
+              >
+                {alipaySubWallets.length === 0 ? (
+                  <option value="">加载中...</option>
+                ) : (
+                  alipaySubWallets.map((wallet) => (
+                    <option key={wallet.id} value={wallet.id}>
+                      {`${wallet.name}（${formatMoney(wallet.balanceMinor, "CNY")}）`}
+                    </option>
+                  ))
+                )}
+              </select>
+            </div>
+          )}
           <div className="space-y-1">
             <div className="text-sm text-muted-foreground">金额（CNY，留空 = 全部余额）</div>
             <input

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -762,7 +762,7 @@ export async function withdrawTaobao(
 
 export async function transferTaobaoToStoreAlipay(
   shopId: string,
-  payload: { amount?: string; remark?: string }
+  payload: { amount?: string; remark?: string; targetWalletId?: string }
 ): Promise<TaobaoFlowReport> {
   const body: Record<string, unknown> = {};
   if (payload.amount) {
@@ -771,11 +771,31 @@ export async function transferTaobaoToStoreAlipay(
   if (payload.remark) {
     body.remark = payload.remark;
   }
+  if (payload.targetWalletId) {
+    body.target_wallet_id = Number(payload.targetWalletId);
+  }
   const data = (await postJson(
     `/api/taobao/shops/${shopId}/transfer-to-store-alipay`,
     body
   )) as TaobaoFlowReportResponse;
   return normalizeFlowReport(data);
+}
+
+export async function transferAssetWallets(
+  fromWalletId: string,
+  toWalletId: string,
+  amount: string,
+  remark?: string
+): Promise<unknown> {
+  const body: Record<string, unknown> = {
+    from_wallet_id: Number(fromWalletId),
+    to_wallet_id: Number(toWalletId),
+    amount
+  };
+  if (remark) {
+    body.remark = remark;
+  }
+  return postJson("/api/wallets/transfer", body);
 }
 
 export async function getTaobaoOrders(


### PR DESCRIPTION
## Summary
- 淘宝页「转店铺支付宝」弹窗：丙火/小小加目标支付宝下拉（4 个候选：丙火网络/TOM/BOSS/小小电玩），默认选当前 storeAlipayWallet，选项显示余额；兔仔保持现状（无下拉，固定走账面）
- 资产钱包页：仅在支付宝子钱包行（type=ASSET_RMB 且父=支付宝钱包）显示「转账」按钮，避免按钮泛滥；其他钱包不显示
- AssetTransferModal：from 不可改 + to 下拉（其他支付宝子钱包）+ amount + remark，调通用 `/wallets/transfer`
- `lib/api.ts`：`transferTaobaoToStoreAlipay` 接受可选 `targetWalletId`；新增 `transferAssetWallets(fromId, toId, amount, remark?)`

## 后端契约
- POST `/taobao/shops/{id}/transfer-to-store-alipay` body 加可选 `target_wallet_id`（PR #77 已上线）
- POST `/wallets/transfer` body `{from_wallet_id, to_wallet_id, amount, exchange_rate?, remark?}`（PR #54 已上线）

本期只支持同币种 CNY ↔ CNY，无 `exchange_rate`（后端默认 1.0）；跨币种暂不支持，弹窗 header 已文案告知。

## Test plan
- [x] `npm run typecheck` 全过（tsc --noEmit）
- [x] curl `http://localhost:8000/wallets/assets` 验证支付宝下 4 个子钱包（id=3 丙火网络/4 TOM/5 BOSS/11 小小电玩，全部 ASSET_RMB，父=支付宝钱包 id=2）
- [ ] 手测：丙火店铺转店铺支付宝 → 下拉默认丙火网络支付宝，可切换到 TOM/BOSS/小小，显示余额
- [ ] 手测：兔仔店铺转店铺支付宝 → 仍然无下拉，显示「将转入：兔仔电玩支付宝（账面）」
- [ ] 手测：资产页 RMB tab → 4 个支付宝子钱包行有「转账」按钮，其他钱包（微信子钱包/USDT 子钱包）无按钮
- [ ] 手测：点「转账」 → 弹窗 from 不可改，to 下拉 3 个候选（排除自己），提交后两钱包余额原子变化

Closes #78

Generated with [Claude Code](https://claude.com/claude-code)