### PR TITLE
[PR] [FEAT-F15] 淘宝页同步 v2 后端

### DIFF
--- a/frontend/components/taobao-page.tsx
+++ b/frontend/components/taobao-page.tsx
@@ -7,7 +7,6 @@ import {
   CheckCircle2,
   FileSpreadsheet,
   ListOrdered,
-  Loader2,
   RefreshCcw,
   Snowflake,
   Wallet,
@@ -22,7 +21,6 @@ import {
   getTaobaoShops,
   getTaobaoWalletTransactions,
   importTaobaoExcel,
-  releaseAggregator,
   transferTaobaoToStoreAlipay,
   withdrawTaobao
 } from "@/lib/api";
@@ -30,7 +28,6 @@ import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import type {
   TaobaoImportReport,
-  TaobaoReleaseReport,
   TaobaoShop,
   TaobaoShopWallet,
   WalletBalance
@@ -521,6 +518,28 @@ function ImportExcelModal({ shop, onClose }: { shop: TaobaoShop; onClose: () => 
                 <ReportRow label="跳过（未付款/未发货）" value={report.skippedUnpaidOrUnshipped} />
                 <ReportRow label="跳过（未知支付方式）" value={report.skippedUnknownPayment} />
               </div>
+              {report.totalFeeAmountMinor > 0 || report.autoReleasedCount > 0 ? (
+                <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3 text-sm">
+                  <div className="flex items-center gap-2 font-medium text-emerald-700">
+                    <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+                    自动结算
+                  </div>
+                  <div className="mt-2 space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-muted-foreground">本次手续费</span>
+                      <span className="tabular-nums text-sm font-semibold text-muted-foreground">
+                        {formatMoney(report.totalFeeAmountMinor, "CNY")}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-xs text-emerald-700">自动解冻</span>
+                      <span className="tabular-nums text-sm font-semibold text-emerald-700">
+                        {report.autoReleasedCount} 笔（{formatMoney(report.autoReleasedAmountMinor, "CNY")}）
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
               {report.errors.length > 0 ? (
                 <div className="space-y-1 rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm">
                   <div className="font-medium text-red-700">错误 {report.errors.length} 条</div>
@@ -535,7 +554,7 @@ function ImportExcelModal({ shop, onClose }: { shop: TaobaoShop; onClose: () => 
           ) : (
             <>
               <div className="rounded-md border border-dashed border-border p-3 text-xs text-muted-foreground">
-                上传千牛后台导出的 .xlsx 文件，按规则入账每条订单并对老订单做 reconcile。
+                请上传过去 14 天的千牛 Excel（.xlsx），按规则入账每条订单并对老订单做 reconcile，导入末尾系统会自动扣手续费 + 自动解冻已到期订单。
               </div>
               <div className="space-y-1">
                 <div className="text-sm text-muted-foreground">选择 Excel 文件</div>
@@ -618,18 +637,15 @@ function WalletRow({
   onShowTransactions,
   onWithdraw,
   onTransferToStoreAlipay,
-  releasing,
-  onRelease,
   maturityInfo
 }: {
   row: WalletRowDef;
   onShowTransactions: (wallet: TaobaoShopWallet, label: string) => void;
   onWithdraw: () => void;
   onTransferToStoreAlipay: () => void;
-  releasing: boolean;
-  onRelease: () => void;
-  // PR #82：仅聚合冻结行使用，传后端实时聚合的"待解冻"金额 + 笔数
-  // 决定按钮高亮（emerald）与否（ghost 灰色），并在行下方显示信息条
+  // PR #85：聚合冻结行的"待解冻"信息条，从 GET shops 实时聚合数据来
+  // 仅在 maturedCount > 0 时显示提示文案"↳ 下次导入将自动解冻 ¥X (N 笔)"
+  // 旧"一键解冻"按钮已下线（端点 405），由"导入 Excel"末尾的 autoRelease 自动完成
   maturityInfo?: { maturedAmountMinor: number; maturedCount: number };
 }) {
   const isBankCard = row.kind === "bank-card";
@@ -645,8 +661,6 @@ function WalletRow({
           ? "text-amber-700"
           : "text-foreground";
 
-  // 聚合冻结行：是否有可解冻笔数（后端实时数据 OR 本次解冻 report 里的 maturedCount）
-  const hasMatured = isFrozen && (maturityInfo?.maturedCount ?? 0) > 0;
   const showMaturityBar = isFrozen && maturityInfo && maturityInfo.maturedCount > 0;
 
   return (
@@ -661,27 +675,6 @@ function WalletRow({
             {formatMoney(row.wallet.balanceMinor, "CNY")}
           </div>
           <div className="flex flex-wrap items-center gap-1.5">
-            {isFrozen ? (
-              <Button
-                variant={hasMatured ? "outline" : "ghost"}
-                size="sm"
-                onClick={onRelease}
-                disabled={releasing}
-                className={cn(
-                  hasMatured
-                    ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 hover:bg-emerald-500/20"
-                    : "text-muted-foreground"
-                )}
-                title={hasMatured ? "一键解冻所有到期" : "暂无可解冻"}
-              >
-                {releasing ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
-                ) : (
-                  <Snowflake className="h-3.5 w-3.5" aria-hidden="true" />
-                )}
-                一键解冻到期
-              </Button>
-            ) : null}
             {isAvailable ? (
               <Button variant="outline" size="sm" onClick={onWithdraw}>
                 <ArrowRightLeft className="h-3.5 w-3.5" aria-hidden="true" />
@@ -706,7 +699,7 @@ function WalletRow({
         </div>
         {showMaturityBar ? (
           <div className="text-xs tabular-nums text-emerald-600">
-            ↳ 待解冻 {formatMoney(maturityInfo.maturedAmountMinor, "CNY")} ({maturityInfo.maturedCount} 笔)
+            ↳ 下次导入将自动解冻 {formatMoney(maturityInfo.maturedAmountMinor, "CNY")} ({maturityInfo.maturedCount} 笔)
           </div>
         ) : null}
       </div>
@@ -731,24 +724,6 @@ function ShopCard({
   onTransferToStoreAlipay: () => void;
   onImport: () => void;
 }) {
-  const queryClient = useQueryClient();
-  const [releaseReport, setReleaseReport] = useState<TaobaoReleaseReport | null>(null);
-  const [releaseError, setReleaseError] = useState<string | null>(null);
-
-  const releaseMutation = useMutation({
-    mutationFn: () => releaseAggregator(shop.id),
-    onSuccess: async (report) => {
-      setReleaseReport(report);
-      setReleaseError(null);
-      await queryClient.invalidateQueries({ queryKey: ["taobao-shops"] });
-      await queryClient.invalidateQueries({ queryKey: ["taobao-wallet-transactions", shop.id] });
-    },
-    onError: (err) => {
-      setReleaseError(err instanceof Error ? err.message : "解冻失败");
-      setReleaseReport(null);
-    }
-  });
-
   const rows = getWalletRows(shop);
   const isBookkeeping = shop.storeAlipayWallet.type === "TAOBAO";
 
@@ -829,8 +804,6 @@ function ShopCard({
               onShowTransactions={onShowTransactions}
               onWithdraw={onWithdraw}
               onTransferToStoreAlipay={onTransferToStoreAlipay}
-              releasing={releaseMutation.isPending}
-              onRelease={() => releaseMutation.mutate()}
               maturityInfo={
                 row.kind === "aggregator-frozen"
                   ? {
@@ -842,41 +815,6 @@ function ShopCard({
             />
           ))}
         </div>
-        {releaseError ? (
-          <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
-            解冻失败：{releaseError}
-          </div>
-        ) : null}
-        {releaseReport ? (
-          <div className="rounded-md border border-emerald-500/40 bg-emerald-50/60 p-3 text-sm">
-            <div className="flex items-center gap-2 font-medium text-emerald-700">
-              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
-              {releaseReport.maturedCount > 0
-                ? `已解冻 ${releaseReport.maturedCount} 笔到期`
-                : "暂无到期可解冻"}
-            </div>
-            <div className="mt-1 grid grid-cols-2 gap-2 text-xs text-emerald-700/90">
-              <div>
-                累计解冻
-                <span className="ml-1 tabular-nums font-semibold">
-                  {formatMoney(releaseReport.maturedAmountMinor, "CNY")}
-                </span>
-              </div>
-              <div>
-                冻结余额
-                <span className="ml-1 tabular-nums font-semibold">
-                  {formatMoney(releaseReport.frozenBalanceAfterMinor, "CNY")}
-                </span>
-              </div>
-              <div className="col-span-2">
-                可提现余额
-                <span className="ml-1 tabular-nums font-semibold">
-                  {formatMoney(releaseReport.availableBalanceAfterMinor, "CNY")}
-                </span>
-              </div>
-            </div>
-          </div>
-        ) : null}
       </CardContent>
     </Card>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -27,7 +27,6 @@ import type {
   TaobaoOrder,
   TaobaoOrderPaymentMethod,
   TaobaoOrderStatus,
-  TaobaoReleaseReport,
   TaobaoShop,
   TaobaoShopWallet,
   TaobaoStoreAlipayWallet,
@@ -555,18 +554,14 @@ type TaobaoImportReportResponse = {
   skipped_unpaid_or_unshipped?: number;
   skippedUnknownPayment?: number;
   skipped_unknown_payment?: number;
+  // PR #85：自动结算字段
+  autoReleasedAmount?: string | number;
+  auto_released_amount?: string | number;
+  autoReleasedCount?: number;
+  auto_released_count?: number;
+  totalFeeAmount?: string | number;
+  total_fee_amount?: string | number;
   errors?: string[];
-};
-
-type TaobaoReleaseReportResponse = {
-  maturedCount?: number;
-  matured_count?: number;
-  maturedAmount?: string | number;
-  matured_amount?: string | number;
-  frozenBalanceAfter?: string | number;
-  frozen_balance_after?: string | number;
-  availableBalanceAfter?: string | number;
-  available_balance_after?: string | number;
 };
 
 type TaobaoFlowReportResponse = {
@@ -683,16 +678,16 @@ function normalizeImportReport(data: TaobaoImportReportResponse): TaobaoImportRe
     skippedNoChange: Number(data.skippedNoChange ?? data.skipped_no_change ?? 0),
     skippedUnpaidOrUnshipped: Number(data.skippedUnpaidOrUnshipped ?? data.skipped_unpaid_or_unshipped ?? 0),
     skippedUnknownPayment: Number(data.skippedUnknownPayment ?? data.skipped_unknown_payment ?? 0),
+    autoReleasedAmountMinor: decimalToMinor(
+      data.autoReleasedAmount ?? data.auto_released_amount ?? 0,
+      "CNY"
+    ),
+    autoReleasedCount: Number(data.autoReleasedCount ?? data.auto_released_count ?? 0),
+    totalFeeAmountMinor: decimalToMinor(
+      data.totalFeeAmount ?? data.total_fee_amount ?? 0,
+      "CNY"
+    ),
     errors: data.errors ?? []
-  };
-}
-
-function normalizeReleaseReport(data: TaobaoReleaseReportResponse): TaobaoReleaseReport {
-  return {
-    maturedCount: Number(data.maturedCount ?? data.matured_count ?? 0),
-    maturedAmountMinor: decimalToMinor(data.maturedAmount ?? data.matured_amount ?? 0, "CNY"),
-    frozenBalanceAfterMinor: decimalToMinor(data.frozenBalanceAfter ?? data.frozen_balance_after ?? 0, "CNY"),
-    availableBalanceAfterMinor: decimalToMinor(data.availableBalanceAfter ?? data.available_balance_after ?? 0, "CNY")
   };
 }
 
@@ -745,14 +740,6 @@ export async function importTaobaoExcel(shopId: string, file: File): Promise<Tao
 
   const data = (text ? JSON.parse(text) : {}) as TaobaoImportReportResponse;
   return normalizeImportReport(data);
-}
-
-export async function releaseAggregator(shopId: string): Promise<TaobaoReleaseReport> {
-  const data = (await postJson(
-    `/api/taobao/shops/${shopId}/aggregator/release`,
-    {}
-  )) as TaobaoReleaseReportResponse;
-  return normalizeReleaseReport(data);
 }
 
 export async function withdrawTaobao(

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -183,14 +183,13 @@ export type TaobaoImportReport = {
   skippedNoChange: number;
   skippedUnpaidOrUnshipped: number;
   skippedUnknownPayment: number;
+  // PR #85：本次导入末尾自动结算（autoRelease + 手续费扣减）
+  // - autoReleasedAmountMinor / autoReleasedCount：本次自动解冻的金额 + 笔数
+  // - totalFeeAmountMinor：本次导入产生的手续费总和
+  autoReleasedAmountMinor: number;
+  autoReleasedCount: number;
+  totalFeeAmountMinor: number;
   errors: string[];
-};
-
-export type TaobaoReleaseReport = {
-  maturedCount: number;
-  maturedAmountMinor: number;
-  frozenBalanceAfterMinor: number;
-  availableBalanceAfterMinor: number;
 };
 
 export type TaobaoFlowReport = {


### PR DESCRIPTION
## Summary
- 删除"一键解冻"按钮（PR #85 端点已 405/404）+ ReleaseAggregatorReport 弹窗 + 相关 state/mutation
- 聚合冻结行保留"待解冻"提示，文案改成 `↳ 下次导入将自动解冻 ¥X (N 笔)`
- 导入报告弹窗加"自动结算"一节：手续费灰色、自动解冻 emerald 高亮，仅 totalFeeAmount>0 或 autoReleasedCount>0 显示
- Excel 上传文案改成"请上传过去 14 天的千牛 Excel"
- types.ts + lib/api.ts 同步 ImportReport 三个新字段（autoReleasedAmountMinor / autoReleasedCount / totalFeeAmountMinor，camel/snake 双向兼容）

Closes #86

## 文件变更
- `frontend/types.ts`：TaobaoImportReport 加 3 字段；删除 TaobaoReleaseReport
- `frontend/lib/api.ts`：normalizeImportReport 加 3 字段解析；删除 releaseAggregator + 关联类型/normalize
- `frontend/components/taobao-page.tsx`：删除一键解冻按钮 + ShopCard 内 release mutation 整套 + 底部报告 UI；ImportReportModal 加自动结算节；Excel 上传文案改写；WalletRow props 简化
- `frontend/lib/mock-data.ts`：未改动（无 mockImportReport，TaobaoOrder type 未加新字段，遵循 PM 派发指令的 4 件核心事范围）

## Test plan
- [x] `cd frontend && npm run typecheck` 零错误
- [x] `curl -X POST http://localhost:8000/taobao/shops/1/aggregator/release` → 404（端点已下线，符合预期）
- [x] 聚合冻结行 maturedCount > 0 时显示"↳ 下次导入将自动解冻 ¥X (N 笔)"，maturedCount = 0 时隐藏
- [x] 导入完成弹窗：totalFeeAmount=0 且 autoReleasedCount=0 时不显示"自动结算"节；其一 > 0 时显示
- [x] Excel 上传弹窗未选文件时显示新文案"请上传过去 14 天的千牛 Excel"

## 视觉对齐
- 自动解冻一节：`bg-emerald-500/10 border-emerald-500/40 text-emerald-700`（与原 release report 同色系）
- 手续费数字：`text-muted-foreground`（灰色不刺激，符合 Issue 规定）
- 自动解冻数字：`text-emerald-700`（突出系统帮你做了事）

🤖 Generated with [Claude Code](https://claude.com/claude-code)