### PR TITLE
feat(frontend): 淘宝页 6 钱包加日汇总弹窗 (#95)

### DIFF
--- a/frontend/components/taobao-page.tsx
+++ b/frontend/components/taobao-page.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowRightLeft,
   Banknote,
+  CalendarDays,
   CheckCircle2,
   FileSpreadsheet,
   ListOrdered,
@@ -19,6 +20,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   getAssetWallets,
   getTaobaoShops,
+  getTaobaoWalletDailySummary,
   getTaobaoWalletTransactions,
   importTaobaoExcel,
   transferTaobaoToStoreAlipay,
@@ -192,6 +194,99 @@ function TransactionsModal({
                   </div>
                 );
               })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 日汇总弹窗（按日期聚合该钱包的 IN / OUT / 净 / 笔数）
+// ---------------------------------------------------------------------------
+
+function DailySummaryModal({
+  shop,
+  wallet,
+  walletLabel,
+  onClose
+}: {
+  shop: TaobaoShop;
+  wallet: TaobaoShopWallet;
+  walletLabel: string;
+  onClose: () => void;
+}) {
+  const { data: rows = [], isFetching } = useQuery({
+    queryKey: ["taobao-wallet-daily-summary", shop.id, wallet.id],
+    queryFn: () => getTaobaoWalletDailySummary(shop.id, wallet.id)
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="flex max-h-[80vh] w-full max-w-3xl flex-col">
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle>
+              {shop.name} · {walletLabel} · 日汇总
+            </CardTitle>
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              <X className="h-4 w-4" aria-hidden="true" />
+              关闭
+            </Button>
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            当前余额 <span className="tabular-nums">{formatMoney(wallet.balanceMinor, "CNY")}</span>
+            <span className="mx-2">·</span>
+            按日期降序展示每日入账/出账/净额/笔数
+          </div>
+        </CardHeader>
+        <CardContent className="flex-1 overflow-y-auto">
+          {rows.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+              {isFetching ? "加载中..." : "暂无流水"}
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-md border border-border">
+              <table className="w-full text-sm">
+                <thead className="bg-muted/40 text-xs text-muted-foreground">
+                  <tr>
+                    <th className="px-3 py-2 text-left font-medium">日期</th>
+                    <th className="px-3 py-2 text-right font-medium">入账</th>
+                    <th className="px-3 py-2 text-right font-medium">出账</th>
+                    <th className="px-3 py-2 text-right font-medium">净额</th>
+                    <th className="px-3 py-2 text-right font-medium">笔数</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-border">
+                  {rows.map((row) => {
+                    const netColor =
+                      row.netAmountMinor > 0
+                        ? "text-green-600"
+                        : row.netAmountMinor < 0
+                          ? "text-red-600"
+                          : "text-muted-foreground";
+                    return (
+                      <tr key={row.date} className="hover:bg-muted/30">
+                        <td className="px-3 py-2 font-medium tabular-nums">{row.date}</td>
+                        <td className="px-3 py-2 text-right tabular-nums text-green-600">
+                          {row.inAmountMinor > 0 ? formatMoney(row.inAmountMinor, "CNY") : "-"}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums text-red-600">
+                          {row.outAmountMinor > 0 ? formatMoney(row.outAmountMinor, "CNY") : "-"}
+                        </td>
+                        <td className={cn("px-3 py-2 text-right font-semibold tabular-nums", netColor)}>
+                          {row.netAmountMinor > 0 ? "+" : ""}
+                          {formatMoney(row.netAmountMinor, "CNY")}
+                        </td>
+                        <td className="px-3 py-2 text-right tabular-nums text-muted-foreground">
+                          {row.count}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
             </div>
           )}
         </CardContent>
@@ -635,12 +730,14 @@ function ReportRow({
 function WalletRow({
   row,
   onShowTransactions,
+  onShowDailySummary,
   onWithdraw,
   onTransferToStoreAlipay,
   maturityInfo
 }: {
   row: WalletRowDef;
   onShowTransactions: (wallet: TaobaoShopWallet, label: string) => void;
+  onShowDailySummary: (wallet: TaobaoShopWallet, label: string) => void;
   onWithdraw: () => void;
   onTransferToStoreAlipay: () => void;
   // PR #85：聚合冻结行的"待解冻"信息条，从 GET shops 实时聚合数据来
@@ -695,6 +792,14 @@ function WalletRow({
               <ListOrdered className="h-3.5 w-3.5" aria-hidden="true" />
               流水
             </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onShowDailySummary(row.wallet, row.label)}
+            >
+              <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+              日汇总
+            </Button>
           </div>
         </div>
         {showMaturityBar ? (
@@ -714,12 +819,14 @@ function WalletRow({
 function ShopCard({
   shop,
   onShowTransactions,
+  onShowDailySummary,
   onWithdraw,
   onTransferToStoreAlipay,
   onImport
 }: {
   shop: TaobaoShop;
   onShowTransactions: (wallet: TaobaoShopWallet, label: string) => void;
+  onShowDailySummary: (wallet: TaobaoShopWallet, label: string) => void;
   onWithdraw: () => void;
   onTransferToStoreAlipay: () => void;
   onImport: () => void;
@@ -794,6 +901,16 @@ function ShopCard({
               <ListOrdered className="h-3.5 w-3.5" aria-hidden="true" />
               流水
             </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                onShowDailySummary(shop.storeAlipayWallet, "店铺支付宝")
+              }
+            >
+              <CalendarDays className="h-3.5 w-3.5" aria-hidden="true" />
+              日汇总
+            </Button>
           </div>
         </div>
         <div className="divide-y divide-border rounded-md border border-border">
@@ -802,6 +919,7 @@ function ShopCard({
               key={row.kind}
               row={row}
               onShowTransactions={onShowTransactions}
+              onShowDailySummary={onShowDailySummary}
               onWithdraw={onWithdraw}
               onTransferToStoreAlipay={onTransferToStoreAlipay}
               maturityInfo={
@@ -834,6 +952,11 @@ export function TaobaoPage() {
   const [transferShop, setTransferShop] = useState<TaobaoShop | null>(null);
   const [importShop, setImportShop] = useState<TaobaoShop | null>(null);
   const [transactionsTarget, setTransactionsTarget] = useState<{
+    shop: TaobaoShop;
+    wallet: TaobaoShopWallet;
+    label: string;
+  } | null>(null);
+  const [dailySummaryTarget, setDailySummaryTarget] = useState<{
     shop: TaobaoShop;
     wallet: TaobaoShopWallet;
     label: string;
@@ -878,6 +1001,9 @@ export function TaobaoPage() {
               onShowTransactions={(wallet, label) =>
                 setTransactionsTarget({ shop, wallet, label })
               }
+              onShowDailySummary={(wallet, label) =>
+                setDailySummaryTarget({ shop, wallet, label })
+              }
               onWithdraw={() => setWithdrawShop(shop)}
               onTransferToStoreAlipay={() => setTransferShop(shop)}
               onImport={() => setImportShop(shop)}
@@ -905,6 +1031,14 @@ export function TaobaoPage() {
           wallet={transactionsTarget.wallet}
           walletLabel={transactionsTarget.label}
           onClose={() => setTransactionsTarget(null)}
+        />
+      ) : null}
+      {dailySummaryTarget ? (
+        <DailySummaryModal
+          shop={dailySummaryTarget.shop}
+          wallet={dailySummaryTarget.wallet}
+          walletLabel={dailySummaryTarget.label}
+          onClose={() => setDailySummaryTarget(null)}
         />
       ) : null}
 

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -30,6 +30,7 @@ import type {
   TaobaoShop,
   TaobaoShopWallet,
   TaobaoStoreAlipayWallet,
+  TaobaoWalletDailySummary,
   TaobaoWalletTransaction,
   Vendor,
   VendorTransaction,
@@ -668,6 +669,29 @@ function normalizeTaobaoWalletTransaction(tx: TaobaoWalletTransactionResponse): 
   };
 }
 
+type TaobaoWalletDailySummaryResponse = {
+  date: string;
+  inAmount?: string | number;
+  in_amount?: string | number;
+  outAmount?: string | number;
+  out_amount?: string | number;
+  netAmount?: string | number;
+  net_amount?: string | number;
+  count: number;
+};
+
+function normalizeTaobaoWalletDailySummary(
+  row: TaobaoWalletDailySummaryResponse
+): TaobaoWalletDailySummary {
+  return {
+    date: row.date,
+    inAmountMinor: decimalToMinor(row.inAmount ?? row.in_amount ?? "0", "CNY"),
+    outAmountMinor: decimalToMinor(row.outAmount ?? row.out_amount ?? "0", "CNY"),
+    netAmountMinor: decimalToMinor(row.netAmount ?? row.net_amount ?? "0", "CNY"),
+    count: Number(row.count ?? 0)
+  };
+}
+
 function normalizeImportReport(data: TaobaoImportReportResponse): TaobaoImportReport {
   return {
     shopName: data.shopName ?? data.shop_name ?? "",
@@ -832,6 +856,25 @@ export async function getTaobaoWalletTransactions(
     return data.map(normalizeTaobaoWalletTransaction);
   } catch {
     return mockTaobaoWalletTransactions[walletId] ?? [];
+  }
+}
+
+export async function getTaobaoWalletDailySummary(
+  shopId: string,
+  walletId: string,
+  options?: { from?: string; to?: string }
+): Promise<TaobaoWalletDailySummary[]> {
+  const qs = new URLSearchParams();
+  if (options?.from) qs.set("from", options.from);
+  if (options?.to) qs.set("to", options.to);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  try {
+    const data = await fetchJson<TaobaoWalletDailySummaryResponse[]>(
+      `/api/taobao/shops/${shopId}/wallets/${walletId}/daily-summary${suffix}`
+    );
+    return data.map(normalizeTaobaoWalletDailySummary);
+  } catch {
+    return [];
   }
 }
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -174,6 +174,15 @@ export type TaobaoWalletTransaction = {
   matureAt: string | null;
 };
 
+// 钱包按日汇总（每天 IN / OUT / 净 / 笔数）—— 见 GET /taobao/shops/{id}/wallets/{wid}/daily-summary
+export type TaobaoWalletDailySummary = {
+  date: string; // YYYY-MM-DD（中国本地）
+  inAmountMinor: number;
+  outAmountMinor: number;
+  netAmountMinor: number;
+  count: number;
+};
+
 export type TaobaoImportReport = {
   shopName: string;
   totalRowsParsed: number;


### PR DESCRIPTION
Closes #95

## 需求
6 个钱包（店铺支付宝、支付宝在途、微信在途、聚合冻结、聚合可提现、银行卡）旁边加可点开的「日汇总」入口。

## 实现
- 每个钱包行 + 店铺支付宝卡片各加「日汇总」按钮(``CalendarDays`` 图标)
- 点击弹出 Modal：日期 / 入账 / 出账 / 净额 / 笔数,按日期降序
- 净额正绿色 / 负红色 / 0 灰色,加粗显示
- 0 显示为「-」让重点更突出
- 数据来自 PR #94 的 ``GET /shops/{id}/wallets/{wid}/daily-summary``
- React Query 缓存,与现有「流水」抽屉风格一致

## 文件改动
| 文件 | 改动 |
|---|---|
| ``frontend/types.ts`` | 加 ``TaobaoWalletDailySummary`` 类型 |
| ``frontend/lib/api.ts`` | 加 ``getTaobaoWalletDailySummary`` + normalize |
| ``frontend/components/taobao-page.tsx`` | 加 ``DailySummaryModal`` 组件 + ``WalletRow`` / ``ShopCard`` 加按钮 + ``TaobaoPage`` 加 state |

## ⚠️ 数据现状提示

后端聚合用 ``WalletTransaction.created_at`` = **流水写入日期**(不是订单业务日期 ``shipped_at`` / ``confirmed_at``)。

当前 production 数据是 5/6 一次性大量导入产生的 4659 笔流水,``created_at`` 都是 5/6,**CEO 打开任何钱包的"日汇总"目前只会看到 1 行**(5/6)。

CEO 每天 incremental 导入 Excel 时各天 ``created_at`` 会自然分布,日汇总就有意义了。如果 CEO 想要按订单业务日期(``shipped_at``/``confirmed_at``) 聚合,可以再加一个 issue 调整。

## 验收
- [x] TS 类型检查通过(``npx tsc --noEmit``)
- [x] 后端端点已验证返回数据正确
- [x] dev server ``http://127.0.0.1:3000/taobao`` HTTP 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)