### PR TITLE
feat(taobao): 日汇总改用业务日期口径 (#97)

### DIFF
--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile, status
 from pydantic import BaseModel, ConfigDict, Field
-from sqlalchemy import case, func, select, text
+from sqlalchemy import and_, case, func, select, text
 from sqlalchemy.orm import Session
 
 from src.database import get_db
@@ -595,13 +595,19 @@ def list_wallet_daily_summary_for_shop(
     to: Optional[str] = Query(None, description="结束日期 YYYY-MM-DD,闭区间"),
     db: Session = Depends(get_db),
 ) -> list[WalletDailySummaryOut]:
-    """单钱包按日聚合：每天的入账/出账/净额/笔数,按日期降序。
+    """单钱包按日聚合：每天的入账/出账/净额/笔数,按业务日期降序。
 
-    业务用途：CEO 想看「5/4 支付宝在途 ¥X、5/5 ¥Y」这类按日明细。
-    数据量小（一天最多几百行）,不分页。可选 ``from``/``to`` 闭区间过滤。
+    业务日期口径（CEO 2026-05-08 确认,见 .claude/skills/taobao-cashflow-rules）：
+    - IN 流水有 order 关联 → 按 order 业务日期：
+      - received       → ``order.confirmed_at``（"5/6 这天确认收货的钱进了店铺支付宝"）
+      - shipped_unconfirmed → ``order.shipped_at``（"5/4 这天发货的钱进了在途"）
+    - 其他流水（OUT、reconcile 撤旧、release、手动操作）→ ``tx.created_at``（操作日）
 
-    ``created_at`` 已是中国本地时间（system tz 已统一 UTC+8）,
-    ``func.date()`` 直接取 YYYY-MM-DD 即中国日期,无需 +8h 转换。
+    LEFT JOIN 找 order：``TaobaoOrder.bookkeeping_tx_id = WalletTransaction.id``
+    无关联或非 IN 流水落入 ELSE 分支。
+
+    ``from``/``to`` 闭区间过滤的是 **业务日期**（CASE 后的结果）。
+    所有时间已统一中国本地（PR #92）,DATE() 直接取 YYYY-MM-DD。
     """
     shop = _get_shop_or_404(db, shop_id)
 
@@ -611,7 +617,30 @@ def list_wallet_daily_summary_for_shop(
             detail="该钱包不属于本店铺",
         )
 
-    date_col = func.date(WalletTransaction.created_at)
+    # 业务日期 CASE 表达式
+    # IN 流水 + order received → confirmed_at
+    # IN 流水 + order shipped_unconfirmed → shipped_at
+    # 其他 → tx.created_at
+    business_date = case(
+        (
+            and_(
+                WalletTransaction.direction == "in",
+                TaobaoOrder.status == TaobaoOrderStatus.RECEIVED.value,
+                TaobaoOrder.confirmed_at.is_not(None),
+            ),
+            func.date(TaobaoOrder.confirmed_at),
+        ),
+        (
+            and_(
+                WalletTransaction.direction == "in",
+                TaobaoOrder.status == TaobaoOrderStatus.SHIPPED_UNCONFIRMED.value,
+                TaobaoOrder.shipped_at.is_not(None),
+            ),
+            func.date(TaobaoOrder.shipped_at),
+        ),
+        else_=func.date(WalletTransaction.created_at),
+    )
+
     in_sum = func.sum(
         case(
             (WalletTransaction.direction == "in", WalletTransaction.amount),
@@ -627,18 +656,23 @@ def list_wallet_daily_summary_for_shop(
 
     stmt = (
         select(
-            date_col.label("d"),
+            business_date.label("d"),
             in_sum.label("in_amt"),
             out_sum.label("out_amt"),
             func.count(WalletTransaction.id).label("cnt"),
         )
+        .select_from(WalletTransaction)
+        .outerjoin(
+            TaobaoOrder,
+            TaobaoOrder.bookkeeping_tx_id == WalletTransaction.id,
+        )
         .where(WalletTransaction.wallet_id == wallet_id)
     )
     if from_:
-        stmt = stmt.where(date_col >= from_)
+        stmt = stmt.where(business_date >= from_)
     if to:
-        stmt = stmt.where(date_col <= to)
-    stmt = stmt.group_by(date_col).order_by(text("d DESC"))
+        stmt = stmt.where(business_date <= to)
+    stmt = stmt.group_by(business_date).order_by(text("d DESC"))
 
     rows = db.execute(stmt).all()
 

--- a/tests/test_taobao_flow_api.py
+++ b/tests/test_taobao_flow_api.py
@@ -919,3 +919,178 @@ def test_daily_summary_store_alipay_wallet_allowed(client):
     assert rows[0]["date"] == "2026-05-06"
     assert Decimal(rows[0]["inAmount"]) == Decimal("99")
     assert rows[0]["count"] == 1
+
+
+def _seed_tx_with_order(
+    wallet_id: int,
+    *,
+    amount: Decimal,
+    tx_created_at: datetime,
+    order_status: str,
+    confirmed_at: datetime | None = None,
+    shipped_at: datetime | None = None,
+    shop_id: int = 1,
+    order_number: str | None = None,
+) -> tuple[int, int]:
+    """注入一笔 IN 流水 + 关联 TaobaoOrder（模拟 Excel 导入产生的）。
+
+    返回 ``(tx_id, order_id)``。用于验证 daily-summary 按业务日期聚合的逻辑。
+    """
+    db = database.SessionLocal()
+    try:
+        tx = WalletTransaction(
+            wallet_id=wallet_id,
+            amount=amount,
+            direction="in",
+            remark="测试订单流水",
+            created_at=tx_created_at,
+        )
+        db.add(tx)
+        db.flush()
+
+        wallet = db.get(Wallet, wallet_id)
+        wallet.balance = Decimal(wallet.balance) + amount
+
+        order = TaobaoOrder(
+            shop_id=shop_id,
+            order_number=order_number or f"BIZ_DATE_{tx.id}",
+            payment_method=TaobaoOrderPaymentMethod.ALIPAY.value,
+            amount=amount,
+            gross_amount=amount,
+            status=order_status,
+            bookkeeping_wallet_id=wallet_id,
+            bookkeeping_tx_id=tx.id,
+            confirmed_at=confirmed_at,
+            shipped_at=shipped_at,
+        )
+        db.add(order)
+        db.commit()
+        return tx.id, order.id
+    finally:
+        db.close()
+
+
+def test_daily_summary_business_date_received_uses_confirmed_at(client):
+    """IN 流水关联 received 订单 → 按 order.confirmed_at 聚合,不是 tx.created_at。
+
+    场景：5/8 才导入 5/6 确认收货的订单。日汇总应显示 5/6 +¥X,不是 5/8。
+    """
+    shop = _shop_by_name("丙火网络")
+    wid = shop.store_alipay_wallet_id
+
+    # 模拟：CEO 5/8 14:00 才导入,但订单是 5/6 10:00 确认收货
+    _seed_tx_with_order(
+        wid,
+        amount=Decimal("99.40"),
+        tx_created_at=datetime(2026, 5, 8, 14, 0, 0),    # 导入时刻
+        order_status=TaobaoOrderStatus.RECEIVED.value,
+        confirmed_at=datetime(2026, 5, 6, 10, 0, 0),     # 业务时刻
+        shop_id=shop.id,
+        order_number="ALIPAY_RECV_56",
+    )
+
+    response = client.get(f"/taobao/shops/{shop.id}/wallets/{wid}/daily-summary")
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 1
+    # 关键断言：date 应该是 5/6（confirmed_at 那天）,不是 5/8（导入那天）
+    assert rows[0]["date"] == "2026-05-06"
+    assert Decimal(rows[0]["inAmount"]) == Decimal("99.40")
+
+
+def test_daily_summary_business_date_shipped_uses_shipped_at(client):
+    """IN 流水关联 shipped_unconfirmed 订单 → 按 order.shipped_at 聚合。"""
+    shop = _shop_by_name("丙火网络")
+    wid = shop.unconfirmed_alipay_wallet_id
+
+    # 5/8 导入,但订单 5/4 发货（在途）
+    _seed_tx_with_order(
+        wid,
+        amount=Decimal("100"),
+        tx_created_at=datetime(2026, 5, 8, 14, 0, 0),
+        order_status=TaobaoOrderStatus.SHIPPED_UNCONFIRMED.value,
+        shipped_at=datetime(2026, 5, 4, 9, 0, 0),
+        shop_id=shop.id,
+        order_number="ALIPAY_SHIP_54",
+    )
+
+    response = client.get(f"/taobao/shops/{shop.id}/wallets/{wid}/daily-summary")
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 1
+    assert rows[0]["date"] == "2026-05-04"  # shipped_at 的那天
+    assert Decimal(rows[0]["inAmount"]) == Decimal("100")
+
+
+def test_daily_summary_out_uses_created_at_even_with_order(client):
+    """OUT 流水即使关联订单也用 created_at（reconcile 撤旧的语义是操作日）。"""
+    shop = _shop_by_name("丙火网络")
+    wid = shop.unconfirmed_alipay_wallet_id
+
+    # 直接 insert 一笔 OUT 流水 + 关联订单
+    db = database.SessionLocal()
+    try:
+        tx = WalletTransaction(
+            wallet_id=wid,
+            amount=Decimal("50"),
+            direction="out",
+            remark="reconcile 撤旧",
+            created_at=datetime(2026, 5, 8, 16, 0, 0),  # 操作日
+        )
+        db.add(tx)
+        db.flush()
+        wallet = db.get(Wallet, wid)
+        wallet.balance = Decimal(wallet.balance) - Decimal("50")
+
+        order = TaobaoOrder(
+            shop_id=shop.id,
+            order_number="OUT_TX_TEST",
+            payment_method=TaobaoOrderPaymentMethod.ALIPAY.value,
+            amount=Decimal("50"),
+            gross_amount=Decimal("50"),
+            status=TaobaoOrderStatus.RECEIVED.value,
+            bookkeeping_wallet_id=wid,
+            bookkeeping_tx_id=tx.id,
+            confirmed_at=datetime(2026, 5, 6, 10, 0, 0),
+        )
+        db.add(order)
+        db.commit()
+    finally:
+        db.close()
+
+    response = client.get(f"/taobao/shops/{shop.id}/wallets/{wid}/daily-summary")
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 1
+    # 关键：OUT 流水按 created_at（5/8 操作日）,不是 confirmed_at（5/6）
+    assert rows[0]["date"] == "2026-05-08"
+    assert Decimal(rows[0]["outAmount"]) == Decimal("50")
+
+
+def test_daily_summary_mix_business_and_operation_dates(client):
+    """混合：order IN 用业务日 + 手动 OUT 用操作日,各日聚合到正确日期。
+
+    场景验证 CEO 真实使用：聚合可提现钱包
+    - 5/13 release 流水（IN, 无 order） → 5/13 +¥
+    - 5/13 提现 OUT（无 order） → 5/13 -¥
+    - 应该看到 5/13 一行,IN/OUT 都有
+    """
+    shop = _shop_by_name("丙火网络")
+    wid = shop.aggregator_available_wallet_id
+
+    # 5/13 release 进账（无 order 关联）
+    _seed_tx_with_date(wid, amount=Decimal("198.80"), direction="in",
+                       created_at=datetime(2026, 5, 13, 0, 0, 0))
+    # 5/13 提现出账
+    _seed_tx_with_date(wid, amount=Decimal("198.80"), direction="out",
+                       created_at=datetime(2026, 5, 13, 12, 30, 0))
+
+    response = client.get(f"/taobao/shops/{shop.id}/wallets/{wid}/daily-summary")
+    assert response.status_code == 200
+    rows = response.json()
+    assert len(rows) == 1
+    assert rows[0]["date"] == "2026-05-13"
+    assert Decimal(rows[0]["inAmount"]) == Decimal("198.80")
+    assert Decimal(rows[0]["outAmount"]) == Decimal("198.80")
+    assert Decimal(rows[0]["netAmount"]) == Decimal("0")
+    assert rows[0]["count"] == 2


### PR DESCRIPTION
Closes #97

## CEO 反馈

PR #94 的日汇总按 ``WalletTransaction.created_at`` 聚合,所有流水挤在 5/6（一次性导入那天）,看不清业务节奏。CEO 要的是「钱真正到达可用钱包的那天」。

## 新口径（见 ``.claude/skills/taobao-cashflow-rules/SKILL.md``）

- **IN 流水 + order received** → ``DATE(order.confirmed_at)``
- **IN 流水 + order shipped_unconfirmed** → ``DATE(order.shipped_at)``
- **其他**（OUT、reconcile 撤旧、release、手动操作） → ``DATE(tx.created_at)``

## 技术实现

``src/routers/taobao.py`` 中 ``list_wallet_daily_summary_for_shop``：
- LEFT JOIN ``taobao_orders ON bookkeeping_tx_id = wallet_transactions.id``
- ``CASE`` 表达式根据 ``direction`` + ``order.status`` 选业务日期 / fallback ``created_at``
- ``from``/``to`` 过滤的是业务日期（CASE 后的结果）

## 测试

新增 4 个：
- ``business_date_received_uses_confirmed_at``: 5/8 导入 5/6 确认收货 → 显示 5/6 ✓
- ``business_date_shipped_uses_shipped_at``: 5/8 导入 5/4 发货 → 显示 5/4 ✓
- ``out_uses_created_at_even_with_order``: OUT 流水用 created_at,不取 order.confirmed_at ✓
- ``mix_business_and_operation_dates``: release + 提现都用 created_at ✓

5 个老测试继续通过（无 order 关联的流水落入 ELSE 分支）。

总 150/150 通过。

## 真实数据验证

```
丙火网络 store_alipay (alipay/received 订单)：
  5/3, 5/4, 5/5, 5/6 — 4 天分布

丙火网络 aggregator_frozen (wechat/received 订单)：
  4/22 ~ 5/6 — 20 天分布
```

之前是全挤在 5/6 一行。

## 前端不用改
返回结构 ``{date, inAmount, outAmount, netAmount, count}`` 不变,只是 ``date`` 字段含义升级为业务日期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)