### PR TITLE
feat(taobao): 聚合可提现日汇总按订单到期日散开

### DIFF
--- a/scripts/migrate_available_business_date.py
+++ b/scripts/migrate_available_business_date.py
@@ -1,0 +1,151 @@
+"""一次性迁移：把聚合可提现里历史合并的 IN 流水按业务日期拆分。
+
+背景：
+  PR #98 之前 ``_auto_release_aggregator`` 一次性 debit/credit,1300+ 笔订单
+  合并成 1 条 IN 流水。新版按 mature_at 日期分组,但历史那 2 条合并 IN
+  仍是一整笔(business_date=NULL),日汇总只能显示 release 那天一行。
+
+  本脚本反向追溯：通过配对的 frozen OUT tx 找出当时被释放的 frozen IN 集合,
+  按 ``order.confirmed_at + 7 天`` 分组求和,把原合并 IN 拆成 N 笔（每天一笔）。
+
+  运行后聚合可提现日汇总按业务日期散开,与 PR #98 新数据口径一致。
+
+幂等：可重复运行,已拆分(business_date 非空)的不会再处理。
+"""
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+from datetime import datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+
+def _parse_dt(s: str) -> datetime:
+    """SQLite TEXT → datetime,容忍带 / 不带毫秒。"""
+    s = s.strip()
+    if "." in s:
+        return datetime.strptime(s, "%Y-%m-%d %H:%M:%S.%f")
+    return datetime.strptime(s, "%Y-%m-%d %H:%M:%S")
+
+
+def main(db_path: str = "finance.db") -> None:
+    if not Path(db_path).exists():
+        raise FileNotFoundError(f"DB 不存在: {db_path}")
+
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        # 找各店铺
+        shops = list(
+            conn.execute(
+                "SELECT id, name, aggregator_frozen_wallet_id, aggregator_available_wallet_id FROM taobao_shops"
+            )
+        )
+
+        for shop in shops:
+            frozen_wid = shop["aggregator_frozen_wallet_id"]
+            avail_wid = shop["aggregator_available_wallet_id"]
+
+            # 该店 available 钱包里 business_date 为空的 IN（历史合并数据）
+            legacy_in = list(
+                conn.execute(
+                    """SELECT id, amount, created_at, remark FROM wallet_transactions
+                       WHERE wallet_id=? AND direction='in' AND business_date IS NULL
+                       ORDER BY id""",
+                    (avail_wid,),
+                )
+            )
+            print(f"[{shop['name']}] 待迁移 available IN: {len(legacy_in)} 笔")
+            if not legacy_in:
+                continue
+
+            # 已被 release 的 frozen IN（mature_at NULL,仍 active）按 id 升序
+            # 这些是配对源,按 id 顺序累计金额匹配各 release 批次
+            all_released_frozen_in = list(
+                conn.execute(
+                    """SELECT t.id, t.amount, o.confirmed_at
+                       FROM wallet_transactions t
+                       JOIN taobao_orders o ON o.bookkeeping_tx_id = t.id
+                       WHERE t.wallet_id=? AND t.direction='in' AND t.mature_at IS NULL
+                       ORDER BY t.id""",
+                    (frozen_wid,),
+                )
+            )
+            cursor_idx = 0  # 在 all_released_frozen_in 里的游标
+
+            for legacy in legacy_in:
+                target_amount = Decimal(str(legacy["amount"]))
+                target_id = legacy["id"]
+
+                # 累加 frozen IN 金额直到等于 legacy.amount
+                cumulative = Decimal("0")
+                matched_indices: list[int] = []
+                for i in range(cursor_idx, len(all_released_frozen_in)):
+                    fr = all_released_frozen_in[i]
+                    cumulative += Decimal(str(fr["amount"]))
+                    matched_indices.append(i)
+                    if cumulative == target_amount:
+                        break
+                else:
+                    print(
+                        f"  [WARN] avail IN id={target_id} amount=¥{target_amount} 找不到精确匹配"
+                        f"（累计到 ¥{cumulative}）,跳过"
+                    )
+                    continue
+
+                # 按 confirmed_at + 7d 分组
+                groups: dict[str, Decimal] = defaultdict(lambda: Decimal("0"))
+                groups_count: dict[str, int] = defaultdict(int)
+                for i in matched_indices:
+                    fr = all_released_frozen_in[i]
+                    if fr["confirmed_at"]:
+                        biz_dt = _parse_dt(fr["confirmed_at"]) + timedelta(days=7)
+                        biz_day = biz_dt.date().isoformat()
+                    else:
+                        biz_day = "1970-01-01"  # fallback
+                    groups[biz_day] += Decimal(str(fr["amount"]))
+                    groups_count[biz_day] += 1
+
+                # 推进游标到这批之后
+                cursor_idx = matched_indices[-1] + 1
+
+                print(f"  avail IN id={target_id} amount=¥{target_amount} → 拆 {len(groups)} 天:")
+                for day in sorted(groups.keys()):
+                    print(f"    {day}: ¥{groups[day]:.2f} ({groups_count[day]} 笔)")
+
+                # 安全检查：分组求和应该 = 原总额
+                groups_sum = sum(groups.values(), Decimal("0"))
+                if groups_sum != target_amount:
+                    print(f"  [ERROR] 分组求和 ¥{groups_sum} ≠ 原 ¥{target_amount},跳过")
+                    continue
+
+                # 删原合并 IN tx
+                conn.execute("DELETE FROM wallet_transactions WHERE id=?", (target_id,))
+
+                # 插 N 笔新 IN tx,各带 business_date
+                base_remark = legacy["remark"] or ""
+                created_at = legacy["created_at"]
+                for day in sorted(groups.keys()):
+                    amount_str = f"{groups[day]:.6f}"
+                    new_remark = f"{base_remark} [迁移拆分:{day}]"
+                    conn.execute(
+                        """INSERT INTO wallet_transactions
+                           (wallet_id, amount, direction, remark, created_at, business_date)
+                           VALUES (?, ?, 'in', ?, ?, ?)""",
+                        (avail_wid, amount_str, new_remark, created_at, day),
+                    )
+                print(f"  ✓ 已删原 IN id={target_id},插入 {len(groups)} 笔新 IN")
+
+        conn.commit()
+        print("\n[OK] 迁移完成,已 commit")
+    except Exception as exc:
+        conn.rollback()
+        print(f"\n[ERROR] {exc}")
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/database.py
+++ b/src/database.py
@@ -44,6 +44,7 @@ def init_db() -> None:
 
     Base.metadata.create_all(bind=engine)
     _ensure_wallet_is_group_column()
+    _ensure_wallet_transaction_business_date_column()
 
 
 def _ensure_wallet_is_group_column() -> None:
@@ -61,6 +62,27 @@ def _ensure_wallet_is_group_column() -> None:
 
     with engine.begin() as connection:
         connection.execute(text("ALTER TABLE wallets ADD COLUMN is_group BOOLEAN NOT NULL DEFAULT 0"))
+
+
+def _ensure_wallet_transaction_business_date_column() -> None:
+    """Add WalletTransaction.business_date for existing SQLite dev databases.
+
+    business_date 用于聚合可提现 IN 流水标记业务日期(=mature_at 那天),
+    daily-summary 端点据此聚合。见 .claude/skills/taobao-cashflow-rules。
+    """
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+
+    inspector = inspect(engine)
+    if "wallet_transactions" not in inspector.get_table_names():
+        return
+
+    column_names = {column["name"] for column in inspector.get_columns("wallet_transactions")}
+    if "business_date" in column_names:
+        return
+
+    with engine.begin() as connection:
+        connection.execute(text("ALTER TABLE wallet_transactions ADD COLUMN business_date DATE"))
 
 
 def get_db() -> Iterator[Session]:

--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -1,12 +1,12 @@
 """Wallet models and balance movement helpers."""
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Numeric, String, Text, select
+from sqlalchemy import Boolean, Date, DateTime, ForeignKey, Numeric, String, Text, select
 from sqlalchemy.orm import Mapped, Session, mapped_column, relationship
 
 from src.database import Base
@@ -84,6 +84,14 @@ class WalletTransaction(Base):
         DateTime(timezone=True),
         nullable=True,
     )
+    # 业务日期标识（仅 IN 流水使用,标记"这笔钱业务上属于哪一天"）：
+    # - 聚合释放(_auto_release_aggregator) 写入的 available IN tx：填 mature_at 那天
+    # - 其他流水：留 NULL,daily-summary 端点回退用 created_at 或 order 业务日期
+    # 见 .claude/skills/taobao-cashflow-rules
+    business_date: Mapped[Optional[date]] = mapped_column(
+        Date,
+        nullable=True,
+    )
 
     wallet: Mapped[Wallet] = relationship(back_populates="transactions")
 
@@ -140,11 +148,17 @@ def credit(
     amount: Decimal | int | float | str,
     remark: str | None = None,
     mature_at: Optional[datetime] = None,
+    business_date: Optional[date] = None,
 ) -> WalletTransaction:
     """Increase a wallet balance and create an inbound transaction record.
 
     可选 ``mature_at`` 表示该笔入账的"成熟时间"（例如聚合支付冻结期满
     可提现的时间点），仅写入 ``WalletTransaction.mature_at``，不影响余额逻辑。
+
+    可选 ``business_date`` 标记该笔入账的"业务日期"（用于按业务日期聚合）：
+    - 聚合释放写入 available IN：业务日期 = mature_at 那天
+    - 其他场景留 None，daily-summary 端点会自动回退用 order 业务日期或 created_at
+    见 ``.claude/skills/taobao-cashflow-rules``。
     """
     value = _to_decimal(amount)
     wallet = get_wallet(session, wallet_id)
@@ -156,6 +170,7 @@ def credit(
         direction=TransactionDirection.IN,
         remark=remark,
         mature_at=mature_at,
+        business_date=business_date,
     )
     session.add(transaction)
     session.flush()

--- a/src/routers/taobao.py
+++ b/src/routers/taobao.py
@@ -617,11 +617,20 @@ def list_wallet_daily_summary_for_shop(
             detail="该钱包不属于本店铺",
         )
 
-    # 业务日期 CASE 表达式
-    # IN 流水 + order received → confirmed_at
-    # IN 流水 + order shipped_unconfirmed → shipped_at
-    # 其他 → tx.created_at
+    # 业务日期 CASE 表达式（优先级从高到低）
+    # 1. IN 流水 + business_date 不为空 → 用 business_date
+    #    （聚合释放写入 available IN 时填 mature_at 那天）
+    # 2. IN 流水 + order received → confirmed_at
+    # 3. IN 流水 + order shipped_unconfirmed → shipped_at
+    # 4. 其他（OUT、reconcile、手动操作、历史无 business_date 的 release）→ tx.created_at
     business_date = case(
+        (
+            and_(
+                WalletTransaction.direction == "in",
+                WalletTransaction.business_date.is_not(None),
+            ),
+            WalletTransaction.business_date,
+        ),
         (
             and_(
                 WalletTransaction.direction == "in",

--- a/src/services/taobao_import.py
+++ b/src/services/taobao_import.py
@@ -391,31 +391,66 @@ def _auto_release_aggregator(
 
     返回 ``(累计金额, 笔数)``。无可解冻流水时返回 ``(Decimal("0"), 0)``,不写流水。
 
-    业务规则：
+    业务规则（CEO 2026-05-08 确认,见 ``.claude/skills/taobao-cashflow-rules``）：
     - 用 ``matured_active_txs`` 找当前应解冻的 IN 流水（``mature_at < 明天 0:00``）
-    - 累计金额从 frozen debit、credit 到 available
-    - **完成后清掉这批 IN 流水的 mature_at**，保证幂等：
-      下次再导入时同一批不会被重复释放（避免 frozen 余额负向漂移）。
+    - **按 mature_at 日期分组**：每天的订单单独一对 debit/credit,
+      让聚合可提现日汇总按"订单原本到期日"散开（5/12 ¥X、5/13 ¥Y...）
+      而不是挤在 release 操作日一行
+    - credit 时填 ``business_date = mature_at 那天``,daily-summary 据此聚合
+    - 完成后清掉 frozen IN 的 mature_at,保证幂等
     """
     active_txs = matured_active_txs(session, shop.aggregator_frozen_wallet_id)
     if not active_txs:
         return Decimal("0"), 0
 
-    matured_amount = sum((Decimal(tx.amount) for tx in active_txs), Decimal("0"))
-    matured_count = len(active_txs)
-    if matured_amount <= 0:
+    # 按 mature_at 当天 0:00 分组（让同一天解冻的订单合并成一对 debit/credit）
+    groups: dict[datetime, list[WalletTransaction]] = {}
+    for tx in active_txs:
+        if tx.mature_at is None:
+            continue
+        # 取 naive China 当天 0:00 作为组 key（mature_at 已是 naive china_now 写入）
+        day_start = tx.mature_at.replace(hour=0, minute=0, second=0, microsecond=0)
+        # 防御 tzinfo: 不应该有,但若有就剥掉
+        if day_start.tzinfo is not None:
+            day_start = day_start.replace(tzinfo=None)
+        groups.setdefault(day_start, []).append(tx)
+
+    if not groups:
         return Decimal("0"), 0
 
-    remark = f"导入自动解冻 {matured_count} 笔到期"
-    debit(session, shop.aggregator_frozen_wallet_id, matured_amount, remark=remark)
-    credit(session, shop.aggregator_available_wallet_id, matured_amount, remark=remark)
+    total_amount = Decimal("0")
+    total_count = 0
 
-    # 幂等保护：已释放的 IN 流水清掉 mature_at,后续查询不再命中
-    for tx in active_txs:
-        tx.mature_at = None
+    # 按日期升序处理,生成稳定的流水顺序
+    for day_start in sorted(groups.keys()):
+        txs_in_group = groups[day_start]
+        group_amount = sum((Decimal(t.amount) for t in txs_in_group), Decimal("0"))
+        group_count = len(txs_in_group)
+        if group_amount <= 0:
+            continue
+
+        date_label = day_start.date().isoformat()
+        remark = f"导入自动解冻 {group_count} 笔（{date_label} 到期批次）"
+
+        debit(session, shop.aggregator_frozen_wallet_id, group_amount, remark=remark)
+        # available IN 写 business_date = 这批的 mature 那天,用于日汇总聚合
+        credit(
+            session,
+            shop.aggregator_available_wallet_id,
+            group_amount,
+            remark=remark,
+            business_date=day_start.date(),
+        )
+
+        # 幂等保护：清这批 frozen IN 的 mature_at
+        for tx in txs_in_group:
+            tx.mature_at = None
+
+        total_amount += group_amount
+        total_count += group_count
+
     session.flush()
-
-    return matured_amount, matured_count
+    return total_amount, total_count
 
 
 def import_qianniu_workbook(

--- a/tests/test_taobao_import_api.py
+++ b/tests/test_taobao_import_api.py
@@ -17,7 +17,7 @@
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from io import BytesIO
 
@@ -1024,6 +1024,85 @@ def test_auto_release_idempotent_second_import_no_double_release(client):
     # 余额不变
     assert _wallet_balance(shop.aggregator_frozen_wallet_id) == Decimal("0.000000")
     assert _wallet_balance(shop.aggregator_available_wallet_id) == Decimal("88.000000")
+
+
+def test_auto_release_groups_by_mature_date_writes_business_date(client):
+    """聚合释放按 mature_at 日期分组,available IN 写 business_date。
+
+    场景：3 笔到期流水,2 笔 mature_at 在 5/7,1 笔在 5/8。
+    释放后 available 钱包应有 2 笔 IN（不是合并成 1 笔）,各自 business_date 是分组日。
+    """
+    from src.models.wallet import WalletTransaction
+    from sqlalchemy import select
+
+    shop = _shop_by_name("丙火网络")
+    # 用过去时间的 mature_at（已成熟）
+    base = datetime(2026, 5, 7, 0, 0, 0)  # 5/7 这天 0 点（已过的某天）
+    _seed_aggregator_frozen_tx(shop, Decimal("100"), base.replace(hour=10), order_number="GR_507_1")
+    _seed_aggregator_frozen_tx(shop, Decimal("50"), base.replace(hour=15), order_number="GR_507_2")
+    _seed_aggregator_frozen_tx(
+        shop, Decimal("80"),
+        datetime(2026, 5, 8, 14, 0, 0),  # 5/8 这天的另一笔
+        order_number="GR_508_1",
+    )
+
+    response = _post_import(client, shop.id, _build_xlsx([]))
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["autoReleasedCount"] == 3
+    assert Decimal(payload["autoReleasedAmount"]) == Decimal("230")
+
+    # 验证：available 钱包应有 2 笔 IN（按 5/7、5/8 分组）,不是合并的 1 笔
+    db = database.SessionLocal()
+    try:
+        avail_in_txs = list(db.scalars(
+            select(WalletTransaction)
+            .where(
+                WalletTransaction.wallet_id == shop.aggregator_available_wallet_id,
+                WalletTransaction.direction == "in",
+            )
+            .order_by(WalletTransaction.id)
+        ))
+    finally:
+        db.close()
+
+    assert len(avail_in_txs) == 2
+    # 第一笔 5/7（100 + 50 = 150）
+    assert Decimal(avail_in_txs[0].amount) == Decimal("150")
+    assert avail_in_txs[0].business_date == date(2026, 5, 7)
+    # 第二笔 5/8（80）
+    assert Decimal(avail_in_txs[1].amount) == Decimal("80")
+    assert avail_in_txs[1].business_date == date(2026, 5, 8)
+
+
+def test_daily_summary_available_uses_business_date(client):
+    """聚合可提现日汇总按 business_date(=mature_at 那天) 散开,不再挤在 release 操作日。"""
+    shop = _shop_by_name("丙火网络")
+    base_507 = datetime(2026, 5, 7, 0, 0, 0)
+    _seed_aggregator_frozen_tx(shop, Decimal("100"), base_507.replace(hour=10), order_number="DS_507_1")
+    _seed_aggregator_frozen_tx(shop, Decimal("50"), base_507.replace(hour=18), order_number="DS_507_2")
+    _seed_aggregator_frozen_tx(
+        shop, Decimal("80"),
+        datetime(2026, 5, 8, 12, 0, 0),
+        order_number="DS_508_1",
+    )
+
+    # 触发自动 release（导入空 Excel）
+    response = _post_import(client, shop.id, _build_xlsx([]))
+    assert response.status_code == 200
+
+    # 查 available 钱包的日汇总
+    available_id = shop.aggregator_available_wallet_id
+    response = client.get(f"/taobao/shops/{shop.id}/wallets/{available_id}/daily-summary")
+    assert response.status_code == 200
+    rows = response.json()
+
+    # 应该看到 5/7 和 5/8 两行（按业务日期 = mature_at 那天）
+    by_date = {r["date"]: r for r in rows}
+    assert "2026-05-07" in by_date
+    assert "2026-05-08" in by_date
+    assert Decimal(by_date["2026-05-07"]["inAmount"]) == Decimal("150")  # 100+50
+    assert Decimal(by_date["2026-05-08"]["inAmount"]) == Decimal("80")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## CEO 需求
聚合可提现日汇总只显示 release 那天一行（5/6 ¥131,563.13）,看不出每天解冻多少。希望按订单原本到期日（confirmed_at + 7d）散开,看清「5/12 ¥X、5/13 ¥Y」节奏。

## 实施方案

### 选 A + 选项 a（见 ``.claude/skills/taobao-cashflow-rules``）

1. **schema 加字段** ``WalletTransaction.business_date: date``
2. **改 release 逻辑**：``_auto_release_aggregator`` 按 mature_at 日期分组,每组一对 debit/credit,credit 时填 business_date = 那天
3. **改 daily-summary CASE**：IN + business_date 非空 → 用 business_date（最高优先级）
4. **历史数据迁移**：``scripts/migrate_available_business_date.py`` 反向追溯历史合并流水,拆成多笔 business_date 各异的小流水

### 文件改动
| 文件 | 改动 |
|---|---|
| ``src/models/wallet.py`` | 加 ``business_date`` 字段 + ``credit()`` 加同名参数 |
| ``src/database.py`` | 加 ``_ensure_wallet_transaction_business_date_column`` ALTER 迁移 |
| ``src/services/taobao_import.py`` | ``_auto_release_aggregator`` 改按 mature_at 日期分组 |
| ``src/routers/taobao.py`` | daily-summary CASE 加 business_date 优先级 |
| ``scripts/migrate_available_business_date.py`` | 一次性历史数据回填脚本 |

## 测试
新增 2 个,共 152/152 通过：
- ``groups_by_mature_date_writes_business_date``: 3 笔流水跨 2 天 → release 拆 2 笔 IN,business_date 正确
- ``daily_summary_available_uses_business_date``: available 日汇总按 business_date 分布

## 实测效果（丙火网络真实数据）

迁移**前**：1 行
```
5/6: +¥131,563.13 (count=2)
```

迁移**后**：13 行
```
5/6  +¥14,343.58
5/5  +¥15,058.99
5/4  +¥9,565.18
5/3  +¥13,115.21
5/2  +¥10,887.12
5/1  +¥6,618.15
4/30 +¥7,425.23
4/29 +¥14,921.63
4/28 +¥16,317.32
4/27 +¥10,587.80
4/26 +¥5,365.73
4/25 +¥5,177.82
4/24 +¥2,179.37
─────────────
累计 ¥131,563.13 ✓ 与钱包余额一致
```

## 部署后必跑
```bash
python scripts/migrate_available_business_date.py
```
（已在本次 commit 之前跑过,生产 DB 已迁移完成。脚本幂等可重复。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)