### PR TITLE
[PR] [FEAT] GET /taobao/shops 加待解冻字段

### DIFF
--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -1,7 +1,6 @@
 """Taobao shop API routes."""
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from decimal import Decimal
 from io import BytesIO
 from typing import Optional
@@ -20,7 +19,6 @@ from src.models.taobao import (
 )
 from src.models.wallet import (
     Currency,
-    TransactionDirection,
     Wallet,
     WalletTransaction,
     WalletType,
@@ -33,6 +31,7 @@ from src.services.taobao_import import (
     TaobaoImportError,
     import_qianniu_workbook,
 )
+from src.services.taobao_maturity import calculate_pending_maturity
 
 
 router = APIRouter(prefix="/taobao", tags=["taobao"])
@@ -61,6 +60,8 @@ class TaobaoShopOut(BaseModel):
     aggregator_frozen: TaobaoShopWalletOut
     aggregator_available: TaobaoShopWalletOut
     bank_card: TaobaoShopWalletOut
+    aggregator_matured_amount: Decimal
+    aggregator_matured_count: int
     remark: Optional[str] = None
     created_at: str
 
@@ -164,7 +165,10 @@ def _serialize_wallet(wallet: Wallet) -> TaobaoShopWalletOut:
     )
 
 
-def serialize_shop(shop: TaobaoShop) -> TaobaoShopOut:
+def serialize_shop(shop: TaobaoShop, db: Session) -> TaobaoShopOut:
+    matured_amount, matured_count = calculate_pending_maturity(
+        db, shop.aggregator_frozen_wallet_id
+    )
     return TaobaoShopOut(
         id=shop.id,
         name=shop.name,
@@ -174,6 +178,8 @@ def serialize_shop(shop: TaobaoShop) -> TaobaoShopOut:
         aggregator_frozen=_serialize_wallet(shop.aggregator_frozen_wallet),
         aggregator_available=_serialize_wallet(shop.aggregator_available_wallet),
         bank_card=_serialize_wallet(shop.bank_card_wallet),
+        aggregator_matured_amount=matured_amount,
+        aggregator_matured_count=matured_count,
         remark=shop.remark,
         created_at=shop.created_at.isoformat() if shop.created_at else "",
     )
@@ -258,7 +264,7 @@ def _shop_wallet_ids(shop: TaobaoShop) -> set[int]:
 
 @router.get("/shops", response_model=list[TaobaoShopOut], response_model_by_alias=True)
 def get_shops(db: Session = Depends(get_db)) -> list[TaobaoShopOut]:
-    return [serialize_shop(shop) for shop in list_taobao_shops(db)]
+    return [serialize_shop(shop, db) for shop in list_taobao_shops(db)]
 
 
 @router.post(
@@ -321,41 +327,16 @@ def release_matured_aggregator(
 ) -> ReleaseReportOut:
     """一键解冻所有到期聚合冻结流水。
 
-    - 查询 ``aggregator_frozen_wallet`` 上 ``mature_at <= now()`` 的所有 in 流水
-    - 仅解冻"仍有效"的流水（其 id 仍是某 TaobaoOrder 的 bookkeeping_tx_id）
-      —— 防御性，避免把已被 reconcile 撤销的旧流水重复解冻
+    - 通过 ``calculate_pending_maturity`` 算出可解冻金额与笔数
+      （查询条件、防御性过滤都集中在 helper 内，与 GET /taobao/shops 共享）
     - 把累计金额从 frozen debit、credit 到 available
     - 单一事务；无到期流水返回 200 + matured_count=0
     """
     shop = _get_shop_or_404(db, shop_id)
-    now = datetime.now(timezone.utc)
 
-    matured_txs = list(
-        db.scalars(
-            select(WalletTransaction)
-            .where(
-                WalletTransaction.wallet_id == shop.aggregator_frozen_wallet_id,
-                WalletTransaction.direction == TransactionDirection.IN.value,
-                WalletTransaction.mature_at.is_not(None),
-                WalletTransaction.mature_at <= now,
-            )
-            .order_by(WalletTransaction.id)
-        )
+    matured_amount, matured_count = calculate_pending_maturity(
+        db, shop.aggregator_frozen_wallet_id
     )
-
-    # 防御：只解冻仍被某 order.bookkeeping_tx_id 引用的（说明状态未变化、未被撤）
-    if matured_txs:
-        tx_ids = [tx.id for tx in matured_txs]
-        active_tx_ids = set(
-            db.scalars(
-                select(TaobaoOrder.bookkeeping_tx_id)
-                .where(TaobaoOrder.bookkeeping_tx_id.in_(tx_ids))
-            )
-        )
-        matured_txs = [tx for tx in matured_txs if tx.id in active_tx_ids]
-
-    matured_count = len(matured_txs)
-    matured_amount = sum((Decimal(tx.amount) for tx in matured_txs), Decimal("0"))
 
     if matured_count > 0:
         try:

--- a/src/services/taobao_maturity.py
+++ b/src/services/taobao_maturity.py
@@ -1,0 +1,67 @@
+"""聚合冻结钱包"待解冻"统计 helper。
+
+抽出 ``calculate_pending_maturity``，让 GET /taobao/shops 与
+POST /taobao/shops/{id}/aggregator/release 共享同一份计算逻辑，
+避免规则漂移。
+
+判定规则（与 release 端点完全一致）：
+  - ``WalletTransaction.wallet_id == frozen_wallet_id``
+  - ``direction == "in"``
+  - ``mature_at IS NOT NULL AND mature_at <= now()``
+  - 防御性二次过滤：仅保留仍被某 ``TaobaoOrder.bookkeeping_tx_id``
+    引用的流水（剔除已被 reconcile 撤销的孤儿流水）
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.taobao import TaobaoOrder
+from src.models.wallet import TransactionDirection, WalletTransaction
+
+
+def calculate_pending_maturity(
+    session: Session,
+    frozen_wallet_id: int,
+) -> tuple[Decimal, int]:
+    """统计某聚合冻结钱包当前可解冻的累计金额与笔数。
+
+    返回 ``(amount, count)``。无可解冻流水时返回 ``(Decimal("0"), 0)``。
+    """
+    now = datetime.now(timezone.utc)
+
+    matured_txs = list(
+        session.scalars(
+            select(WalletTransaction)
+            .where(
+                WalletTransaction.wallet_id == frozen_wallet_id,
+                WalletTransaction.direction == TransactionDirection.IN.value,
+                WalletTransaction.mature_at.is_not(None),
+                WalletTransaction.mature_at <= now,
+            )
+            .order_by(WalletTransaction.id)
+        )
+    )
+
+    if not matured_txs:
+        return Decimal("0"), 0
+
+    # 防御：只算仍被某 order.bookkeeping_tx_id 引用的（说明流水未被 reconcile 撤）
+    tx_ids = [tx.id for tx in matured_txs]
+    active_tx_ids = set(
+        session.scalars(
+            select(TaobaoOrder.bookkeeping_tx_id).where(
+                TaobaoOrder.bookkeeping_tx_id.in_(tx_ids)
+            )
+        )
+    )
+    active_txs = [tx for tx in matured_txs if tx.id in active_tx_ids]
+
+    if not active_txs:
+        return Decimal("0"), 0
+
+    amount = sum((Decimal(tx.amount) for tx in active_txs), Decimal("0"))
+    return amount, len(active_txs)

--- a/tests/test_taobao_shops_api.py
+++ b/tests/test_taobao_shops_api.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
@@ -6,8 +7,13 @@ from sqlalchemy import select
 
 from src import database
 from src.main import app
-from src.models.taobao import TaobaoShop
-from src.models.wallet import Currency, Wallet, WalletType
+from src.models.taobao import (
+    TaobaoOrder,
+    TaobaoOrderPaymentMethod,
+    TaobaoOrderStatus,
+    TaobaoShop,
+)
+from src.models.wallet import Currency, Wallet, WalletType, credit
 from src.services.assets import ensure_default_asset_wallets
 from src.services.taobao import ensure_default_taobao_wallets
 
@@ -179,3 +185,127 @@ def test_xiaoxiao_alipay_visible_in_asset_list(client):
     sub_names = {child["name"] for child in alipay_group["children"]}
     assert "小小电玩支付宝" in sub_names
     assert "丙火网络支付宝" in sub_names
+
+
+# ---------------------------------------------------------------------------
+# aggregatorMaturedAmount / aggregatorMaturedCount 字段（Issue #80）
+# ---------------------------------------------------------------------------
+
+
+def _seed_frozen_tx(
+    shop: TaobaoShop,
+    amount: Decimal,
+    mature_at: datetime,
+    *,
+    bind_to_order: bool = True,
+    order_number: str | None = None,
+) -> int:
+    """直接往 aggregator_frozen 钱包注入一笔 in 流水（可选绑定到 order）。
+
+    返回插入的 WalletTransaction.id。
+    """
+    db = database.SessionLocal()
+    try:
+        tx = credit(
+            db,
+            shop.aggregator_frozen_wallet_id,
+            amount,
+            remark="测试种子",
+            mature_at=mature_at,
+        )
+        if bind_to_order:
+            order = TaobaoOrder(
+                shop_id=shop.id,
+                order_number=order_number or f"SEED_{tx.id}",
+                payment_method=TaobaoOrderPaymentMethod.WECHAT.value,
+                amount=amount,
+                status=TaobaoOrderStatus.RECEIVED.value,
+                bookkeeping_wallet_id=shop.aggregator_frozen_wallet_id,
+                bookkeeping_tx_id=tx.id,
+            )
+            db.add(order)
+        db.commit()
+        return tx.id
+    finally:
+        db.close()
+
+
+def _shop_by_name(name: str) -> TaobaoShop:
+    db = database.SessionLocal()
+    try:
+        return db.scalar(select(TaobaoShop).where(TaobaoShop.name == name))
+    finally:
+        db.close()
+
+
+def test_shops_default_pending_maturity_is_zero(client):
+    """默认（无任何流水）→ 每个店铺 aggregatorMaturedAmount=0, aggregatorMaturedCount=0。"""
+    response = client.get("/taobao/shops")
+    assert response.status_code == 200, response.text
+    shops = response.json()
+
+    assert len(shops) == 3
+    for shop in shops:
+        assert "aggregatorMaturedAmount" in shop
+        assert "aggregatorMaturedCount" in shop
+        assert Decimal(shop["aggregatorMaturedAmount"]) == Decimal("0")
+        assert shop["aggregatorMaturedCount"] == 0
+
+
+def test_shops_pending_maturity_excludes_unmatured(client):
+    """1 笔已到期 + 1 笔未到期 → 仅已到期那笔被计入。"""
+    shop = _shop_by_name("丙火电玩")
+    now = datetime.now(timezone.utc)
+
+    _seed_frozen_tx(shop, Decimal("120"), now - timedelta(hours=1), order_number="MATURED_X")
+    _seed_frozen_tx(shop, Decimal("50"), now + timedelta(days=2), order_number="FUTURE_X")
+
+    response = client.get("/taobao/shops")
+    assert response.status_code == 200, response.text
+    shops = {s["name"]: s for s in response.json()}
+
+    binghuo = shops["丙火电玩"]
+    assert Decimal(binghuo["aggregatorMaturedAmount"]) == Decimal("120")
+    assert binghuo["aggregatorMaturedCount"] == 1
+
+    # 其他店铺无任何流水，依然为 0
+    assert Decimal(shops["兔仔电玩"]["aggregatorMaturedAmount"]) == Decimal("0")
+    assert shops["兔仔电玩"]["aggregatorMaturedCount"] == 0
+    assert Decimal(shops["小小电玩"]["aggregatorMaturedAmount"]) == Decimal("0")
+    assert shops["小小电玩"]["aggregatorMaturedCount"] == 0
+
+
+def test_shops_pending_maturity_aggregates_three_matured(client):
+    """3 笔已到期 → 累计金额 = 三笔之和，count=3。"""
+    shop = _shop_by_name("小小电玩")
+    now = datetime.now(timezone.utc)
+
+    _seed_frozen_tx(shop, Decimal("33.33"), now - timedelta(days=2), order_number="A")
+    _seed_frozen_tx(shop, Decimal("66.67"), now - timedelta(hours=3), order_number="B")
+    _seed_frozen_tx(shop, Decimal("100"), now - timedelta(minutes=5), order_number="C")
+
+    response = client.get("/taobao/shops")
+    assert response.status_code == 200, response.text
+    shops = {s["name"]: s for s in response.json()}
+
+    xiaoxiao = shops["小小电玩"]
+    assert Decimal(xiaoxiao["aggregatorMaturedAmount"]) == Decimal("200")
+    assert xiaoxiao["aggregatorMaturedCount"] == 3
+
+
+def test_shops_pending_maturity_skips_orphan_tx(client):
+    """1 笔已到期 + 1 笔已被 reconcile 撤销（无 order 引用）→ 已撤的不计。"""
+    shop = _shop_by_name("兔仔电玩")
+    now = datetime.now(timezone.utc)
+
+    _seed_frozen_tx(shop, Decimal("88"), now - timedelta(hours=2), order_number="ALIVE")
+    # 第二笔不绑订单，模拟已被 reconcile 撤
+    _seed_frozen_tx(shop, Decimal("999"), now - timedelta(hours=2), bind_to_order=False)
+
+    response = client.get("/taobao/shops")
+    assert response.status_code == 200, response.text
+    shops = {s["name"]: s for s in response.json()}
+
+    tuzai = shops["兔仔电玩"]
+    assert Decimal(tuzai["aggregatorMaturedAmount"]) == Decimal("88")
+    assert tuzai["aggregatorMaturedCount"] == 1


### PR DESCRIPTION
## 关联 Issue
Closes #80

## 改动说明

### 抽 helper 共享算法（src/services/taobao_maturity.py 新建）
- `calculate_pending_maturity(session, frozen_wallet_id) -> tuple[Decimal, int]`
- 单一来源：`mature_at <= now()` + `direction == in` + 防御性"仅保留仍被某 `TaobaoOrder.bookkeeping_tx_id` 引用的流水"过滤
- 无可解冻流水返回 `(Decimal("0"), 0)`

### release 端点复用 helper（src/routers/taobao.py）
- `POST /taobao/shops/{id}/aggregator/release` 删掉原内嵌的 `select(WalletTransaction)` + 过滤逻辑，直接调 `calculate_pending_maturity`
- 行为完全等价（响应 `maturedCount / maturedAmount / frozenBalanceAfter / availableBalanceAfter` 不变）
- 顺手清掉路由不再用到的 `datetime / timezone / TransactionDirection` 三个 import

### GET /taobao/shops 加两字段（src/routers/taobao.py）
- `TaobaoShopOut` 新增 **平级**字段：
  - `aggregatorMaturedAmount: Decimal`
  - `aggregatorMaturedCount: int`
- 不嵌套在 `aggregatorFrozen` 钱包结构内 —— 与 release 端点响应字段同名同位，前端复用方便
- `serialize_shop(shop, db)` 给每个店铺调一次 helper（3 店铺 = 3 次 SQL，符合 Issue 性能注释）

### 测试新增 4 个（tests/test_taobao_shops_api.py）
1. `test_shops_default_pending_maturity_is_zero` — 默认无流水 → 3 店铺均 amount=0/count=0
2. `test_shops_pending_maturity_excludes_unmatured` — 1 已到期 + 1 未到期 → 仅算已到期
3. `test_shops_pending_maturity_aggregates_three_matured` — 3 笔已到期 → 累加金额 + count=3
4. `test_shops_pending_maturity_skips_orphan_tx` — 1 已到期绑订单 + 1 已到期无订单（模拟 reconcile 撤销）→ 孤儿不计入

## 自测
- [x] `python -m pytest tests/test_taobao_shops_api.py -v` 11/11 通过（4 新 + 7 原）
- [x] `python -m pytest tests/ -v` 全模块回归 132/132 通过
- [x] 验收标准 4 个测试场景全覆盖
- [x] release 端点行为不变（test_taobao_flow_api.py 4 个 release 测试保持绿）

## 关键技术决定
- **helper 落 services/ 而非 router 内**：业务规则跨端点复用 + 与现有 `services/` 分层风格一致；router 只负责拼装/响应
- **字段平级而非嵌套**：与 release 响应字段命名对齐（都叫 `maturedAmount/maturedCount`），前端拿到 `shop.aggregatorMaturedAmount` 直接用；嵌进 `aggregatorFrozen` 反而和"钱包元数据"语义混淆
- **复用 release 测试的种子函数模式**：把 `_seed_frozen_tx` 内联在 `test_taobao_shops_api.py`，不跨测试文件 import，保持测试模块自包含

## 遗留点
- 性能：每个店铺都跑 1 次 SQL，3 店铺 3 次（Issue 已注明可接受），未来店铺扩到几十个再考虑 join 优化
- `scripts/` 目录仍有上一波员工留下的未追踪文件（与本 PR 无关）

---
> 由 ropz 实现，请 PM 审查