### PR TITLE
[PR] [FEAT] 千牛 v2 大重构 - 14 列 + 手续费 + 自动解冻

### DIFF
--- a/src/models/taobao.py
+++ b/src/models/taobao.py
@@ -87,8 +87,17 @@ class TaobaoOrder(Base):
     payment_method: Mapped[TaobaoOrderPaymentMethod] = mapped_column(
         String(16), nullable=False
     )
+    # amount 语义：当前入账钱包的金额。在途 = gross；已确认 = net（gross - fee）
     amount: Mapped[Decimal] = mapped_column(
         Numeric(18, 6), nullable=False, default=Decimal("0")
+    )
+    # gross_amount：Excel 原始金额（已确认用 "确认收货打款金额"，在途用 "买家实付金额"）
+    gross_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 6), nullable=False, default=Decimal("0")
+    )
+    # fee_amount：仅 received 时填值（gross × 0.002，2 位 ROUND_HALF_UP）；在途为 NULL
+    fee_amount: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(18, 6), nullable=True
     )
     status: Mapped[TaobaoOrderStatus] = mapped_column(String(32), nullable=False)
     bookkeeping_wallet_id: Mapped[Optional[int]] = mapped_column(
@@ -101,6 +110,10 @@ class TaobaoOrder(Base):
         DateTime(timezone=True), nullable=True
     )
     received_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # confirmed_at：来自 Excel "确认收货时间"。微信 mature_at 计算基础。
+    confirmed_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
     last_synced_at: Mapped[datetime] = mapped_column(

--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -79,23 +79,15 @@ class TaobaoImportReportOut(BaseModel):
     skipped_no_change: int
     skipped_unpaid_or_unshipped: int
     skipped_unknown_payment: int
+    auto_released_amount: Decimal
+    auto_released_count: int
+    total_fee_amount: Decimal
     errors: list[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
 # 金流端点请求 / 响应模型
 # ---------------------------------------------------------------------------
-
-
-class ReleaseReportOut(BaseModel):
-    """聚合冻结一键解冻响应。"""
-
-    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
-
-    matured_count: int
-    matured_amount: Decimal
-    frozen_balance_after: Decimal
-    available_balance_after: Decimal
 
 
 class WithdrawRequest(BaseModel):
@@ -195,6 +187,9 @@ def _serialize_report(report: ImportReport) -> TaobaoImportReportOut:
         skipped_no_change=report.skipped_no_change,
         skipped_unpaid_or_unshipped=report.skipped_unpaid_or_unshipped,
         skipped_unknown_payment=report.skipped_unknown_payment,
+        auto_released_amount=Decimal(report.auto_released_amount),
+        auto_released_count=report.auto_released_count,
+        total_fee_amount=Decimal(report.total_fee_amount),
         errors=list(report.errors),
     )
 
@@ -314,54 +309,6 @@ def import_qianniu_excel(
         raise
 
     return _serialize_report(report)
-
-
-@router.post(
-    "/shops/{shop_id}/aggregator/release",
-    response_model=ReleaseReportOut,
-    response_model_by_alias=True,
-)
-def release_matured_aggregator(
-    shop_id: int,
-    db: Session = Depends(get_db),
-) -> ReleaseReportOut:
-    """一键解冻所有到期聚合冻结流水。
-
-    - 通过 ``calculate_pending_maturity`` 算出可解冻金额与笔数
-      （查询条件、防御性过滤都集中在 helper 内，与 GET /taobao/shops 共享）
-    - 把累计金额从 frozen debit、credit 到 available
-    - 单一事务；无到期流水返回 200 + matured_count=0
-    """
-    shop = _get_shop_or_404(db, shop_id)
-
-    matured_amount, matured_count = calculate_pending_maturity(
-        db, shop.aggregator_frozen_wallet_id
-    )
-
-    if matured_count > 0:
-        try:
-            remark = f"解冻 {matured_count} 笔到期"
-            debit(db, shop.aggregator_frozen_wallet_id, matured_amount, remark=remark)
-            credit(db, shop.aggregator_available_wallet_id, matured_amount, remark=remark)
-            db.commit()
-        except ValueError as exc:
-            db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=str(exc),
-            ) from exc
-        except Exception:
-            db.rollback()
-            raise
-
-    db.refresh(shop.aggregator_frozen_wallet)
-    db.refresh(shop.aggregator_available_wallet)
-    return ReleaseReportOut(
-        matured_count=matured_count,
-        matured_amount=matured_amount,
-        frozen_balance_after=Decimal(shop.aggregator_frozen_wallet.balance),
-        available_balance_after=Decimal(shop.aggregator_available_wallet.balance),
-    )
 
 
 @router.post(

--- a/src/services/taobao_import.py
+++ b/src/services/taobao_import.py
@@ -1,16 +1,19 @@
 """千牛 Excel 导入与订单 reconcile 业务逻辑。
 
 模块职责：
-1. 解析 .xlsx 文件 → 标准化结构化行
-2. 按 9 个字段 / 5 状态映射 / 2 支付方式 / 2 店铺类型分流入账
-3. 老订单状态变化 reconcile（撤旧流水 + 建新流水）
-4. 单一事务原子（异常由调用方 rollback）
+1. 解析 .xlsx 文件 → 标准化结构化行（v2 14 列严格表头）
+2. 按 14 个字段 / 5 状态映射 / 2 支付方式 / 2 店铺类型分流入账
+3. 0.2% 手续费规则：仅 received 时扣（gross - round(gross*0.002, 2)）
+4. 微信/received 的 mature_at 用 ``确认收货时间 + 7 天``
+5. 老订单状态变化 reconcile（撤旧流水 + 建新流水；在途→确认差额=fee 自然消失）
+6. 导入末尾自动跑解冻（与原 release_aggregator 端点逻辑一致）
+7. 单一事务原子（异常由调用方 rollback）
 """
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal
 from io import BytesIO
 from typing import BinaryIO, Optional
 
@@ -31,32 +34,41 @@ from src.models.wallet import (
     credit,
     debit,
 )
+from src.services.taobao_maturity import calculate_pending_maturity
 
 
-# 千牛导出 Excel 的标准表头（前 9 列），多 1 列、少 1 列、列名错都视为结构错
+# 千牛 v2 导出 Excel 的标准表头（14 列严格匹配，多 1 列、少 1 列、列名错都视为结构错）
 EXPECTED_HEADERS: tuple[str, ...] = (
-    "订单编号",
-    "支付单号",
-    "支付详情",
-    "买家实付金额",
-    "订单状态",
-    "订单付款时间",
-    "店铺名称",
-    "发货时间",
-    "确认收货打款金额",
+    "订单编号",          # col 0
+    "支付单号",          # col 1
+    "支付详情",          # col 2
+    "买家实付金额",      # col 3
+    "订单状态",          # col 4
+    "订单创建时间",      # col 5  (忽略,仅占位校验)
+    "订单付款时间",      # col 6
+    "宝贝种类",          # col 7  (忽略,仅占位校验)
+    "店铺名称",          # col 8
+    "卖家服务费",        # col 9  (忽略,CEO 同意以淘宝平台 0.2% 计算)
+    "退款金额",          # col 10 (忽略,仅占位校验)
+    "发货时间",          # col 11
+    "确认收货时间",      # col 12
+    "确认收货打款金额",  # col 13
 )
 
-# 千牛订单状态字面值（用 strip 后与 dict key 对齐）
+# 千牛订单状态字面值（_normalize_status 已把全角逗号统一为半角再做比较）
 QIANNIU_STATUS_PENDING_PAY = "等待买家付款"
 QIANNIU_STATUS_PAID_UNSHIPPED = "买家已付款,等待卖家发货"
-QIANNIU_STATUS_PAID_UNSHIPPED_ALT = "买家已付款，等待卖家发货"  # 全角逗号兜底
-QIANNIU_STATUS_SHIPPED_UNCONFIRMED = "卖家已发货，等待买家确认"
-QIANNIU_STATUS_SHIPPED_UNCONFIRMED_ALT = "卖家已发货,等待买家确认"  # 半角逗号兜底
+QIANNIU_STATUS_SHIPPED_UNCONFIRMED = "卖家已发货,等待买家确认"
 QIANNIU_STATUS_RECEIVED = "交易成功"
 QIANNIU_STATUS_CLOSED = "交易关闭"
 
 # 微信冻结成熟天数
 WECHAT_MATURE_DAYS = 7
+
+# 0.2% 手续费率
+FEE_RATE = Decimal("0.002")
+# 2 位精度
+TWO_PLACES = Decimal("0.01")
 
 
 class TaobaoImportError(Exception):
@@ -75,6 +87,9 @@ class ImportReport:
     skipped_no_change: int = 0
     skipped_unpaid_or_unshipped: int = 0
     skipped_unknown_payment: int = 0
+    auto_released_amount: Decimal = field(default_factory=lambda: Decimal("0"))
+    auto_released_count: int = 0
+    total_fee_amount: Decimal = field(default_factory=lambda: Decimal("0"))
     errors: list[str] = field(default_factory=list)
 
 
@@ -85,7 +100,7 @@ class ParsedRow:
     ``system_status``/``payment_method`` 为 None 表示"应跳过"（未付款 / 未知支付）。
     """
 
-    row_index: int  # Excel 行号（1-based，第 1 行表头跳过，数据从 2 起）
+    row_index: int  # Excel 行号（1-based,第 1 行表头跳过,数据从 2 起）
     order_number: str
     payment_no: str
     payment_detail_raw: str
@@ -94,6 +109,7 @@ class ParsedRow:
     paid_at: Optional[datetime]
     shop_name_in_row: str
     shipped_at: Optional[datetime]
+    confirmed_at: Optional[datetime]
     confirmed_amount: Decimal
     payment_method: Optional[TaobaoOrderPaymentMethod]
     system_status: Optional[TaobaoOrderStatus]
@@ -137,19 +153,26 @@ def _detect_payment_method(payment_detail: str) -> Optional[TaobaoOrderPaymentMe
     return None
 
 
+def _normalize_status(qianniu_status: str) -> str:
+    """归一化中文标点（半角/全角逗号统一为半角）后再做字面值比较。"""
+    if not qianniu_status:
+        return ""
+    return qianniu_status.strip().replace("，", ",")
+
+
 def _map_status(qianniu_status: str) -> tuple[Optional[TaobaoOrderStatus], bool]:
     """千牛状态 → (系统状态, is_pending_or_unshipped)。
 
     返回 (None, True)  : 等待买家付款 / 买家已付款等待发货 → 跳过且计入 unpaid_or_unshipped
     返回 (status, False): 三个会落地的状态 (shipped_unconfirmed/received/closed)
-    返回 (None, False): 完全未知状态（不应发生，作为 errors）
+    返回 (None, False): 完全未知状态（不应发生,作为 errors）
     """
-    s = qianniu_status.strip() if qianniu_status else ""
+    s = _normalize_status(qianniu_status)
     if s == QIANNIU_STATUS_PENDING_PAY:
         return None, True
-    if s in (QIANNIU_STATUS_PAID_UNSHIPPED, QIANNIU_STATUS_PAID_UNSHIPPED_ALT):
+    if s == QIANNIU_STATUS_PAID_UNSHIPPED:
         return None, True
-    if s in (QIANNIU_STATUS_SHIPPED_UNCONFIRMED, QIANNIU_STATUS_SHIPPED_UNCONFIRMED_ALT):
+    if s == QIANNIU_STATUS_SHIPPED_UNCONFIRMED:
         return TaobaoOrderStatus.SHIPPED_UNCONFIRMED, False
     if s == QIANNIU_STATUS_RECEIVED:
         return TaobaoOrderStatus.RECEIVED, False
@@ -158,12 +181,28 @@ def _map_status(qianniu_status: str) -> tuple[Optional[TaobaoOrderStatus], bool]
     return None, False  # 未知状态
 
 
+def compute_fee_and_net(gross: Decimal) -> tuple[Decimal, Decimal]:
+    """0.2% 手续费规则：fee = round(gross × 0.002, 2) ROUND_HALF_UP；net = gross - fee。
+
+    边界值（CEO 已确认）：
+        56.00 → fee=0.11 net=55.89
+        269.00 → fee=0.54 net=268.46
+        27.50 → fee=0.06 net=27.44 （0.055 → ROUND_HALF_UP → 0.06）
+        100.00 → fee=0.20 net=99.80
+    """
+    g = Decimal(gross)
+    raw_fee = g * FEE_RATE
+    fee = raw_fee.quantize(TWO_PLACES, rounding=ROUND_HALF_UP)
+    net = g - fee
+    return fee, net
+
+
 def parse_workbook(file_obj: BinaryIO) -> list[list]:
     """读取 .xlsx → 第一工作表所有行（含表头）。
 
     校验：
     1. 必须能被 openpyxl 打开（否则 TaobaoImportError）
-    2. 第 1 行（表头）前 9 列必须等于 EXPECTED_HEADERS
+    2. 第 1 行（表头）前 14 列必须等于 EXPECTED_HEADERS
     """
     try:
         wb = load_workbook(file_obj, read_only=True, data_only=True)
@@ -193,17 +232,34 @@ def parse_workbook(file_obj: BinaryIO) -> list[list]:
 
 
 def _parse_row(row_index: int, row: tuple) -> ParsedRow:
-    """单行 → ParsedRow（不做 DB 操作）。"""
-    # 取前 9 列；不够列时 IndexError 会暴露在 errors
+    """单行 → ParsedRow（不做 DB 操作）。
+
+    14 列字段映射（仅读取必要列；col 5/7/9/10 占位校验,不读）：
+        col 0  订单编号
+        col 1  支付单号
+        col 2  支付详情
+        col 3  买家实付金额
+        col 4  订单状态
+        col 6  订单付款时间
+        col 8  店铺名称
+        col 11 发货时间
+        col 12 确认收货时间
+        col 13 确认收货打款金额
+    """
     order_number = str(row[0]).strip() if row[0] is not None else ""
     payment_no = str(row[1]).strip() if row[1] is not None else ""
     payment_detail_raw = str(row[2]) if row[2] is not None else ""
     buyer_paid_amount = _to_decimal(row[3])
     qianniu_status_raw = str(row[4]).strip() if row[4] is not None else ""
-    paid_at = _to_datetime(row[5])
-    shop_name_in_row = str(row[6]).strip() if row[6] is not None else ""
-    shipped_at = _to_datetime(row[7])
-    confirmed_amount = _to_decimal(row[8])
+    # col 5 订单创建时间 -- 忽略
+    paid_at = _to_datetime(row[6])
+    # col 7 宝贝种类 -- 忽略
+    shop_name_in_row = str(row[8]).strip() if row[8] is not None else ""
+    # col 9 卖家服务费 -- 忽略（CEO 同意以平台 0.2% 计算）
+    # col 10 退款金额 -- 忽略
+    shipped_at = _to_datetime(row[11])
+    confirmed_at = _to_datetime(row[12])
+    confirmed_amount = _to_decimal(row[13])
 
     payment_method = _detect_payment_method(payment_detail_raw)
     system_status, is_pending_or_unshipped = _map_status(qianniu_status_raw)
@@ -220,6 +276,7 @@ def _parse_row(row_index: int, row: tuple) -> ParsedRow:
         paid_at=paid_at,
         shop_name_in_row=shop_name_in_row,
         shipped_at=shipped_at,
+        confirmed_at=confirmed_at,
         confirmed_amount=confirmed_amount,
         payment_method=payment_method,
         system_status=system_status,
@@ -260,8 +317,8 @@ def _resolve_target_wallet(
     return None
 
 
-def _amount_for_status(parsed: ParsedRow) -> Decimal:
-    """按状态选金额：received 用确认收货金额；shipped_unconfirmed 用买家实付。"""
+def _gross_for_status(parsed: ParsedRow) -> Decimal:
+    """按状态选 gross：received 用确认收货金额；shipped_unconfirmed 用买家实付。"""
     if parsed.system_status == TaobaoOrderStatus.RECEIVED:
         return parsed.confirmed_amount
     if parsed.system_status == TaobaoOrderStatus.SHIPPED_UNCONFIRMED:
@@ -276,14 +333,17 @@ def _credit_for_row(
     wallet_id: int,
     amount: Decimal,
 ) -> WalletTransaction:
-    """按规则 credit。微信/received 写 mature_at = received_at + 7d。"""
+    """按规则 credit。微信/received 写 mature_at = confirmed_at + 7d（兜底用 shipped_at + 7d）。
+
+    ``amount`` 已是入账钱包应入账的"当前金额"（received 是 net；shipped_unconfirmed 是 gross）。
+    """
     mature_at: Optional[datetime] = None
     if (
         parsed.payment_method == TaobaoOrderPaymentMethod.WECHAT
         and parsed.system_status == TaobaoOrderStatus.RECEIVED
     ):
-        # received_at 优先用 shipped_at（同一行的 "发货时间"），缺失则用 paid_at；都缺则 now()
-        base = parsed.shipped_at or parsed.paid_at or datetime.now()
+        # 优先用 confirmed_at（Excel "确认收货时间"），缺失时兜底用 shipped_at；都缺则 now()
+        base = parsed.confirmed_at or parsed.shipped_at or datetime.now()
         mature_at = base + timedelta(days=WECHAT_MATURE_DAYS)
     remark = f"千牛订单 #{parsed.order_number} {parsed.system_status.value}"
     return credit(
@@ -302,7 +362,7 @@ def _debit_old_tx(
 ) -> None:
     """根据 ``order.bookkeeping_tx_id`` 找老流水的 amount，从老钱包 debit 同金额。
 
-    若 bookkeeping_tx_id / wallet_id 任一缺失，跳过（视为之前未入账）。
+    若 bookkeeping_tx_id / wallet_id 任一缺失,跳过（视为之前未入账）。
     """
     if order.bookkeeping_tx_id is None or order.bookkeeping_wallet_id is None:
         return
@@ -317,12 +377,36 @@ def _debit_old_tx(
     )
 
 
+def _auto_release_aggregator(
+    session: Session,
+    shop: TaobaoShop,
+) -> tuple[Decimal, int]:
+    """导入流程末尾自动跑解冻。复用 ``calculate_pending_maturity`` 计算 + debit/credit 转账。
+
+    返回 ``(累计金额, 笔数)``。无可解冻流水时返回 ``(Decimal("0"), 0)``,不写流水。
+
+    与原 ``release_aggregator`` 端点的逻辑保持一致：
+    - 仅算 mature_at <= now 且仍被某 ``TaobaoOrder.bookkeeping_tx_id`` 引用的流水
+    - 累计金额从 frozen debit、credit 到 available
+    """
+    matured_amount, matured_count = calculate_pending_maturity(
+        session, shop.aggregator_frozen_wallet_id
+    )
+    if matured_count <= 0 or matured_amount <= 0:
+        return Decimal("0"), 0
+
+    remark = f"导入自动解冻 {matured_count} 笔到期"
+    debit(session, shop.aggregator_frozen_wallet_id, matured_amount, remark=remark)
+    credit(session, shop.aggregator_available_wallet_id, matured_amount, remark=remark)
+    return matured_amount, matured_count
+
+
 def import_qianniu_workbook(
     session: Session,
     shop: TaobaoShop,
     file_obj: BinaryIO,
 ) -> ImportReport:
-    """主入口：解析 + 入账 + reconcile，返回 ImportReport。
+    """主入口：解析 + 入账 + reconcile + 末尾自动解冻，返回 ImportReport。
 
     调用方负责 commit / rollback。本函数只 add + flush，**不 commit**。
     任何 SQLAlchemy 异常会向上抛，调用方应 rollback。
@@ -390,6 +474,11 @@ def import_qianniu_workbook(
         else:
             _handle_existing_order(session, shop, existing, parsed, report)
 
+    # 末尾自动解冻
+    auto_amount, auto_count = _auto_release_aggregator(session, shop)
+    report.auto_released_amount = auto_amount
+    report.auto_released_count = auto_count
+
     return report
 
 
@@ -402,10 +491,18 @@ def _handle_new_order(
     """情况 1：新订单。
 
     - closed：不入账，但仍记一行 TaobaoOrder（status=closed, bookkeeping=None）
-    - 其他：按状态入账
+    - received：算 fee/net，credit 用 net；TaobaoOrder.amount=net、gross_amount=gross、fee_amount=fee、confirmed_at
+    - shipped_unconfirmed：credit 用 gross；TaobaoOrder.amount=gross、gross_amount=gross、fee_amount=NULL、confirmed_at=NULL
     """
-    amount = _amount_for_status(parsed)
+    gross = _gross_for_status(parsed)
     wallet_id = _resolve_target_wallet(shop, parsed.payment_method, parsed.system_status)
+
+    # 默认值（适配 closed / 异常分支）
+    fee: Optional[Decimal] = None
+    amount = gross
+
+    if parsed.system_status == TaobaoOrderStatus.RECEIVED:
+        fee, amount = compute_fee_and_net(gross)
 
     bookkeeping_wallet_id: Optional[int] = None
     bookkeeping_tx_id: Optional[int] = None
@@ -415,27 +512,33 @@ def _handle_new_order(
         bookkeeping_wallet_id = wallet_id
         bookkeeping_tx_id = tx.id
 
-    received_at = parsed.shipped_at if parsed.system_status == TaobaoOrderStatus.RECEIVED else None
+    received_at = (
+        parsed.confirmed_at or parsed.shipped_at
+        if parsed.system_status == TaobaoOrderStatus.RECEIVED
+        else None
+    )
+    confirmed_at = parsed.confirmed_at if parsed.system_status == TaobaoOrderStatus.RECEIVED else None
 
     order = TaobaoOrder(
         shop_id=shop.id,
         order_number=parsed.order_number,
-        payment_method=parsed.payment_method.value,
+        payment_method=parsed.payment_method.value if parsed.payment_method is not None else "alipay",
         amount=amount,
+        gross_amount=gross,
+        fee_amount=fee,
         status=parsed.system_status.value,
         bookkeeping_wallet_id=bookkeeping_wallet_id,
         bookkeeping_tx_id=bookkeeping_tx_id,
         shipped_at=parsed.shipped_at,
         received_at=received_at,
+        confirmed_at=confirmed_at,
     )
     session.add(order)
     session.flush()
 
-    if parsed.system_status == TaobaoOrderStatus.CLOSED:
-        # 新进来就 closed,不算 closed_reverted（因从未入过账）
-        report.created_orders += 1
-    else:
-        report.created_orders += 1
+    if fee is not None:
+        report.total_fee_amount += fee
+    report.created_orders += 1
 
 
 def _handle_existing_order(
@@ -448,7 +551,7 @@ def _handle_existing_order(
     """情况 2/3/4/5：老订单。
 
     2: status 没变 → 仅更新 last_synced_at
-    3/5: status 变了（包括跳级）→ 撤老流水 + 入新账
+    3/5: status 变了（包括跳级）→ 撤老流水(按老 amount) + 入新账（received → net；shipped → gross）
     4: 变 closed → 撤老流水 + 不入新账
     """
     old_status_value = order.status.value if hasattr(order.status, "value") else order.status
@@ -473,8 +576,13 @@ def _handle_existing_order(
     # 情况 3/5：变到另一个会落地的状态
     _debit_old_tx(session, order, "状态变化")
 
-    new_amount = _amount_for_status(parsed)
+    new_gross = _gross_for_status(parsed)
     new_wallet_id = _resolve_target_wallet(shop, parsed.payment_method, parsed.system_status)
+
+    new_fee: Optional[Decimal] = None
+    new_amount = new_gross
+    if parsed.system_status == TaobaoOrderStatus.RECEIVED:
+        new_fee, new_amount = compute_fee_and_net(new_gross)
 
     new_tx_id: Optional[int] = None
     if new_wallet_id is not None and new_amount > 0:
@@ -483,12 +591,17 @@ def _handle_existing_order(
 
     order.status = parsed.system_status.value
     order.amount = new_amount
+    order.gross_amount = new_gross
+    order.fee_amount = new_fee
     order.bookkeeping_wallet_id = new_wallet_id if new_tx_id is not None else None
     order.bookkeeping_tx_id = new_tx_id
     order.last_synced_at = datetime.now()
     if parsed.system_status == TaobaoOrderStatus.RECEIVED:
-        order.received_at = parsed.shipped_at or order.received_at
+        order.received_at = parsed.confirmed_at or parsed.shipped_at or order.received_at
+        order.confirmed_at = parsed.confirmed_at or order.confirmed_at
     if parsed.shipped_at is not None:
         order.shipped_at = parsed.shipped_at
 
+    if new_fee is not None:
+        report.total_fee_amount += new_fee
     report.status_changed_orders += 1

--- a/tests/test_taobao_flow_api.py
+++ b/tests/test_taobao_flow_api.py
@@ -1,7 +1,7 @@
-"""淘宝 4 个金流端点 + 订单/钱包流水查询 测试。
+"""淘宝金流端点 + 订单/钱包流水查询 测试。
 
-覆盖：
-- /aggregator/release：到期累计、无到期、防御性排除已撤流水
+覆盖（issue #84 后）：
+- 一键解冻端点已删除（改为 import 末尾自动解冻），相关测试见 test_taobao_import_api.py
 - /withdraw：可提现 → 银行卡 / 余额不足 / amount<=0
 - /transfer-to-store-alipay：丙火 / 兔仔均成功 / amount 默认全额 / 银行卡空
 - /orders：列表 + status/payment_method 过滤 + 分页 + 排序
@@ -74,10 +74,7 @@ def _seed_aggregator_frozen_tx(
     bind_to_order: bool = True,
     order_number: str | None = None,
 ) -> int:
-    """直接往 aggregator_frozen 钱包注入一笔 in 流水，并视情况绑定到 TaobaoOrder。
-
-    返回：插入的 WalletTransaction.id
-    """
+    """直接往 aggregator_frozen 钱包注入一笔 in 流水，并视情况绑定到 TaobaoOrder。"""
     db = database.SessionLocal()
     try:
         tx = credit(
@@ -93,6 +90,7 @@ def _seed_aggregator_frozen_tx(
                 order_number=order_number or f"SEED_{tx.id}",
                 payment_method=TaobaoOrderPaymentMethod.WECHAT.value,
                 amount=amount,
+                gross_amount=amount,
                 status=TaobaoOrderStatus.RECEIVED.value,
                 bookkeeping_wallet_id=shop.aggregator_frozen_wallet_id,
                 bookkeeping_tx_id=tx.id,
@@ -102,78 +100,6 @@ def _seed_aggregator_frozen_tx(
         return tx.id
     finally:
         db.close()
-
-
-# ---------------------------------------------------------------------------
-# /aggregator/release
-# ---------------------------------------------------------------------------
-
-
-def test_release_aggregates_only_matured_transactions(client):
-    """3 笔流水：2 笔已到期、1 笔未到期 → 仅解冻已到期金额。"""
-    shop = _shop_by_name("丙火电玩")
-    now = datetime.now(timezone.utc)
-
-    _seed_aggregator_frozen_tx(shop, Decimal("100"), now - timedelta(days=1), order_number="MAT_1")
-    _seed_aggregator_frozen_tx(shop, Decimal("50"), now - timedelta(hours=2), order_number="MAT_2")
-    _seed_aggregator_frozen_tx(shop, Decimal("80"), now + timedelta(days=3), order_number="FUTURE_1")
-
-    # 解冻前 frozen=230, available=0
-    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("230.000000")
-    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("0.000000")
-
-    response = client.post(f"/taobao/shops/{shop.id}/aggregator/release")
-    assert response.status_code == 200, response.text
-    payload = response.json()
-
-    assert payload["maturedCount"] == 2
-    assert Decimal(payload["maturedAmount"]) == Decimal("150")
-    assert Decimal(payload["frozenBalanceAfter"]) == Decimal("80.000000")
-    assert Decimal(payload["availableBalanceAfter"]) == Decimal("150.000000")
-
-    # 数据库实际余额一致
-    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("80.000000")
-    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("150.000000")
-
-
-def test_release_when_no_matured_returns_zero(client):
-    """无到期流水时 200 + matured_count=0，不报错、不动余额。"""
-    shop = _shop_by_name("丙火电玩")
-    now = datetime.now(timezone.utc)
-    _seed_aggregator_frozen_tx(shop, Decimal("99"), now + timedelta(days=2), order_number="FUT_ONLY")
-
-    response = client.post(f"/taobao/shops/{shop.id}/aggregator/release")
-    assert response.status_code == 200, response.text
-    payload = response.json()
-
-    assert payload["maturedCount"] == 0
-    assert Decimal(payload["maturedAmount"]) == Decimal("0")
-    assert Decimal(payload["frozenBalanceAfter"]) == Decimal("99.000000")
-    assert Decimal(payload["availableBalanceAfter"]) == Decimal("0.000000")
-
-
-def test_release_skips_orphan_matured_tx(client):
-    """防御性：到期但已被 reconcile 撤掉（无 order 引用）的流水不应再被解冻。"""
-    shop = _shop_by_name("丙火电玩")
-    now = datetime.now(timezone.utc)
-
-    # 流水 A：到期，绑订单
-    _seed_aggregator_frozen_tx(shop, Decimal("200"), now - timedelta(days=1), order_number="ALIVE_A")
-    # 流水 B：到期，但故意不绑订单（模拟已被撤）
-    _seed_aggregator_frozen_tx(shop, Decimal("70"), now - timedelta(days=1), bind_to_order=False)
-
-    response = client.post(f"/taobao/shops/{shop.id}/aggregator/release")
-    assert response.status_code == 200
-    payload = response.json()
-
-    # 仅 A 被解冻
-    assert payload["maturedCount"] == 1
-    assert Decimal(payload["maturedAmount"]) == Decimal("200")
-
-
-def test_release_404_when_shop_not_found(client):
-    response = client.post("/taobao/shops/99999/aggregator/release")
-    assert response.status_code == 404
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_taobao_import_api.py
+++ b/tests/test_taobao_import_api.py
@@ -1,18 +1,23 @@
-"""千牛 Excel 导入 + 订单 reconcile + 状态变化金流 综合测试。
+"""千牛 v2 14 列 Excel 导入 + 订单 reconcile + 状态变化金流 综合测试。
 
-涵盖：
+涵盖（issue #84 后）：
 - 端点 happy path：新订单 / 老订单 / 状态变化 / 关闭 / 跳过
+- 14 列严格表头校验（多 1 列、少 1 列、列名错都视为结构错）
 - 三维分流矩阵（A 类 vs B 类 / alipay vs wechat / shipped_unconfirmed vs received）
-- 微信/received → aggregator_frozen + mature_at = received_at + 7d
-- 状态变化 reconcile：撤老钱包流水 + 入新钱包
+- 0.2% 手续费规则：仅 received 时扣，net = gross - round(gross*0.002, 2) ROUND_HALF_UP
+  边界值：56→0.11、269→0.54、27.50→0.06、100→0.20
+- 在途订单 amount=gross；已确认订单 amount=net、gross/fee/confirmed_at 都填值
+- 微信/received → aggregator_frozen + mature_at = confirmed_at + 7d；缺失时兜底 shipped_at + 7d
+- reconcile：在途→确认（debit gross + credit net，差额=fee 自然消失）
 - 状态变成 closed：撤账无新流水
 - 错误处理：404 shop / 400 非 .xlsx / 400 表头错
 - 跳过未付款 / 未发货 / 未知支付方式
 - 单一事务原子性
+- 末尾自动解冻：到期流水自动从 frozen → available
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from io import BytesIO
 
@@ -33,20 +38,27 @@ from src.models.wallet import (
     TransactionDirection,
     Wallet,
     WalletTransaction,
+    credit,
 )
 from src.services.assets import ensure_default_asset_wallets
 from src.services.taobao import ensure_default_taobao_wallets
 
 
+# 千牛 v2 标准 14 列表头
 HEADERS = [
     "订单编号",
     "支付单号",
     "支付详情",
     "买家实付金额",
     "订单状态",
+    "订单创建时间",
     "订单付款时间",
+    "宝贝种类",
     "店铺名称",
+    "卖家服务费",
+    "退款金额",
     "发货时间",
+    "确认收货时间",
     "确认收货打款金额",
 ]
 
@@ -71,6 +83,42 @@ def _shop_by_name(name: str) -> TaobaoShop:
         return db.scalar(select(TaobaoShop).where(TaobaoShop.name == name))
     finally:
         db.close()
+
+
+def _row(
+    *,
+    order_no: str,
+    payment_no: str,
+    payment_detail: str,
+    buyer_paid: str,
+    status_zh: str,
+    paid_at: str = "",
+    shop_name: str = "丙火电玩",
+    shipped_at: str = "",
+    confirmed_at: str = "",
+    confirmed_amount: str = "0.00",
+    created_at: str = "",
+    bao_kind: str = "1",
+    seller_service_fee: str = "0.00",
+    refund_amount: str = "0.00",
+) -> list:
+    """生成 14 列数据行。col 5/7/9/10 占位（CEO 同意忽略,但表头必须严格）。"""
+    return [
+        order_no,                                     # col 0  订单编号
+        payment_no,                                   # col 1  支付单号
+        payment_detail,                               # col 2  支付详情
+        buyer_paid,                                   # col 3  买家实付金额
+        status_zh,                                    # col 4  订单状态
+        created_at or paid_at,                        # col 5  订单创建时间(占位)
+        paid_at,                                      # col 6  订单付款时间
+        bao_kind,                                     # col 7  宝贝种类(占位)
+        shop_name,                                    # col 8  店铺名称
+        seller_service_fee,                           # col 9  卖家服务费(占位)
+        refund_amount,                                # col 10 退款金额(占位)
+        shipped_at,                                   # col 11 发货时间
+        confirmed_at,                                 # col 12 确认收货时间
+        confirmed_amount,                             # col 13 确认收货打款金额
+    ]
 
 
 def _build_xlsx(rows: list[list], headers: list[str] | None = None) -> bytes:
@@ -139,6 +187,16 @@ def _last_tx(wallet_id: int) -> WalletTransaction:
         db.close()
 
 
+def _get_order(order_number: str) -> TaobaoOrder:
+    db = database.SessionLocal()
+    try:
+        return db.scalar(
+            select(TaobaoOrder).where(TaobaoOrder.order_number == order_number)
+        )
+    finally:
+        db.close()
+
+
 # ---------------------------------------------------------------------------
 # 端点错误路径
 # ---------------------------------------------------------------------------
@@ -161,9 +219,11 @@ def test_import_400_when_not_xlsx(client):
     assert ".xlsx" in response.json()["detail"]
 
 
-def test_import_400_when_header_wrong(client):
+def test_import_400_when_header_wrong_in_middle(client):
+    """中间一列改名 → 400 表头错。"""
     shop = _shop_by_name("丙火电玩")
-    bad_headers = ["订单编号", "支付单号", "WRONG"] + HEADERS[3:]
+    bad_headers = HEADERS.copy()
+    bad_headers[7] = "WRONG_COL"  # 把 "宝贝种类" 改错
     content = _build_xlsx([], headers=bad_headers)
     response = _post_import(client, shop.id, content)
     assert response.status_code == 400
@@ -171,8 +231,21 @@ def test_import_400_when_header_wrong(client):
 
 
 def test_import_400_when_columns_too_few(client):
+    """少 1 列（13 列）→ 400 列数不足。"""
     shop = _shop_by_name("丙火电玩")
-    content = _build_xlsx([], headers=HEADERS[:5])
+    content = _build_xlsx([], headers=HEADERS[:13])
+    response = _post_import(client, shop.id, content)
+    assert response.status_code == 400
+
+
+def test_import_400_when_old_v1_9col_header_rejected(client):
+    """v1 旧 9 列表头 → 14 列严格校验下应被 400 拒绝。"""
+    shop = _shop_by_name("丙火电玩")
+    old_headers = [
+        "订单编号", "支付单号", "支付详情", "买家实付金额", "订单状态",
+        "订单付款时间", "店铺名称", "发货时间", "确认收货打款金额",
+    ]
+    content = _build_xlsx([], headers=old_headers)
     response = _post_import(client, shop.id, content)
     assert response.status_code == 400
 
@@ -181,28 +254,30 @@ def test_import_400_when_row_shop_name_mismatched(client):
     """行内店铺名 != 上传 shop.name → 400 + 错误信息含两个店铺名 + 整体回滚。"""
     shop = _shop_by_name("丙火电玩")
     rows = [
-        [
-            "ROW_OK",
-            "PAY_OK",
-            _alipay_detail("PAY_OK", "10.00"),
-            "10.00",
-            "交易成功",
-            "2026-04-29 23:00:00",
-            "丙火电玩",
-            "2026-04-30 00:00:00",
-            "10.00",
-        ],
-        [
-            "ROW_BAD",
-            "PAY_BAD",
-            _alipay_detail("PAY_BAD", "20.00"),
-            "20.00",
-            "交易成功",
-            "2026-04-29 23:00:00",
-            "兔仔电玩",  # 不匹配上传的丙火电玩
-            "2026-04-30 00:00:00",
-            "20.00",
-        ],
+        _row(
+            order_no="ROW_OK",
+            payment_no="PAY_OK",
+            payment_detail=_alipay_detail("PAY_OK", "10.00"),
+            buyer_paid="10.00",
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 12:00:00",
+            confirmed_amount="10.00",
+        ),
+        _row(
+            order_no="ROW_BAD",
+            payment_no="PAY_BAD",
+            payment_detail=_alipay_detail("PAY_BAD", "20.00"),
+            buyer_paid="20.00",
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="兔仔电玩",  # 不匹配
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 12:00:00",
+            confirmed_amount="20.00",
+        ),
     ]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 400, response.text
@@ -210,7 +285,7 @@ def test_import_400_when_row_shop_name_mismatched(client):
     assert "兔仔电玩" in detail
     assert "丙火电玩" in detail
 
-    # 整体回滚：第一行也不应入账
+    # 整体回滚
     assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
     db = database.SessionLocal()
@@ -225,17 +300,18 @@ def test_import_400_when_row_shop_name_empty(client):
     """行内店铺名为空 → 视为不匹配 → 400。"""
     shop = _shop_by_name("丙火电玩")
     rows = [
-        [
-            "ROW_EMPTY_SHOP",
-            "PAY_X",
-            _alipay_detail("PAY_X", "10.00"),
-            "10.00",
-            "交易成功",
-            "2026-04-29 23:00:00",
-            "",  # 空店铺名
-            "2026-04-30 00:00:00",
-            "10.00",
-        ],
+        _row(
+            order_no="ROW_EMPTY_SHOP",
+            payment_no="PAY_X",
+            payment_detail=_alipay_detail("PAY_X", "10.00"),
+            buyer_paid="10.00",
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 12:00:00",
+            confirmed_amount="10.00",
+        ),
     ]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 400
@@ -262,131 +338,240 @@ def test_import_400_when_file_empty(client):
 
 
 def test_new_alipay_received_a_shop_to_store_alipay_wallet(client):
-    """A 类店铺（丙火电玩）alipay/received → store_alipay_wallet（资产支付宝子钱包）。"""
+    """A 类店铺（丙火）alipay/received → store_alipay_wallet,扣 0.2% 手续费。"""
     shop = _shop_by_name("丙火电玩")
-    rows = [[
-        "ORDER_A1",
-        "PAY_A1",
-        _alipay_detail("PAY_A1", "100.00"),
-        "100.00",
-        "交易成功",
-        "2026-04-29 23:57:43",
-        "丙火电玩",
-        "2026-04-30 00:03:21",
-        "100.00",
-    ]]
+    rows = [_row(
+        order_no="ORDER_A1",
+        payment_no="PAY_A1",
+        payment_detail=_alipay_detail("PAY_A1", "100.00"),
+        buyer_paid="100.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:57:43",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:03:21",
+        confirmed_at="2026-04-30 14:00:00",
+        confirmed_amount="100.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["createdOrders"] == 1
 
-    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("100.000000")
+    # 100.00 → fee 0.20 → net 99.80
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("99.800000")
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
+    assert Decimal(payload["totalFeeAmount"]) == Decimal("0.20")
 
 
 def test_new_alipay_received_b_shop_to_store_alipay_wallet(client):
-    """B 类店铺（兔仔电玩）alipay/received → store_alipay_wallet（兔仔电玩支付宝,type=TAOBAO）,不再进 bank_card。"""
+    """B 类店铺（兔仔）alipay/received → store_alipay_wallet（兔仔电玩支付宝,type=TAOBAO）。"""
     shop = _shop_by_name("兔仔电玩")
-    rows = [[
-        "ORDER_B1",
-        "PAY_B1",
-        _alipay_detail("PAY_B1", "50.00"),
-        "50.00",
-        "交易成功",
-        "2026-04-29 23:57:43",
-        "兔仔电玩",
-        "2026-04-30 00:03:21",
-        "50.00",
-    ]]
+    rows = [_row(
+        order_no="ORDER_B1",
+        payment_no="PAY_B1",
+        payment_detail=_alipay_detail("PAY_B1", "50.00"),
+        buyer_paid="50.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:57:43",
+        shop_name="兔仔电玩",
+        shipped_at="2026-04-30 00:03:21",
+        confirmed_at="2026-04-30 14:00:00",
+        confirmed_amount="50.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
-    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("50.000000")
+    # 50 → fee 0.10 → net 49.90
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("49.900000")
     assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("0.000000")
 
 
-def test_new_wechat_received_to_aggregator_frozen_with_mature_at(client):
-    """wechat/received → aggregator_frozen，且 mature_at = received_at + 7d。"""
+def test_new_wechat_received_to_aggregator_frozen_with_mature_at_from_confirmed_at(client):
+    """wechat/received → aggregator_frozen，mature_at = confirmed_at + 7d。"""
     shop = _shop_by_name("丙火电玩")
-    received_at_str = "2026-04-30 00:03:21"
-    rows = [[
-        "ORDER_W1",
-        "PAY_W1",
-        _wechat_detail("PAY_W1", "200.00"),
-        "200.00",
-        "交易成功",
-        "2026-04-29 23:57:43",
-        "丙火电玩",
-        received_at_str,
-        "200.00",
-    ]]
+    confirmed_at_str = "2026-04-30 14:30:00"
+    shipped_at_str = "2026-04-30 00:03:21"
+    rows = [_row(
+        order_no="ORDER_W1",
+        payment_no="PAY_W1",
+        payment_detail=_wechat_detail("PAY_W1", "200.00"),
+        buyer_paid="200.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:57:43",
+        shop_name="丙火电玩",
+        shipped_at=shipped_at_str,
+        confirmed_at=confirmed_at_str,
+        confirmed_amount="200.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
 
-    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("200.000000")
+    # 200 → fee 0.40 → net 199.60
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("199.600000")
     tx = _last_tx(shop.aggregator_frozen_wallet_id)
     assert tx is not None
     assert tx.mature_at is not None
-    expected_mature = datetime.strptime(received_at_str, "%Y-%m-%d %H:%M:%S") + timedelta(days=7)
+    expected_mature = datetime.strptime(confirmed_at_str, "%Y-%m-%d %H:%M:%S") + timedelta(days=7)
     assert tx.mature_at.replace(tzinfo=None) == expected_mature
 
 
-def test_new_wechat_received_b_shop_also_to_aggregator_frozen(client):
-    """B 类（兔仔）的 wechat/received 仍然走聚合冻结（聚合支付独立于店铺归属）。"""
-    shop = _shop_by_name("兔仔电玩")
-    rows = [[
-        "ORDER_B_W1",
-        "PAY_B_W1",
-        _wechat_detail("PAY_B_W1", "60.00"),
-        "60.00",
-        "交易成功",
-        "2026-04-29 23:57:43",
-        "兔仔电玩",
-        "2026-04-30 00:03:21",
-        "60.00",
-    ]]
+def test_mature_at_falls_back_to_shipped_at_when_confirmed_at_missing(client):
+    """confirmed_at 缺失时,mature_at 兜底用 shipped_at + 7d。"""
+    shop = _shop_by_name("丙火电玩")
+    shipped_at_str = "2026-04-30 00:03:21"
+    rows = [_row(
+        order_no="ORDER_FB",
+        payment_no="PAY_FB",
+        payment_detail=_wechat_detail("PAY_FB", "100.00"),
+        buyer_paid="100.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:57:43",
+        shop_name="丙火电玩",
+        shipped_at=shipped_at_str,
+        confirmed_at="",  # 缺失
+        confirmed_amount="100.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
-    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("60.000000")
-    assert _wallet_balance(shop.bank_card_wallet_id) == Decimal("0.000000")
+
+    tx = _last_tx(shop.aggregator_frozen_wallet_id)
+    expected = datetime.strptime(shipped_at_str, "%Y-%m-%d %H:%M:%S") + timedelta(days=7)
+    assert tx.mature_at.replace(tzinfo=None) == expected
+
+
+def test_new_wechat_received_b_shop_also_to_aggregator_frozen(client):
+    """B 类（兔仔）的 wechat/received 仍然走聚合冻结。"""
+    shop = _shop_by_name("兔仔电玩")
+    rows = [_row(
+        order_no="ORDER_B_W1",
+        payment_no="PAY_B_W1",
+        payment_detail=_wechat_detail("PAY_B_W1", "60.00"),
+        buyer_paid="60.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:57:43",
+        shop_name="兔仔电玩",
+        shipped_at="2026-04-30 00:03:21",
+        confirmed_at="2026-04-30 14:00:00",
+        confirmed_amount="60.00",
+    )]
+    response = _post_import(client, shop.id, _build_xlsx(rows))
+    assert response.status_code == 200, response.text
+    # 60 → fee 0.12 → net 59.88
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("59.880000")
 
 
 def test_new_alipay_shipped_unconfirmed_to_unconfirmed_alipay(client):
-    """alipay/shipped_unconfirmed → unconfirmed_alipay,金额用买家实付。"""
+    """alipay/shipped_unconfirmed → unconfirmed_alipay,金额用买家实付（gross）,不扣手续费。"""
     shop = _shop_by_name("丙火电玩")
-    rows = [[
-        "ORDER_S1",
-        "PAY_S1",
-        _alipay_detail("PAY_S1", "27.50"),
-        "27.50",
-        "卖家已发货，等待买家确认",
-        "2026-04-29 23:46:25",
-        "丙火电玩",
-        "2026-04-30 00:10:45",
-        "0.00",
-    ]]
+    rows = [_row(
+        order_no="ORDER_S1",
+        payment_no="PAY_S1",
+        payment_detail=_alipay_detail("PAY_S1", "27.50"),
+        buyer_paid="27.50",
+        status_zh="卖家已发货，等待买家确认",
+        paid_at="2026-04-29 23:46:25",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:10:45",
+        confirmed_at="",
+        confirmed_amount="0.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
+    # 在途：amount = gross = 27.50（不扣费）
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("27.500000")
     assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
+    # TaobaoOrder：amount=gross, fee_amount=NULL, confirmed_at=NULL
+    order = _get_order("ORDER_S1")
+    assert Decimal(order.amount) == Decimal("27.500000")
+    assert Decimal(order.gross_amount) == Decimal("27.500000")
+    assert order.fee_amount is None
+    assert order.confirmed_at is None
+
 
 def test_new_wechat_shipped_unconfirmed_to_unconfirmed_wechat(client):
-    """wechat/shipped_unconfirmed → unconfirmed_wechat。"""
+    """wechat/shipped_unconfirmed → unconfirmed_wechat,不扣手续费。"""
     shop = _shop_by_name("丙火电玩")
-    rows = [[
-        "ORDER_S2",
-        "PAY_S2",
-        _wechat_detail("PAY_S2", "33.00"),
-        "33.00",
-        "卖家已发货，等待买家确认",
-        "2026-04-29 23:46:25",
-        "丙火电玩",
-        "2026-04-30 00:10:45",
-        "0.00",
-    ]]
+    rows = [_row(
+        order_no="ORDER_S2",
+        payment_no="PAY_S2",
+        payment_detail=_wechat_detail("PAY_S2", "33.00"),
+        buyer_paid="33.00",
+        status_zh="卖家已发货，等待买家确认",
+        paid_at="2026-04-29 23:46:25",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:10:45",
+        confirmed_at="",
+        confirmed_amount="0.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200
     assert _wallet_balance(shop.unconfirmed_wechat_wallet_id) == Decimal("33.000000")
+
+
+# ---------------------------------------------------------------------------
+# 0.2% 手续费精度（CEO 边界值）
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "gross,expected_net,expected_fee",
+    [
+        ("56.00", "55.890000", "0.110000"),
+        ("269.00", "268.460000", "0.540000"),
+        ("27.50", "27.440000", "0.060000"),  # 0.055 → ROUND_HALF_UP → 0.06
+        ("100.00", "99.800000", "0.200000"),
+        ("57.00", "56.890000", "0.110000"),
+    ],
+)
+def test_fee_precision_rounding_half_up(client, gross, expected_net, expected_fee):
+    """逐个边界金额跑 alipay/received，验证 net & fee 精度。"""
+    shop = _shop_by_name("丙火电玩")
+    rows = [_row(
+        order_no=f"FEE_{gross}",
+        payment_no=f"PF_{gross}",
+        payment_detail=_alipay_detail(f"PF_{gross}", gross),
+        buyer_paid=gross,
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_at="2026-04-30 14:00:00",
+        confirmed_amount=gross,
+    )]
+    response = _post_import(client, shop.id, _build_xlsx(rows))
+    assert response.status_code == 200, response.text
+
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal(expected_net)
+
+    order = _get_order(f"FEE_{gross}")
+    assert Decimal(order.amount) == Decimal(expected_net)
+    assert Decimal(order.gross_amount) == Decimal(gross + "0000")  # numeric(18,6)
+    assert Decimal(order.fee_amount) == Decimal(expected_fee)
+
+
+def test_total_fee_amount_summed_across_received_rows(client):
+    """totalFeeAmount = 所有 received 行 fee 之和。"""
+    shop = _shop_by_name("丙火电玩")
+    rows = [
+        _row(
+            order_no=f"SUM_F_{i}",
+            payment_no=f"P_SUM_{i}",
+            payment_detail=_alipay_detail(f"P_SUM_{i}", str(amt)),
+            buyer_paid=str(amt),
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 14:00:00",
+            confirmed_amount=str(amt),
+        )
+        for i, amt in enumerate(["56.00", "269.00", "100.00"])
+    ]
+    response = _post_import(client, shop.id, _build_xlsx(rows))
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    # 0.11 + 0.54 + 0.20 = 0.85
+    assert Decimal(payload["totalFeeAmount"]) == Decimal("0.85")
 
 
 # ---------------------------------------------------------------------------
@@ -398,28 +583,28 @@ def test_skip_pending_pay_and_paid_unshipped(client):
     """等待买家付款 / 买家已付款等待发货 → 跳过，不入账。"""
     shop = _shop_by_name("丙火电玩")
     rows = [
-        [
-            "ORDER_PEND",
-            "PAY_PEND",
-            _alipay_detail("PAY_PEND", "0.00"),
-            "0.00",
-            "等待买家付款",
-            "",
-            "丙火电玩",
-            "",
-            "0.00",
-        ],
-        [
-            "ORDER_UNSHIP",
-            "PAY_UNSHIP",
-            _alipay_detail("PAY_UNSHIP", "10.00"),
-            "10.00",
-            "买家已付款,等待卖家发货",
-            "2026-04-29 23:00:00",
-            "丙火电玩",
-            "",
-            "0.00",
-        ],
+        _row(
+            order_no="ORDER_PEND",
+            payment_no="PAY_PEND",
+            payment_detail=_alipay_detail("PAY_PEND", "0.00"),
+            buyer_paid="0.00",
+            status_zh="等待买家付款",
+            paid_at="",
+            shop_name="丙火电玩",
+            shipped_at="",
+            confirmed_amount="0.00",
+        ),
+        _row(
+            order_no="ORDER_UNSHIP",
+            payment_no="PAY_UNSHIP",
+            payment_detail=_alipay_detail("PAY_UNSHIP", "10.00"),
+            buyer_paid="10.00",
+            status_zh="买家已付款,等待卖家发货",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="",
+            confirmed_amount="0.00",
+        ),
     ]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200
@@ -438,19 +623,20 @@ def test_skip_pending_pay_and_paid_unshipped(client):
 
 
 def test_skip_unknown_payment_method(client):
-    """支付详情含怪字符串(无 微信支付/支付宝) → skippedUnknownPayment + 不入账 + 不建订单。"""
+    """支付详情含怪字符串 → skippedUnknownPayment + 不入账。"""
     shop = _shop_by_name("丙火电玩")
-    rows = [[
-        "ORDER_UNKNOWN",
-        "PAY_UNKNOWN",
-        "支付方式：未知通道，金额：50.00；",  # 没有"微信支付"也没有"支付宝"
-        "50.00",
-        "交易成功",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "50.00",
-    ]]
+    rows = [_row(
+        order_no="ORDER_UNKNOWN",
+        payment_no="PAY_UNKNOWN",
+        payment_detail="支付方式：未知通道，金额：50.00；",
+        buyer_paid="50.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_at="2026-04-30 14:00:00",
+        confirmed_amount="50.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200
     payload = response.json()
@@ -459,19 +645,19 @@ def test_skip_unknown_payment_method(client):
 
 
 def test_new_closed_order_no_credit(client):
-    """新订单状态就是 closed → 不入账,但 TaobaoOrder 仍写一行（status=closed）。"""
+    """新订单状态就是 closed → 不入账。"""
     shop = _shop_by_name("丙火电玩")
-    rows = [[
-        "ORDER_CLOSED",
-        "PAY_CLOSED",
-        _alipay_detail("PAY_CLOSED", "0.00"),
-        "0.00",
-        "交易关闭",
-        "",
-        "丙火电玩",
-        "",
-        "0.00",
-    ]]
+    rows = [_row(
+        order_no="ORDER_CLOSED",
+        payment_no="PAY_CLOSED",
+        payment_detail=_alipay_detail("PAY_CLOSED", "0.00"),
+        buyer_paid="0.00",
+        status_zh="交易关闭",
+        paid_at="",
+        shop_name="丙火电玩",
+        shipped_at="",
+        confirmed_amount="0.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200
     payload = response.json()
@@ -479,15 +665,11 @@ def test_new_closed_order_no_credit(client):
     assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
 
-    db = database.SessionLocal()
-    try:
-        order = db.scalar(select(TaobaoOrder).where(TaobaoOrder.order_number == "ORDER_CLOSED"))
-        assert order is not None
-        assert order.status == TaobaoOrderStatus.CLOSED.value
-        assert order.bookkeeping_wallet_id is None
-        assert order.bookkeeping_tx_id is None
-    finally:
-        db.close()
+    order = _get_order("ORDER_CLOSED")
+    assert order is not None
+    assert order.status == TaobaoOrderStatus.CLOSED.value
+    assert order.bookkeeping_wallet_id is None
+    assert order.bookkeeping_tx_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -495,99 +677,103 @@ def test_new_closed_order_no_credit(client):
 # ---------------------------------------------------------------------------
 
 
-def test_reconcile_shipped_unconfirmed_to_received(client):
-    """状态从 shipped_unconfirmed → received：撤老钱包(unconfirmed_alipay) + 入新钱包(store_alipay_wallet)。"""
+def test_reconcile_shipped_unconfirmed_to_received_alipay(client):
+    """alipay 在途 → 确认：撤老钱包(unconfirmed_alipay 100) + 入新钱包(store_alipay 99.80)。
+
+    差额 0.2 = fee 自然消失。
+    """
     shop = _shop_by_name("丙火电玩")
-    # 第一次导入：shipped_unconfirmed
-    rows1 = [[
-        "ORDER_RECONCILE",
-        "PAY_R1",
-        _alipay_detail("PAY_R1", "100.00"),
-        "100.00",
-        "卖家已发货，等待买家确认",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "0.00",
-    ]]
+    # 1) 在途 100
+    rows1 = [_row(
+        order_no="ORDER_RECONCILE",
+        payment_no="PAY_R1",
+        payment_detail=_alipay_detail("PAY_R1", "100.00"),
+        buyer_paid="100.00",
+        status_zh="卖家已发货，等待买家确认",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_amount="0.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows1))
     assert response.status_code == 200
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("100.000000")
     assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
-    # 第二次导入：同一订单变成 received
-    rows2 = [[
-        "ORDER_RECONCILE",
-        "PAY_R1",
-        _alipay_detail("PAY_R1", "100.00"),
-        "100.00",
-        "交易成功",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "100.00",
-    ]]
+    # 2) 同一订单变 received（gross 100）
+    rows2 = [_row(
+        order_no="ORDER_RECONCILE",
+        payment_no="PAY_R1",
+        payment_detail=_alipay_detail("PAY_R1", "100.00"),
+        buyer_paid="100.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_at="2026-04-30 14:00:00",
+        confirmed_amount="100.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows2))
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["statusChangedOrders"] == 1
     assert payload["createdOrders"] == 0
 
-    # 老钱包（unconfirmed_alipay）应该被 debit 100,余额回 0
+    # 老钱包：debit 100 → 0
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
-    # 新钱包（store_alipay_wallet）应该 +100
-    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("100.000000")
+    # 新钱包：credit net=99.80
+    assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("99.800000")
+    # totalFee = 0.20
+    assert Decimal(payload["totalFeeAmount"]) == Decimal("0.20")
 
-    # 老钱包应该有 1 in + 1 out = 2 笔流水
+    # 老钱包应该有 1 in + 1 out = 2 笔
     assert _wallet_tx_count(shop.unconfirmed_alipay_wallet_id) == 2
-
-    # 老钱包最近一笔应该是 OUT 方向
     last = _last_tx(shop.unconfirmed_alipay_wallet_id)
     direction = last.direction.value if hasattr(last.direction, "value") else last.direction
     assert direction == TransactionDirection.OUT.value
     assert "reconcile" in (last.remark or "")
+    # debit 金额 = 老 amount = 100（gross,不是 net）
+    assert Decimal(last.amount) == Decimal("100.000000")
 
-    # TaobaoOrder 状态应该更新
-    db = database.SessionLocal()
-    try:
-        order = db.scalar(
-            select(TaobaoOrder).where(TaobaoOrder.order_number == "ORDER_RECONCILE")
-        )
-        status_value = order.status.value if hasattr(order.status, "value") else order.status
-        assert status_value == TaobaoOrderStatus.RECEIVED.value
-        assert order.bookkeeping_wallet_id == shop.store_alipay_wallet_id
-    finally:
-        db.close()
+    # TaobaoOrder：amount→net, gross/fee/confirmed_at 都补上
+    order = _get_order("ORDER_RECONCILE")
+    status_value = order.status.value if hasattr(order.status, "value") else order.status
+    assert status_value == TaobaoOrderStatus.RECEIVED.value
+    assert order.bookkeeping_wallet_id == shop.store_alipay_wallet_id
+    assert Decimal(order.amount) == Decimal("99.800000")
+    assert Decimal(order.gross_amount) == Decimal("100.000000")
+    assert Decimal(order.fee_amount) == Decimal("0.200000")
+    assert order.confirmed_at is not None
 
 
 def test_reconcile_to_closed_no_new_credit(client):
     """状态从 shipped_unconfirmed → closed：撤老钱包,无新流水。"""
     shop = _shop_by_name("丙火电玩")
-    rows1 = [[
-        "ORDER_TO_CLOSED",
-        "PAY_C1",
-        _alipay_detail("PAY_C1", "80.00"),
-        "80.00",
-        "卖家已发货，等待买家确认",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "0.00",
-    ]]
+    rows1 = [_row(
+        order_no="ORDER_TO_CLOSED",
+        payment_no="PAY_C1",
+        payment_detail=_alipay_detail("PAY_C1", "80.00"),
+        buyer_paid="80.00",
+        status_zh="卖家已发货，等待买家确认",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_amount="0.00",
+    )]
     _post_import(client, shop.id, _build_xlsx(rows1))
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("80.000000")
 
-    rows2 = [[
-        "ORDER_TO_CLOSED",
-        "PAY_C1",
-        _alipay_detail("PAY_C1", "80.00"),
-        "80.00",
-        "交易关闭",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "0.00",
-    ]]
+    rows2 = [_row(
+        order_no="ORDER_TO_CLOSED",
+        payment_no="PAY_C1",
+        payment_detail=_alipay_detail("PAY_C1", "80.00"),
+        buyer_paid="80.00",
+        status_zh="交易关闭",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_amount="0.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows2))
     assert response.status_code == 200
     payload = response.json()
@@ -596,32 +782,26 @@ def test_reconcile_to_closed_no_new_credit(client):
     assert _wallet_balance(shop.unconfirmed_alipay_wallet_id) == Decimal("0.000000")
     assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
-    db = database.SessionLocal()
-    try:
-        order = db.scalar(
-            select(TaobaoOrder).where(TaobaoOrder.order_number == "ORDER_TO_CLOSED")
-        )
-        assert order.status == TaobaoOrderStatus.CLOSED.value
-        assert order.bookkeeping_wallet_id is None
-        assert order.bookkeeping_tx_id is None
-    finally:
-        db.close()
+    order = _get_order("ORDER_TO_CLOSED")
+    assert order.status == TaobaoOrderStatus.CLOSED.value
+    assert order.bookkeeping_wallet_id is None
+    assert order.bookkeeping_tx_id is None
 
 
 def test_reconcile_no_change_skipped(client):
     """状态没变 → skippedNoChange + 0 流水变化。"""
     shop = _shop_by_name("丙火电玩")
-    rows = [[
-        "ORDER_SAME",
-        "PAY_SAME",
-        _alipay_detail("PAY_SAME", "55.00"),
-        "55.00",
-        "卖家已发货，等待买家确认",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "0.00",
-    ]]
+    rows = [_row(
+        order_no="ORDER_SAME",
+        payment_no="PAY_SAME",
+        payment_detail=_alipay_detail("PAY_SAME", "55.00"),
+        buyer_paid="55.00",
+        status_zh="卖家已发货，等待买家确认",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_amount="0.00",
+    )]
     _post_import(client, shop.id, _build_xlsx(rows))
     before_tx = _wallet_tx_count(shop.unconfirmed_alipay_wallet_id)
 
@@ -635,115 +815,209 @@ def test_reconcile_no_change_skipped(client):
     assert before_tx == after_tx == 1
 
 
-def test_reconcile_skip_jump_unconfirmed_to_received(client):
-    """跳级：第一次 shipped_unconfirmed，下一次直接 received（情况 5），同情况 3 处理。"""
+def test_reconcile_skip_jump_unconfirmed_to_received_wechat(client):
+    """跳级 wechat：在途 120 → 确认 120 → debit 120 + credit net=119.76（fee 0.24）+ mature_at。"""
     shop = _shop_by_name("丙火电玩")
-    rows1 = [[
-        "ORDER_JUMP",
-        "PAY_J1",
-        _wechat_detail("PAY_J1", "120.00"),
-        "120.00",
-        "卖家已发货，等待买家确认",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "0.00",
-    ]]
+    rows1 = [_row(
+        order_no="ORDER_JUMP",
+        payment_no="PAY_J1",
+        payment_detail=_wechat_detail("PAY_J1", "120.00"),
+        buyer_paid="120.00",
+        status_zh="卖家已发货，等待买家确认",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_amount="0.00",
+    )]
     _post_import(client, shop.id, _build_xlsx(rows1))
     assert _wallet_balance(shop.unconfirmed_wechat_wallet_id) == Decimal("120.000000")
 
-    # 跳到 received（wechat/received → aggregator_frozen + mature_at）
-    rows2 = [[
-        "ORDER_JUMP",
-        "PAY_J1",
-        _wechat_detail("PAY_J1", "120.00"),
-        "120.00",
-        "交易成功",
-        "2026-04-29 23:00:00",
-        "丙火电玩",
-        "2026-04-30 00:00:00",
-        "120.00",
-    ]]
+    rows2 = [_row(
+        order_no="ORDER_JUMP",
+        payment_no="PAY_J1",
+        payment_detail=_wechat_detail("PAY_J1", "120.00"),
+        buyer_paid="120.00",
+        status_zh="交易成功",
+        paid_at="2026-04-29 23:00:00",
+        shop_name="丙火电玩",
+        shipped_at="2026-04-30 00:00:00",
+        confirmed_at="2026-04-30 14:00:00",
+        confirmed_amount="120.00",
+    )]
     response = _post_import(client, shop.id, _build_xlsx(rows2))
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     payload = response.json()
     assert payload["statusChangedOrders"] == 1
 
     assert _wallet_balance(shop.unconfirmed_wechat_wallet_id) == Decimal("0.000000")
-    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("120.000000")
+    # 120 → fee 0.24 → net 119.76
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("119.760000")
 
     new_tx = _last_tx(shop.aggregator_frozen_wallet_id)
     assert new_tx.mature_at is not None
 
 
 # ---------------------------------------------------------------------------
-# 综合：多行 + 报告字段
+# 自动解冻（ImportReport 末尾自动跑）
+# ---------------------------------------------------------------------------
+
+
+def _seed_aggregator_frozen_tx(
+    shop: TaobaoShop,
+    amount: Decimal,
+    mature_at: datetime,
+    *,
+    bind_to_order: bool = True,
+    order_number: str | None = None,
+) -> int:
+    """灌一笔聚合冻结流水（可绑订单）。"""
+    db = database.SessionLocal()
+    try:
+        tx = credit(
+            db,
+            shop.aggregator_frozen_wallet_id,
+            amount,
+            remark="测试种子",
+            mature_at=mature_at,
+        )
+        if bind_to_order:
+            order = TaobaoOrder(
+                shop_id=shop.id,
+                order_number=order_number or f"SEED_{tx.id}",
+                payment_method=TaobaoOrderPaymentMethod.WECHAT.value,
+                amount=amount,
+                gross_amount=amount,
+                status=TaobaoOrderStatus.RECEIVED.value,
+                bookkeeping_wallet_id=shop.aggregator_frozen_wallet_id,
+                bookkeeping_tx_id=tx.id,
+            )
+            db.add(order)
+        db.commit()
+        return tx.id
+    finally:
+        db.close()
+
+
+def test_auto_release_on_import_moves_matured_to_available(client):
+    """fixture 灌入到期流水 → 导入新订单 → 报告含 autoReleased*。"""
+    shop = _shop_by_name("丙火电玩")
+    now = datetime.now(timezone.utc)
+    _seed_aggregator_frozen_tx(shop, Decimal("100"), now - timedelta(days=1), order_number="MAT_AR_1")
+    _seed_aggregator_frozen_tx(shop, Decimal("50"), now - timedelta(hours=2), order_number="MAT_AR_2")
+    _seed_aggregator_frozen_tx(shop, Decimal("80"), now + timedelta(days=3), order_number="FUT_AR")
+
+    # 解冻前 frozen=230, available=0
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("230.000000")
+    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("0.000000")
+
+    # 导入空数据行（仅触发末尾自动解冻）
+    rows: list[list] = []
+    response = _post_import(client, shop.id, _build_xlsx(rows))
+    assert response.status_code == 200, response.text
+    payload = response.json()
+
+    assert payload["autoReleasedCount"] == 2
+    assert Decimal(payload["autoReleasedAmount"]) == Decimal("150")
+
+    # 余额：frozen 80（仅未到期）, available 150
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("80.000000")
+    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("150.000000")
+
+
+def test_auto_release_no_matured_returns_zero(client):
+    """无任何到期流水时 autoReleased*=0,不动余额。"""
+    shop = _shop_by_name("丙火电玩")
+    now = datetime.now(timezone.utc)
+    _seed_aggregator_frozen_tx(shop, Decimal("99"), now + timedelta(days=2), order_number="FUT_ONLY_AR")
+
+    response = _post_import(client, shop.id, _build_xlsx([]))
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["autoReleasedCount"] == 0
+    assert Decimal(payload["autoReleasedAmount"]) == Decimal("0")
+
+    assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("99.000000")
+    assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("0.000000")
+
+
+def test_release_endpoint_removed_returns_404_or_405(client):
+    """一键解冻端点已删,POST 应 404/405。"""
+    shop = _shop_by_name("丙火电玩")
+    response = client.post(f"/taobao/shops/{shop.id}/aggregator/release")
+    assert response.status_code in (404, 405), response.text
+
+
+# ---------------------------------------------------------------------------
+# 综合：报告字段
 # ---------------------------------------------------------------------------
 
 
 def test_full_report_counts(client):
+    """5 行综合：报告字段全到位。"""
     shop = _shop_by_name("丙火电玩")
     rows = [
-        # 1) 新订单 received alipay
-        [
-            "F_RECV_AL",
-            "P1",
-            _alipay_detail("P1", "10.00"),
-            "10.00",
-            "交易成功",
-            "2026-04-29 23:00:00",
-            "丙火电玩",
-            "2026-04-30 00:00:00",
-            "10.00",
-        ],
-        # 2) 新订单 shipped_unconfirmed wechat
-        [
-            "F_SHIP_WX",
-            "P2",
-            _wechat_detail("P2", "20.00"),
-            "20.00",
-            "卖家已发货，等待买家确认",
-            "2026-04-29 23:00:00",
-            "丙火电玩",
-            "2026-04-30 00:00:00",
-            "0.00",
-        ],
-        # 3) 跳过: 等待付款
-        [
-            "F_PEND",
-            "P3",
-            _alipay_detail("P3", "0.00"),
-            "0.00",
-            "等待买家付款",
-            "",
-            "丙火电玩",
-            "",
-            "0.00",
-        ],
-        # 4) 跳过: 未知支付
-        [
-            "F_UNKNOWN",
-            "P4",
-            "支付方式：信用卡，金额：30.00；",
-            "30.00",
-            "交易成功",
-            "2026-04-29 23:00:00",
-            "丙火电玩",
-            "2026-04-30 00:00:00",
-            "30.00",
-        ],
-        # 5) closed 新单
-        [
-            "F_CLOSED",
-            "P5",
-            _alipay_detail("P5", "0.00"),
-            "0.00",
-            "交易关闭",
-            "",
-            "丙火电玩",
-            "",
-            "0.00",
-        ],
+        # 1) received alipay 10 → fee 0.02 → net 9.98
+        _row(
+            order_no="F_RECV_AL",
+            payment_no="P1",
+            payment_detail=_alipay_detail("P1", "10.00"),
+            buyer_paid="10.00",
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 14:00:00",
+            confirmed_amount="10.00",
+        ),
+        # 2) shipped wechat 20 (无 fee)
+        _row(
+            order_no="F_SHIP_WX",
+            payment_no="P2",
+            payment_detail=_wechat_detail("P2", "20.00"),
+            buyer_paid="20.00",
+            status_zh="卖家已发货，等待买家确认",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_amount="0.00",
+        ),
+        # 3) skip pending pay
+        _row(
+            order_no="F_PEND",
+            payment_no="P3",
+            payment_detail=_alipay_detail("P3", "0.00"),
+            buyer_paid="0.00",
+            status_zh="等待买家付款",
+            paid_at="",
+            shop_name="丙火电玩",
+            shipped_at="",
+            confirmed_amount="0.00",
+        ),
+        # 4) skip unknown payment
+        _row(
+            order_no="F_UNKNOWN",
+            payment_no="P4",
+            payment_detail="支付方式：信用卡，金额：30.00；",
+            buyer_paid="30.00",
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 14:00:00",
+            confirmed_amount="30.00",
+        ),
+        # 5) closed
+        _row(
+            order_no="F_CLOSED",
+            payment_no="P5",
+            payment_detail=_alipay_detail("P5", "0.00"),
+            buyer_paid="0.00",
+            status_zh="交易关闭",
+            paid_at="",
+            shop_name="丙火电玩",
+            shipped_at="",
+            confirmed_amount="0.00",
+        ),
     ]
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
@@ -751,44 +1025,51 @@ def test_full_report_counts(client):
 
     assert payload["shopName"] == "丙火电玩"
     assert payload["totalRowsParsed"] == 5
-    assert payload["createdOrders"] == 3  # received + shipped + closed-new
+    assert payload["createdOrders"] == 3
     assert payload["statusChangedOrders"] == 0
     assert payload["closedReverted"] == 0
     assert payload["skippedNoChange"] == 0
     assert payload["skippedUnpaidOrUnshipped"] == 1
     assert payload["skippedUnknownPayment"] == 1
     assert payload["errors"] == []
+    # 自动解冻 / 总手续费 字段都返回
+    assert "autoReleasedAmount" in payload
+    assert "autoReleasedCount" in payload
+    assert "totalFeeAmount" in payload
+    # 仅 1 个 received 行（10 → fee 0.02）
+    assert Decimal(payload["totalFeeAmount"]) == Decimal("0.02")
 
 
 def test_atomic_transaction_no_partial_on_db_error(client, monkeypatch):
     """单一事务原子：一条流水抛错应整个 rollback。"""
     shop = _shop_by_name("丙火电玩")
     rows = [
-        [
-            "OK_1",
-            "P1",
-            _alipay_detail("P1", "10.00"),
-            "10.00",
-            "交易成功",
-            "2026-04-29 23:00:00",
-            "丙火电玩",
-            "2026-04-30 00:00:00",
-            "10.00",
-        ],
-        [
-            "BAD_2",
-            "P2",
-            _alipay_detail("P2", "20.00"),
-            "20.00",
-            "交易成功",
-            "2026-04-29 23:00:00",
-            "丙火电玩",
-            "2026-04-30 00:00:00",
-            "20.00",
-        ],
+        _row(
+            order_no="OK_1",
+            payment_no="P1",
+            payment_detail=_alipay_detail("P1", "10.00"),
+            buyer_paid="10.00",
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 14:00:00",
+            confirmed_amount="10.00",
+        ),
+        _row(
+            order_no="BAD_2",
+            payment_no="P2",
+            payment_detail=_alipay_detail("P2", "20.00"),
+            buyer_paid="20.00",
+            status_zh="交易成功",
+            paid_at="2026-04-29 23:00:00",
+            shop_name="丙火电玩",
+            shipped_at="2026-04-30 00:00:00",
+            confirmed_at="2026-04-30 14:00:00",
+            confirmed_amount="20.00",
+        ),
     ]
 
-    # patch 第二次 credit 调用让它抛异常
     import src.services.taobao_import as ti_module
 
     original_credit = ti_module.credit
@@ -802,7 +1083,6 @@ def test_atomic_transaction_no_partial_on_db_error(client, monkeypatch):
 
     monkeypatch.setattr(ti_module, "credit", boom)
 
-    # 启用 raise_server_exceptions=False 后,RuntimeError 转 500
     no_raise_client = TestClient(app, raise_server_exceptions=False)
     response = no_raise_client.post(
         f"/taobao/shops/{shop.id}/import",
@@ -816,7 +1096,6 @@ def test_atomic_transaction_no_partial_on_db_error(client, monkeypatch):
     )
     assert response.status_code == 500
 
-    # 第一笔应该被 rollback,余额仍为 0
     assert _wallet_balance(shop.store_alipay_wallet_id) == Decimal("0.000000")
 
     db = database.SessionLocal()
@@ -828,19 +1107,20 @@ def test_atomic_transaction_no_partial_on_db_error(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# 模拟样例 281 条数据规模
+# 大样本回归（v2 14 列分布）
 # ---------------------------------------------------------------------------
 
 
-def test_large_sample_distribution(client):
-    """根据 scripts/qianniu_sample.json 状态分布生成 281 条（丙火电玩），跑通且报告字段对账。
+def test_large_sample_distribution_v2(client):
+    """根据 scripts/qianniu_sample_v2.json 状态分布生成 1738 条（丙火），跑通 + 对账。
 
-    分布:
-    - 交易成功                 : 55  (received)
-    - 卖家已发货,等待买家确认  : 181 (shipped_unconfirmed)
-    - 等待买家付款             : 10  (skipped)
-    - 交易关闭                 : 22  (closed)
-    - 买家已付款,等待卖家发货  : 12  (skipped)
+    v2 实际样例分布:
+    - 交易成功(received)            : 947
+    - 卖家已发货,等待买家确认(在途) : 676
+    - 交易关闭                      : 96
+    - 买家已付款,等待卖家发货(skip) : 19
+
+    支付方式分布: wechat 1325 / alipay 413 (近似)
     """
     shop = _shop_by_name("丙火电玩")
     rows: list[list] = []
@@ -857,52 +1137,52 @@ def test_large_sample_distribution(client):
             if status in ("交易成功", "卖家已发货，等待买家确认")
             else ""
         )
+        confirm_time = (
+            "2026-04-30 14:00:00" if status == "交易成功" else ""
+        )
         pay_time = (
             "2026-04-29 23:00:00"
             if status in ("交易成功", "卖家已发货，等待买家确认", "买家已付款,等待卖家发货")
             else ""
         )
-        rows.append([
-            order_no,
-            f"P{idx:04d}",
-            detail_fn(f"P{idx:04d}", str(amount)),
-            str(amount),
-            status,
-            pay_time,
-            "丙火电玩",
-            ship_time,
-            confirm_amount,
-        ])
+        rows.append(_row(
+            order_no=order_no,
+            payment_no=f"P{idx:04d}",
+            payment_detail=detail_fn(f"P{idx:04d}", str(amount)),
+            buyer_paid=str(amount),
+            status_zh=status,
+            paid_at=pay_time,
+            shop_name="丙火电玩",
+            shipped_at=ship_time,
+            confirmed_at=confirm_time,
+            confirmed_amount=confirm_amount,
+        ))
 
-    # 55 received
-    for i in range(55):
-        add("交易成功", Decimal("100.00"), "alipay" if i % 2 == 0 else "wechat")
-    # 181 shipped_unconfirmed
-    for i in range(181):
-        add("卖家已发货，等待买家确认", Decimal("50.00"), "alipay" if i % 2 == 0 else "wechat")
-    # 10 pending pay
-    for _ in range(10):
-        add("等待买家付款", Decimal("0.00"))
-    # 22 closed
-    for _ in range(22):
+    # received 947
+    for i in range(947):
+        add("交易成功", Decimal("100.00"), "alipay" if i % 4 == 0 else "wechat")
+    # shipped 676
+    for i in range(676):
+        add("卖家已发货，等待买家确认", Decimal("50.00"), "alipay" if i % 4 == 0 else "wechat")
+    # closed 96
+    for _ in range(96):
         add("交易关闭", Decimal("0.00"))
-    # 12 paid unshipped
-    for _ in range(12):
+    # paid_unshipped 19
+    for _ in range(19):
         add("买家已付款,等待卖家发货", Decimal("30.00"))
 
-    # 注：scripts/qianniu_sample.json 的 5 个状态计数和为 280；JSON 顶层 total_rows=281
-    # 与之有 1 行差异（怀疑是空行或不在 5 状态枚举里的样本）。我们按状态分布精确测,
-    # 这里行数应 = 280。
-    assert len(rows) == 280
+    assert len(rows) == 947 + 676 + 96 + 19  # 1738
+
     response = _post_import(client, shop.id, _build_xlsx(rows))
     assert response.status_code == 200, response.text
     p = response.json()
 
-    assert p["totalRowsParsed"] == 280
-    # received(55) + shipped(181) + closed(22) 都建订单，pending+unshipped(22) 跳过
-    assert p["createdOrders"] == 55 + 181 + 22
-    assert p["skippedUnpaidOrUnshipped"] == 10 + 12
+    assert p["totalRowsParsed"] == 1738
+    assert p["createdOrders"] == 947 + 676 + 96
+    assert p["skippedUnpaidOrUnshipped"] == 19
     assert p["skippedUnknownPayment"] == 0
     assert p["statusChangedOrders"] == 0
     assert p["closedReverted"] == 0
     assert p["errors"] == []
+    # 947 个 received,每条 100 → fee 0.20 → 总 fee = 947 * 0.20 = 189.40
+    assert Decimal(p["totalFeeAmount"]) == Decimal("189.40")

--- a/tests/test_taobao_shops_api.py
+++ b/tests/test_taobao_shops_api.py
@@ -219,6 +219,7 @@ def _seed_frozen_tx(
                 order_number=order_number or f"SEED_{tx.id}",
                 payment_method=TaobaoOrderPaymentMethod.WECHAT.value,
                 amount=amount,
+                gross_amount=amount,
                 status=TaobaoOrderStatus.RECEIVED.value,
                 bookkeeping_wallet_id=shop.aggregator_frozen_wallet_id,
                 bookkeeping_tx_id=tx.id,


### PR DESCRIPTION
## Summary

闭 Issue #84。千牛 v2 大重构：14 列 Excel + 0.2% 手续费 + 导入末尾自动解冻 + 删一键解冻端点。

### 数据模型

- `TaobaoOrder` 新增 3 字段:
  - `gross_amount`: Excel 原始金额（received 用"确认收货打款金额"，在途用"买家实付金额"）
  - `fee_amount`: 仅 received 时填值；在途为 NULL
  - `confirmed_at`: 来自 Excel "确认收货时间"（微信 mature_at 计算基础）
- `amount` 字段语义改为"当前入账钱包的金额"（在途=gross，确认=net），不改名免破坏 reconcile

### Excel 解析升级（14 列）

`EXPECTED_HEADERS` 升级为严格 14 列：
```
订单编号 / 支付单号 / 支付详情 / 买家实付金额 / 订单状态 /
订单创建时间 / 订单付款时间 / 宝贝种类 / 店铺名称 / 卖家服务费 /
退款金额 / 发货时间 / 确认收货时间 / 确认收货打款金额
```

列号重映射：店铺名 col 6→8、发货时间 col 7→11、确认收货打款金额 col 8→13、新增 col 12 确认收货时间。

CEO 同意忽略 col 5/7/9/10（仅占位校验）。

### 0.2% 手续费规则

新增 helper `compute_fee_and_net(gross) -> (fee, net)`：
```python
fee = (gross * Decimal("0.002")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
net = gross - fee
```

CEO 边界值实测均通过：
- 56.00 → fee 0.11 net 55.89
- 269.00 → fee 0.54 net 268.46
- 27.50 → fee 0.06 net 27.44 (0.055 → ROUND_HALF_UP → 0.06)
- 100.00 → fee 0.20 net 99.80

仅 `received` 时扣；在途订单 `amount = gross`、`fee_amount = NULL`。

### mature_at 算法切换

微信 + received 时：`mature_at = confirmed_at + 7d`（不再用 shipped_at + 7d）。

`confirmed_at` 缺失时兜底 `shipped_at + 7d`，再缺则 `now() + 7d`（防御 Excel 异常）。

### Reconcile：在途→确认

旧流水按老 `amount`（即 gross）debit；新流水按 `net` credit。差额 0.2% 自然消失（视为淘宝平台吃掉的手续费，不单独记流水）。

### 导入末尾自动解冻

新增 `_auto_release_aggregator(session, shop)`，在 `import_qianniu_workbook` 末尾自动调用。复用 `calculate_pending_maturity` helper，与原 release 端点逻辑一致：
- 仅算 `mature_at <= now` 且仍被 `TaobaoOrder.bookkeeping_tx_id` 引用的流水
- 累计金额从 frozen debit、credit 到 available

### `ImportReport` 加 3 字段

- `auto_released_amount`: 本次导入自动解冻的累计金额
- `auto_released_count`: 解冻笔数
- `total_fee_amount`: 本次产生的手续费总和（CEO 核对用）

### 删除一键解冻端点

- 删除 `POST /taobao/shops/{id}/aggregator/release` handler
- 删除 `ReleaseReportOut` Pydantic schema
- 保留 `calculate_pending_maturity` helper（GET /taobao/shops + 自动解冻仍用）

### 数据库迁移

**直接删 finance.db 重建**（系统未上线，与之前几次重构一致）。生产部署只需在切换前清空数据库。

## Test plan

- [x] 14 列严格表头：通过/中间列名错/列数不足/v1 旧 9 列被拒 全覆盖
- [x] 手续费精度：56/269/27.50/100/57 五个 ROUND_HALF_UP 边界 parametrize 全过
- [x] 在途订单 amount=gross / fee=NULL / confirmed_at=NULL
- [x] 已确认订单 amount=net / fee/gross/confirmed_at 都填值
- [x] mature_at = confirmed_at + 7d；缺失时兜底 shipped_at + 7d
- [x] reconcile 在途→确认：debit gross + credit net（差额=fee 自然消失）+ 老 amount 是 gross
- [x] reconcile 跨级 wechat 在途→确认：mature_at 也补上
- [x] 自动解冻：3 笔（2 已到期 + 1 未到）→ autoReleased*=2 笔/150；无到期=0
- [x] POST /aggregator/release 返回 405
- [x] totalFeeAmount 跨多行求和（0.11+0.54+0.20=0.85）
- [x] 大样本回归 v2 1738 条（受 947+在途 676+关闭 96+跳过 19）
- [x] 全模块 `python -m pytest tests/ -v`：139 / 139 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)