### PR TITLE
fix(taobao): mature_at 改回精确 confirmed_at + 7d（对齐千牛后台）

### DIFF
--- a/src/services/taobao_import.py
+++ b/src/services/taobao_import.py
@@ -4,8 +4,9 @@
 1. 解析 .xlsx 文件 → 标准化结构化行（v2 14 列严格表头）
 2. 按 14 个字段 / 5 状态映射 / 2 支付方式 / 2 店铺类型分流入账
 3. 0.6% 手续费规则：仅 received 时扣（gross - round(gross*0.006, 2)）
-4. 微信/received 的 mature_at = ``(确认收货日期 + 7 天) 当天 00:00:00``
-   —— 按"日"对齐：5/5 任何时刻确认的订单 → 5/12 0:00 起一起到期解冻
+4. 微信/received 的 mature_at = ``confirmed_at + 7 天``（精确到分秒，与千牛后台一致）
+   —— 4/29 14:30 确认 → 5/6 14:30 进入"聚合可提现"显示
+   —— 实际可点提现按钮要等 5/7（与千牛节奏一致，CEO 手动把控,系统不强制拦截）
 5. 老订单状态变化 reconcile（撤旧流水 + 建新流水；在途→确认差额=fee 自然消失）
 6. 导入末尾自动跑解冻（与原 release_aggregator 端点逻辑一致）
 7. 单一事务原子（异常由调用方 rollback）
@@ -334,13 +335,12 @@ def _credit_for_row(
     wallet_id: int,
     amount: Decimal,
 ) -> WalletTransaction:
-    """按规则 credit。微信/received 写 mature_at = (确认收货日期 + 7 天) 当天 00:00:00。
+    """按规则 credit。微信/received 写 mature_at = confirmed_at + 7 天（精确到分秒）。
 
     ``amount`` 已是入账钱包应入账的"当前金额"（received 是 net；shipped_unconfirmed 是 gross）。
 
-    mature_at 按"日"对齐：5/5 14:30 与 5/5 02:15 确认的订单 mature_at 都是 5/12 00:00:00，
-    这样 5/12 任意时刻调用 release（mature_at <= now()）都能把 5/5 整天订单一起解冻，
-    符合 CEO 业务"每天解冻 7 天前 0 点到 23:59 的订单"逻辑。
+    mature_at 与千牛后台一致：4/29 14:30 确认收货 → 5/6 14:30 进入"聚合可提现"。
+    （CEO 沿千牛节奏手动操作提现,系统不强制拦截当天提现）
     """
     mature_at: Optional[datetime] = None
     if (
@@ -349,9 +349,7 @@ def _credit_for_row(
     ):
         # 优先用 confirmed_at（Excel "确认收货时间"），缺失时兜底用 shipped_at；都缺则 now()
         base = parsed.confirmed_at or parsed.shipped_at or datetime.now()
-        # 按"日"对齐：截到当天 0:00:00 再加 7 天 → 7 天后的 0:00:00 起到期
-        base_day_start = base.replace(hour=0, minute=0, second=0, microsecond=0)
-        mature_at = base_day_start + timedelta(days=WECHAT_MATURE_DAYS)
+        mature_at = base + timedelta(days=WECHAT_MATURE_DAYS)
     remark = f"千牛订单 #{parsed.order_number} {parsed.system_status.value}"
     return credit(
         session,

--- a/tests/test_taobao_import_api.py
+++ b/tests/test_taobao_import_api.py
@@ -410,9 +410,9 @@ def test_new_wechat_received_to_aggregator_frozen_with_mature_at_from_confirmed_
     tx = _last_tx(shop.aggregator_frozen_wallet_id)
     assert tx is not None
     assert tx.mature_at is not None
-    # mature_at 按"日"对齐：confirmed_at 当天 0:00 + 7 天
+    # mature_at 精确到分秒：与千牛后台一致 confirmed_at + 7 天
     confirmed_dt = datetime.strptime(confirmed_at_str, "%Y-%m-%d %H:%M:%S")
-    expected_mature = confirmed_dt.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
+    expected_mature = confirmed_dt + timedelta(days=7)
     assert tx.mature_at.replace(tzinfo=None) == expected_mature
 
 
@@ -436,9 +436,9 @@ def test_mature_at_falls_back_to_shipped_at_when_confirmed_at_missing(client):
     assert response.status_code == 200, response.text
 
     tx = _last_tx(shop.aggregator_frozen_wallet_id)
-    # mature_at 按"日"对齐：shipped_at 当天 0:00 + 7 天
+    # mature_at 精确到分秒：与千牛后台一致 shipped_at + 7 天
     shipped_dt = datetime.strptime(shipped_at_str, "%Y-%m-%d %H:%M:%S")
-    expected = shipped_dt.replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=7)
+    expected = shipped_dt + timedelta(days=7)
     assert tx.mature_at.replace(tzinfo=None) == expected
 
 


### PR DESCRIPTION
## 背景
PR #89 把 mature_at 改成「按日对齐到当天 0:00:00 + 7 天」，CEO 实际验证发现这与千牛后台不一致：
- 4/29 14:30 确认收货 → 千牛后台显示解冻时刻是 **5/6 14:30**（精确到分秒），不是 5/6 00:00:00
- 系统应当与千牛口径完全一致

## 修改
1. `src/services/taobao_import.py:_credit_for_row` 去掉 `base.replace(hour=0, minute=0, second=0, microsecond=0)`，直接 `mature_at = base + timedelta(days=7)`
2. 模块 docstring 更新：明示「精确到分秒,与千牛后台一致」
3. 注明实际可点提现按钮要次日中午——CEO 沿千牛节奏手动操作,系统**不强制拦截**当天提现
4. 两处测试期望值移除日对齐逻辑

## 不变
- `FEE_RATE = 0.006`（0.6% 手续费）
- 自动解冻仍在导入末尾触发（`_auto_release_aggregator`）
- 「可提现」钱包显示口径不变

## 测试
139/139 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)