### PR TITLE
chore(time): 所有系统时间统一中国时区(UTC+8)

### DIFF
--- a/scripts/migrate_utc_timestamps_to_china.py
+++ b/scripts/migrate_utc_timestamps_to_china.py
@@ -1,0 +1,90 @@
+"""一次性迁移：把历史 UTC 时间戳 +8h 改成中国时间。
+
+背景：
+  PR chore/all-times-china 之前,SQLite ``server_default=func.now()`` 写的是
+  ``CURRENT_TIMESTAMP``（UTC,长度 19,无毫秒）。这与 Python 写入的 China naive
+  （长度 26,带毫秒）混存,导致同一表 created_at 列上存在 8 小时跳变。
+
+PR 后所有写入都用 ``china_now()``（长度 26,毫秒,中国本地）。
+本脚本把存量长度=19 的值 +8h 转成长度=26 的中国时间。
+
+判定方法（精确）：
+  对每个目标列：
+    - WHERE length(col) = 19   → 旧 UTC,执行 col = strftime('%Y-%m-%d %H:%M:%f000', datetime(col, '+8 hours'))
+    - WHERE length(col) = 26   → 已是中国,跳过
+
+幂等：可重复运行,不会重复 +8h（只看长度 19 的）。
+
+迁移目标列：
+  - wallets.created_at        (server_default 写的 UTC)
+  - wallets.deleted_at        (assets.py 老代码用 func.now() 写的 UTC,新代码已改 china_now)
+  - wallet_transactions.created_at
+  - taobao_shops.created_at
+  - taobao_orders.recorded_at  (server_default 写的 UTC)
+
+不动：
+  - taobao_orders.last_synced_at  (Python 写的,长度 26,已是中国)
+  - 所有 Excel 源时间(shipped_at/confirmed_at/received_at): 已是中国
+  - WalletTransaction.mature_at: 已是中国
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+TARGETS = [
+    ("wallets", "created_at"),
+    ("wallets", "deleted_at"),
+    ("wallet_transactions", "created_at"),
+    ("taobao_shops", "created_at"),
+    ("taobao_orders", "recorded_at"),
+]
+
+
+def main(db_path: str = "finance.db") -> None:
+    if not Path(db_path).exists():
+        raise FileNotFoundError(f"DB 文件不存在: {db_path}")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        for table, col in TARGETS:
+            # 先看有多少行需要迁移
+            count = conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE {col} IS NOT NULL AND length({col}) = 19"
+            ).fetchone()[0]
+
+            if count == 0:
+                print(f"[{table}.{col}] 无 UTC 长度=19 的行,跳过")
+                continue
+
+            sample = conn.execute(
+                f"SELECT {col} FROM {table} WHERE length({col}) = 19 LIMIT 1"
+            ).fetchone()
+            print(f"[{table}.{col}] {count} 行待 +8h，旧样本: {sample[0]}")
+
+            # +8h 并补足毫秒位 → 标准化为长度 26
+            conn.execute(
+                f"""
+                UPDATE {table}
+                SET {col} = strftime('%Y-%m-%d %H:%M:%f000', datetime({col}, '+8 hours'))
+                WHERE {col} IS NOT NULL AND length({col}) = 19
+                """
+            )
+
+            new_sample = conn.execute(
+                f"SELECT {col} FROM {table} WHERE rowid IN (SELECT rowid FROM {table} ORDER BY rowid LIMIT 1)"
+            ).fetchone()
+            print(f"  ✓ 已 +8h，新样本: {new_sample[0]}")
+
+        conn.commit()
+        print("\n[OK] 迁移完成,已 commit")
+    except Exception as exc:
+        conn.rollback()
+        print(f"\n[ERROR] {exc}")
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/models/taobao.py
+++ b/src/models/taobao.py
@@ -6,11 +6,12 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
 from src.models.wallet import Wallet
+from src.utils.time import china_now
 
 
 class TaobaoOrderPaymentMethod(str, Enum):
@@ -51,7 +52,7 @@ class TaobaoShop(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
 
     store_alipay_wallet: Mapped[Wallet] = relationship(
@@ -119,12 +120,12 @@ class TaobaoOrder(Base):
     last_synced_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
     recorded_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
 
     shop: Mapped[TaobaoShop] = relationship(foreign_keys=[shop_id])

--- a/src/models/vendor.py
+++ b/src/models/vendor.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
 from src.models.wallet import Wallet
+from src.utils.time import china_now
 
 
 class Vendor(Base):
@@ -21,7 +22,7 @@ class Vendor(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
 
     wallet: Mapped[Wallet] = relationship("Wallet", foreign_keys=[wallet_id])

--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -6,10 +6,11 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Numeric, String, Text, func, select
+from sqlalchemy import Boolean, DateTime, ForeignKey, Numeric, String, Text, select
 from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from src.database import Base
+from src.utils.time import china_now
 
 
 class WalletType(str, Enum):
@@ -48,7 +49,7 @@ class Wallet(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
     deleted_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True),
@@ -77,7 +78,7 @@ class WalletTransaction(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
     mature_at: Mapped[Optional[datetime]] = mapped_column(
         DateTime(timezone=True),

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -6,10 +6,11 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text, func
+from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
+from src.utils.time import china_now
 
 
 class XboxCountry(str, Enum):
@@ -44,7 +45,7 @@ class XboxAccount(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
 
     transactions: Mapped[list["XboxTransaction"]] = relationship(
@@ -65,7 +66,7 @@ class XboxTransaction(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        server_default=func.now(),
+        default=china_now,
     )
 
     account: Mapped[XboxAccount] = relationship(back_populates="transactions")

--- a/src/routers/assets.py
+++ b/src/routers/assets.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from src.database import get_db
 from src.models.wallet import Wallet, credit, debit, list_transactions
 from src.services.assets import create_asset_sub_wallet, is_asset_wallet, list_asset_wallets
+from src.utils.time import china_now
 
 
 router = APIRouter(prefix="/wallets/assets", tags=["asset-wallets"])
@@ -214,7 +215,7 @@ def delete_asset_wallet(
             detail="请先删除子钱包",
         )
 
-    wallet.deleted_at = func.now()
+    wallet.deleted_at = china_now()
     db.commit()
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/src/services/taobao_import.py
+++ b/src/services/taobao_import.py
@@ -37,6 +37,7 @@ from src.models.wallet import (
     debit,
 )
 from src.services.taobao_maturity import calculate_pending_maturity, matured_active_txs
+from src.utils.time import china_now
 
 
 # 千牛 v2 导出 Excel 的标准表头（14 列严格匹配，多 1 列、少 1 列、列名错都视为结构错）
@@ -348,7 +349,7 @@ def _credit_for_row(
         and parsed.system_status == TaobaoOrderStatus.RECEIVED
     ):
         # 优先用 confirmed_at（Excel "确认收货时间"），缺失时兜底用 shipped_at；都缺则 now()
-        base = parsed.confirmed_at or parsed.shipped_at or datetime.now()
+        base = parsed.confirmed_at or parsed.shipped_at or china_now()
         mature_at = base + timedelta(days=WECHAT_MATURE_DAYS)
     remark = f"千牛订单 #{parsed.order_number} {parsed.system_status.value}"
     return credit(
@@ -574,7 +575,7 @@ def _handle_existing_order(
 
     if old_status_value == parsed.system_status.value:
         # 情况 2：无变化
-        order.last_synced_at = datetime.now()
+        order.last_synced_at = china_now()
         report.skipped_no_change += 1
         return
 
@@ -585,7 +586,7 @@ def _handle_existing_order(
         order.status = TaobaoOrderStatus.CLOSED.value
         order.bookkeeping_wallet_id = None
         order.bookkeeping_tx_id = None
-        order.last_synced_at = datetime.now()
+        order.last_synced_at = china_now()
         report.closed_reverted += 1
         return
 

--- a/src/services/taobao_maturity.py
+++ b/src/services/taobao_maturity.py
@@ -26,11 +26,12 @@ from sqlalchemy.orm import Session
 
 from src.models.taobao import TaobaoOrder
 from src.models.wallet import TransactionDirection, WalletTransaction
+from src.utils.time import china_now
 
 
 def _today_cutoff() -> datetime:
-    """返回明天 00:00:00（naive 本地时间）—— mature_at < cutoff 即视为今天或之前到期。"""
-    now = datetime.now()
+    """返回明天 00:00:00（中国时间 naive）—— mature_at < cutoff 即视为今天或之前到期。"""
+    now = china_now()
     today_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     return today_start + timedelta(days=1)
 

--- a/src/utils/time.py
+++ b/src/utils/time.py
@@ -1,0 +1,27 @@
+"""时间工具：所有系统时间统一使用中国时区(UTC+8)。
+
+设计原则：
+1. 所有写入 DB 的 datetime 都是 ``china_now()`` 返回的 naive 中国本地时间
+   （tzinfo=None,但语义为 UTC+8）
+2. 来自千牛 Excel 的 confirmed_at / shipped_at 等天然就是中国本地,不再转换
+3. 不再使用 ``func.now()`` (SQLite CURRENT_TIMESTAMP 是 UTC) 和
+   ``datetime.now(timezone.utc)``,以避免和 Excel 数据混 8 小时
+4. 用 ``timezone(timedelta(hours=8))`` 而非 ZoneInfo("Asia/Shanghai"),
+   避免 Windows Python 缺 tzdata 的问题（中国不再实施夏令时,固定偏移即可）
+5. ``DateTime(timezone=True)`` 列定义保留（在 SQLite 上是 no-op,
+   PostgreSQL 兼容时再考虑）
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+CHINA_TZ = timezone(timedelta(hours=8), name="UTC+8")
+
+
+def china_now() -> datetime:
+    """返回当前中国时间（naive datetime,无 tz 信息,但语义为中国本地）。
+
+    用固定 UTC+8 取时,即便服务器在非中国时区也能得到中国时间。
+    返回 naive 是为了与千牛 Excel 时间（也是 naive 中国）保持比较语义一致。
+    """
+    return datetime.now(CHINA_TZ).replace(tzinfo=None)


### PR DESCRIPTION
## CEO 要求
"所有系统时间使用中国时间"

## 旧问题
SQLite ``CURRENT_TIMESTAMP`` 是 UTC，Python ``datetime.now()`` 是服务器本地（中国）。两者混用导致同一列上既有 ``2026-05-06 10:52:39``（UTC 长度 19）也有 ``2026-05-06 18:52:39.967470``（China 长度 26）—— **同一事件出现 8 小时偏差**。

另外历史代码用 ``datetime.now(timezone.utc)`` 与 ``mature_at`` 做 string 字典序比较，有 tz 边界 bug 风险。

## 新规范

**1. 新增 ``src/utils/time.py`` 统一入口：**
```python
CHINA_TZ = timezone(timedelta(hours=8), name="UTC+8")

def china_now() -> datetime:
    """返回 naive 中国时间（UTC+8 不含 tz 信息）。"""
    return datetime.now(CHINA_TZ).replace(tzinfo=None)
```
为什么用固定偏移而不是 ``ZoneInfo``：Windows Python 缺 ``tzdata`` 包，``ZoneInfo("Asia/Shanghai")`` 会抛 ``ZoneInfoNotFoundError``。中国不再实施夏令时（1991 年后），固定 UTC+8 永远正确。

**2. 替换所有时间源：**
| 旧 | 新 | 改了哪些文件 |
|---|---|---|
| ``server_default=func.now()`` | ``default=china_now`` | wallet/taobao/vendor/xbox 模型 |
| ``func.now()`` (router) | ``china_now()`` | routers/assets.py |
| ``datetime.now()`` | ``china_now()`` | services/taobao_import.py, taobao_maturity.py |

**3. 历史数据迁移**
``scripts/migrate_utc_timestamps_to_china.py`` 用 ``length(col) = 19`` 识别旧 UTC 行 +8h（已跑）：
- wallets.created_at 30 行
- wallet_transactions.created_at 4659 行
- taobao_shops.created_at 3 行
- taobao_orders.recorded_at 5423 行
- ``last_synced_at`` (length=26) 已是 China，不动
- Excel 源时间(shipped/confirmed/received_at)、mature_at 一直是 China，不动

## 测试
141/141 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)