### PR TITLE
feat(taobao): 钱包按日汇总端点 (#93)

### DIFF
--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import select
+from sqlalchemy import case, func, select, text
 from sqlalchemy.orm import Session
 
 from src.database import get_db
@@ -140,6 +140,22 @@ class WalletTransactionOut(BaseModel):
     remark: Optional[str] = None
     created_at: str
     mature_at: Optional[str] = None
+
+
+class WalletDailySummaryOut(BaseModel):
+    """钱包按日聚合：每天的入账总额、出账总额、净额、笔数。
+
+    ``date`` 取 ``WalletTransaction.created_at`` 的日期（中国时区,
+    系统时间已统一 UTC+8）。
+    """
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    date: str  # YYYY-MM-DD
+    in_amount: Decimal
+    out_amount: Decimal
+    net_amount: Decimal
+    count: int
 
 
 # ---------------------------------------------------------------------------
@@ -565,3 +581,78 @@ def list_wallet_transactions_for_shop(
         )
     )
     return [_serialize_transaction(tx) for tx in txs]
+
+
+@router.get(
+    "/shops/{shop_id}/wallets/{wallet_id}/daily-summary",
+    response_model=list[WalletDailySummaryOut],
+    response_model_by_alias=True,
+)
+def list_wallet_daily_summary_for_shop(
+    shop_id: int,
+    wallet_id: int,
+    from_: Optional[str] = Query(None, alias="from", description="起始日期 YYYY-MM-DD,闭区间"),
+    to: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD,闭区间"),
+    db: Session = Depends(get_db),
+) -> list[WalletDailySummaryOut]:
+    """单钱包按日聚合：每天的入账/出账/净额/笔数,按日期降序。
+
+    业务用途：CEO 想看「5/4 支付宝在途 ¥X、5/5 ¥Y」这类按日明细。
+    数据量小（一天最多几百行）,不分页。可选 ``from``/``to`` 闭区间过滤。
+
+    ``created_at`` 已是中国本地时间（system tz 已统一 UTC+8）,
+    ``func.date()`` 直接取 YYYY-MM-DD 即中国日期,无需 +8h 转换。
+    """
+    shop = _get_shop_or_404(db, shop_id)
+
+    if wallet_id not in _shop_wallet_ids(shop):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="该钱包不属于本店铺",
+        )
+
+    date_col = func.date(WalletTransaction.created_at)
+    in_sum = func.sum(
+        case(
+            (WalletTransaction.direction == "in", WalletTransaction.amount),
+            else_=0,
+        )
+    )
+    out_sum = func.sum(
+        case(
+            (WalletTransaction.direction == "out", WalletTransaction.amount),
+            else_=0,
+        )
+    )
+
+    stmt = (
+        select(
+            date_col.label("d"),
+            in_sum.label("in_amt"),
+            out_sum.label("out_amt"),
+            func.count(WalletTransaction.id).label("cnt"),
+        )
+        .where(WalletTransaction.wallet_id == wallet_id)
+    )
+    if from_:
+        stmt = stmt.where(date_col >= from_)
+    if to:
+        stmt = stmt.where(date_col <= to)
+    stmt = stmt.group_by(date_col).order_by(text("d DESC"))
+
+    rows = db.execute(stmt).all()
+
+    out: list[WalletDailySummaryOut] = []
+    for row in rows:
+        in_amount = Decimal(row.in_amt or 0)
+        out_amount = Decimal(row.out_amt or 0)
+        out.append(
+            WalletDailySummaryOut(
+                date=str(row.d),
+                in_amount=in_amount,
+                out_amount=out_amount,
+                net_amount=in_amount - out_amount,
+                count=int(row.cnt),
+            )
+        )
+    return out

--- a/tests/test_taobao_flow_api.py
+++ b/tests/test_taobao_flow_api.py
@@ -779,3 +779,143 @@ def test_wallet_transactions_pagination_and_desc(client):
     assert len(txs) == 2
     # id desc：第一条是最新（最大 id）
     assert txs[0]["id"] > txs[1]["id"]
+
+
+# ---------------------------------------------------------------------------
+# /wallets/{wallet_id}/daily-summary
+# ---------------------------------------------------------------------------
+
+
+def _seed_tx_with_date(
+    wallet_id: int,
+    *,
+    amount: Decimal,
+    direction: str,
+    created_at: datetime,
+    remark: str = "测试",
+) -> int:
+    """直接 insert 一笔流水并强制设置 created_at（绕过 default=china_now）。"""
+    db = database.SessionLocal()
+    try:
+        tx = WalletTransaction(
+            wallet_id=wallet_id,
+            amount=amount,
+            direction=direction,
+            remark=remark,
+            created_at=created_at,
+        )
+        db.add(tx)
+        # 同时更新钱包余额,避免后续 debit 失败
+        wallet = db.get(Wallet, wallet_id)
+        if direction == "in":
+            wallet.balance = Decimal(wallet.balance) + amount
+        else:
+            wallet.balance = Decimal(wallet.balance) - amount
+        db.commit()
+        return tx.id
+    finally:
+        db.close()
+
+
+def test_daily_summary_aggregates_in_out_count_per_day(client):
+    """3 天的混合流水 → 按日聚合 IN/OUT/净/笔数,降序返回。"""
+    shop = _shop_by_name("丙火网络")
+    wid = shop.unconfirmed_alipay_wallet_id
+
+    # 5/4: in 100 + in 50, 共 150 IN
+    _seed_tx_with_date(wid, amount=Decimal("100"), direction="in",
+                       created_at=datetime(2026, 5, 4, 10, 0, 0))
+    _seed_tx_with_date(wid, amount=Decimal("50"), direction="in",
+                       created_at=datetime(2026, 5, 4, 14, 0, 0))
+    # 5/5: in 200, out 30
+    _seed_tx_with_date(wid, amount=Decimal("200"), direction="in",
+                       created_at=datetime(2026, 5, 5, 9, 0, 0))
+    _seed_tx_with_date(wid, amount=Decimal("30"), direction="out",
+                       created_at=datetime(2026, 5, 5, 18, 0, 0))
+    # 5/6: out 80
+    _seed_tx_with_date(wid, amount=Decimal("80"), direction="out",
+                       created_at=datetime(2026, 5, 6, 12, 0, 0))
+
+    response = client.get(f"/taobao/shops/{shop.id}/wallets/{wid}/daily-summary")
+    assert response.status_code == 200, response.text
+    rows = response.json()
+    assert len(rows) == 3
+
+    # 降序：5/6 > 5/5 > 5/4
+    assert rows[0]["date"] == "2026-05-06"
+    assert Decimal(rows[0]["inAmount"]) == Decimal("0")
+    assert Decimal(rows[0]["outAmount"]) == Decimal("80")
+    assert Decimal(rows[0]["netAmount"]) == Decimal("-80")
+    assert rows[0]["count"] == 1
+
+    assert rows[1]["date"] == "2026-05-05"
+    assert Decimal(rows[1]["inAmount"]) == Decimal("200")
+    assert Decimal(rows[1]["outAmount"]) == Decimal("30")
+    assert Decimal(rows[1]["netAmount"]) == Decimal("170")
+    assert rows[1]["count"] == 2
+
+    assert rows[2]["date"] == "2026-05-04"
+    assert Decimal(rows[2]["inAmount"]) == Decimal("150")
+    assert Decimal(rows[2]["outAmount"]) == Decimal("0")
+    assert Decimal(rows[2]["netAmount"]) == Decimal("150")
+    assert rows[2]["count"] == 2
+
+
+def test_daily_summary_empty_wallet_returns_empty(client):
+    """没有流水的钱包返回空列表。"""
+    shop = _shop_by_name("丙火网络")
+    response = client.get(
+        f"/taobao/shops/{shop.id}/wallets/{shop.bank_card_wallet_id}/daily-summary"
+    )
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+def test_daily_summary_404_when_wallet_not_in_shop(client):
+    """跨店铺钱包 → 404。"""
+    shop = _shop_by_name("丙火网络")
+    other = _shop_by_name("小小电玩")
+    response = client.get(
+        f"/taobao/shops/{shop.id}/wallets/{other.bank_card_wallet_id}/daily-summary"
+    )
+    assert response.status_code == 404
+
+
+def test_daily_summary_filters_by_date_range(client):
+    """from / to 闭区间过滤。"""
+    shop = _shop_by_name("丙火网络")
+    wid = shop.aggregator_available_wallet_id
+
+    for day in (3, 4, 5, 6, 7):
+        _seed_tx_with_date(
+            wid,
+            amount=Decimal("10"),
+            direction="in",
+            created_at=datetime(2026, 5, day, 10, 0, 0),
+        )
+
+    # 只取 5/4 ~ 5/6 三天
+    response = client.get(
+        f"/taobao/shops/{shop.id}/wallets/{wid}/daily-summary",
+        params={"from": "2026-05-04", "to": "2026-05-06"},
+    )
+    assert response.status_code == 200
+    rows = response.json()
+    assert [r["date"] for r in rows] == ["2026-05-06", "2026-05-05", "2026-05-04"]
+    assert all(Decimal(r["inAmount"]) == Decimal("10") for r in rows)
+
+
+def test_daily_summary_store_alipay_wallet_allowed(client):
+    """店铺支付宝钱包（含 A/B 类）也支持日汇总。"""
+    shop = _shop_by_name("丙火网络")
+    wid = shop.store_alipay_wallet_id
+    _seed_tx_with_date(wid, amount=Decimal("99"), direction="in",
+                       created_at=datetime(2026, 5, 6, 15, 30, 0))
+
+    response = client.get(f"/taobao/shops/{shop.id}/wallets/{wid}/daily-summary")
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 1
+    assert rows[0]["date"] == "2026-05-06"
+    assert Decimal(rows[0]["inAmount"]) == Decimal("99")
+    assert rows[0]["count"] == 1

--- a/tests/test_taobao_import_api.py
+++ b/tests/test_taobao_import_api.py
@@ -386,10 +386,17 @@ def test_new_alipay_received_b_shop_to_store_alipay_wallet(client):
 
 
 def test_new_wechat_received_to_aggregator_frozen_with_mature_at_from_confirmed_at(client):
-    """wechat/received → aggregator_frozen，mature_at = confirmed_at + 7d。"""
+    """wechat/received → aggregator_frozen，mature_at = confirmed_at + 7d。
+
+    confirmed_at 用相对今天的未来日期,确保 mature_at 仍在未来（不会被自动解冻）。
+    """
     shop = _shop_by_name("丙火网络")
-    confirmed_at_str = "2026-04-30 14:30:00"
-    shipped_at_str = "2026-04-30 00:03:21"
+    # 用今天 + 2 天作为 confirmed_at,这样 mature_at = 今天 + 9 天,稳在未来
+    base_day = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=2)
+    confirmed_dt = base_day.replace(hour=14, minute=30)
+    shipped_dt = base_day.replace(hour=0, minute=3, second=21)
+    confirmed_at_str = confirmed_dt.strftime("%Y-%m-%d %H:%M:%S")
+    shipped_at_str = shipped_dt.strftime("%Y-%m-%d %H:%M:%S")
     rows = [_row(
         order_no="ORDER_W1",
         payment_no="PAY_W1",
@@ -411,7 +418,6 @@ def test_new_wechat_received_to_aggregator_frozen_with_mature_at_from_confirmed_
     assert tx is not None
     assert tx.mature_at is not None
     # mature_at 精确到分秒：与千牛后台一致 confirmed_at + 7 天
-    confirmed_dt = datetime.strptime(confirmed_at_str, "%Y-%m-%d %H:%M:%S")
     expected_mature = confirmed_dt + timedelta(days=7)
     assert tx.mature_at.replace(tzinfo=None) == expected_mature
 
@@ -419,7 +425,12 @@ def test_new_wechat_received_to_aggregator_frozen_with_mature_at_from_confirmed_
 def test_mature_at_falls_back_to_shipped_at_when_confirmed_at_missing(client):
     """confirmed_at 缺失时,mature_at 兜底用 shipped_at + 7d。"""
     shop = _shop_by_name("丙火网络")
-    shipped_at_str = "2026-04-30 00:03:21"
+    # 用今天 + 2 天的未来 shipped_at 防自动解冻
+    shipped_dt = (
+        datetime.now().replace(hour=0, minute=3, second=21, microsecond=0)
+        + timedelta(days=2)
+    )
+    shipped_at_str = shipped_dt.strftime("%Y-%m-%d %H:%M:%S")
     rows = [_row(
         order_no="ORDER_FB",
         payment_no="PAY_FB",
@@ -437,7 +448,6 @@ def test_mature_at_falls_back_to_shipped_at_when_confirmed_at_missing(client):
 
     tx = _last_tx(shop.aggregator_frozen_wallet_id)
     # mature_at 精确到分秒：与千牛后台一致 shipped_at + 7 天
-    shipped_dt = datetime.strptime(shipped_at_str, "%Y-%m-%d %H:%M:%S")
     expected = shipped_dt + timedelta(days=7)
     assert tx.mature_at.replace(tzinfo=None) == expected
 
@@ -445,6 +455,10 @@ def test_mature_at_falls_back_to_shipped_at_when_confirmed_at_missing(client):
 def test_new_wechat_received_b_shop_also_to_aggregator_frozen(client):
     """B 类（兔仔）的 wechat/received 仍然走聚合冻结。"""
     shop = _shop_by_name("兔仔电玩")
+    # 用今天 + 2 天作 confirmed_at,防止自动解冻
+    base_day = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(days=2)
+    confirmed_at_str = base_day.replace(hour=14).strftime("%Y-%m-%d %H:%M:%S")
+    shipped_at_str = base_day.replace(hour=0, minute=3, second=21).strftime("%Y-%m-%d %H:%M:%S")
     rows = [_row(
         order_no="ORDER_B_W1",
         payment_no="PAY_B_W1",
@@ -453,8 +467,8 @@ def test_new_wechat_received_b_shop_also_to_aggregator_frozen(client):
         status_zh="交易成功",
         paid_at="2026-04-29 23:57:43",
         shop_name="兔仔电玩",
-        shipped_at="2026-04-30 00:03:21",
-        confirmed_at="2026-04-30 14:00:00",
+        shipped_at=shipped_at_str,
+        confirmed_at=confirmed_at_str,
         confirmed_amount="60.00",
     )]
     response = _post_import(client, shop.id, _build_xlsx(rows))


### PR DESCRIPTION
Closes #93

## 需求
CEO 想点开每个钱包看「5/4 ¥X、5/5 ¥Y」按天的进出明细。

## 实现

### 新端点
``GET /taobao/shops/{shop_id}/wallets/{wallet_id}/daily-summary``

### 返回
```json
[
  {"date": "2026-05-08", "inAmount": "1234.56", "outAmount": "0.00", "netAmount": "1234.56", "count": 12},
  {"date": "2026-05-07", "inAmount": "999.99", "outAmount": "200.00", "netAmount": "799.99", "count": 8}
]
```
- 按日期降序
- 默认全部历史（数据量小不分页）
- 可选 ``from`` / ``to`` (YYYY-MM-DD 闭区间) 过滤
- 校验 ``wallet_id ∈ shop 的 6 个钱包``,否则 404

### 关键技术点
- SQL 一次性 group：``func.date(created_at)`` + ``case`` sum
- PR #92 已统一中国时区,``func.date(created_at)`` 直接得 YYYY-MM-DD 即中国日期,无需 +8h
- ``from`` 是 Python 关键字,用 ``Query(..., alias="from")`` + 变量名 ``from_``

## 测试
新增 5 个：
- 聚合正确性（3 天 IN/OUT/净/笔数）
- 空钱包返回 ``[]``
- 跨店 wallet_id → 404
- ``from``/``to`` 范围过滤
- 店铺支付宝钱包也支持

**顺手修了 3 个不相关的回归（不阻塞合并）：**
3 个 mature_at 测试原本绑定 ``confirmed_at = "2026-04-30"``，系统日期到 5/8 后这些订单已超过 7 天自动解冻条件,导致 frozen 余额变 0 测试失败。改为相对 ``datetime.now() + 2 天`` 的动态日期,稳定通过。

测试 146/146。

🤖 Generated with [Claude Code](https://claude.com/claude-code)