### PR TITLE
feat(xbox): P0.1 账号库存升级（加字段 + 密码加密 + 操作日志）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Finance system 环境变量示例
+# 复制为 .env 并填实际值。.env 已 .gitignore,绝不提交。
+
+# XBOX 账号密码 AES-256 加密密钥（base64 编码的 32 字节）
+# 生成命令：python -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode())"
+XBOX_ACCOUNT_PASSWORD_KEY=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 SQLAlchemy==2.0.36
+cryptography==48.0.0
 fastapi==0.115.0
 httpx==0.27.2
 openpyxl==3.1.5

--- a/src/database.py
+++ b/src/database.py
@@ -45,6 +45,7 @@ def init_db() -> None:
     Base.metadata.create_all(bind=engine)
     _ensure_wallet_is_group_column()
     _ensure_wallet_transaction_business_date_column()
+    _ensure_xbox_account_extended_columns()
 
 
 def _ensure_wallet_is_group_column() -> None:
@@ -62,6 +63,48 @@ def _ensure_wallet_is_group_column() -> None:
 
     with engine.begin() as connection:
         connection.execute(text("ALTER TABLE wallets ADD COLUMN is_group BOOLEAN NOT NULL DEFAULT 0"))
+
+
+def _ensure_xbox_account_extended_columns() -> None:
+    """Add XBOX account 扩展字段（PR #103 / issue #102）。
+
+    旧 SQLite 库 ``xbox_accounts`` 只有 6 个字段,新版加：
+    account_no / login_email / password_enc / exchange_rate /
+    status / status_message / last_synced_at
+    """
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+
+    inspector = inspect(engine)
+    if "xbox_accounts" not in inspector.get_table_names():
+        return
+
+    column_names = {column["name"] for column in inspector.get_columns("xbox_accounts")}
+
+    additions = [
+        ("account_no", "VARCHAR(64)"),
+        ("login_email", "VARCHAR(255)"),
+        ("password_enc", "TEXT"),
+        ("exchange_rate", "NUMERIC(12, 6)"),
+        ("status", "VARCHAR(32) NOT NULL DEFAULT 'active'"),
+        ("status_message", "TEXT"),
+        ("last_synced_at", "DATETIME"),
+    ]
+
+    with engine.begin() as connection:
+        for col_name, col_def in additions:
+            if col_name not in column_names:
+                connection.execute(
+                    text(f"ALTER TABLE xbox_accounts ADD COLUMN {col_name} {col_def}")
+                )
+
+        # account_no 唯一索引（重复运行幂等：CREATE INDEX IF NOT EXISTS）
+        connection.execute(
+            text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_xbox_accounts_account_no "
+                "ON xbox_accounts(account_no) WHERE account_no IS NOT NULL"
+            )
+        )
 
 
 def _ensure_wallet_transaction_business_date_column() -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -1,11 +1,37 @@
 """Finance system API application."""
 from __future__ import annotations
 
+import os
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
 
-from src import database
+
+def _load_dotenv_basic() -> None:
+    """简单读 .env 到 os.environ（不依赖 python-dotenv,只支持 KEY=VALUE 格式）。
+
+    项目根目录的 .env 已 .gitignore。XBOX_ACCOUNT_PASSWORD_KEY 等敏感配置走这。
+    """
+    env_path = Path(__file__).resolve().parent.parent / ".env"
+    if not env_path.exists():
+        return
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        key = key.strip()
+        value = value.strip()
+        # 不覆盖已存在的环境变量(允许 export 优先)
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+_load_dotenv_basic()
+
+
+from src import database  # noqa: E402  必须在 _load_dotenv_basic 之后
 from src.routers.assets import router as assets_router
 from src.routers.vendors import router as vendors_router
 from src.routers.xbox import router as xbox_router

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -1,4 +1,10 @@
-"""XBOX account and transaction ORM models."""
+"""XBOX account and transaction ORM models。
+
+PR #103 (issue #102): 按 XBOX 订单板块需求文档 v1.0 升级账号库存。
+- XboxAccount 加字段：account_no / login_email / password_enc / exchange_rate / status / status_message
+- 加 XboxAccountAuditLog 表记录账号变更
+- 旧的 XboxTransaction (recharge/consume) 暂保留兼容
+"""
 from __future__ import annotations
 
 from datetime import datetime
@@ -23,6 +29,15 @@ class XboxCurrency(str, Enum):
     GBP = "GBP"
 
 
+class XboxAccountStatus(str, Enum):
+    """账号状态（CEO 2026-05-08 确认 4 种）。"""
+
+    ACTIVE = "active"  # 可用
+    DISABLED = "disabled"  # 停用
+    ERROR = "error"  # 异常（密码错 / 登录失败）
+    NEED_VERIFICATION = "need_verification"  # 需要安全验证
+
+
 class XboxTransactionType(str, Enum):
     RECHARGE = "recharge"
     CONSUME = "consume"
@@ -41,6 +56,24 @@ class XboxAccount(Base):
         nullable=False,
         default=Decimal("0"),
     )
+    # PR #103 新增字段
+    account_no: Mapped[Optional[str]] = mapped_column(
+        String(64), nullable=True, unique=True, index=True
+    )  # 业务唯一编号（加卡系统对接标识）
+    login_email: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    password_enc: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # AES-GCM base64
+    exchange_rate: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(12, 6), nullable=True
+    )  # 账号固定汇率（CEO 选 3C：先按账号锁汇率）
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default=XboxAccountStatus.ACTIVE.value
+    )
+    status_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # 末次同步时间（FR-04 用,P0 先建字段）
+    last_synced_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -52,6 +85,38 @@ class XboxAccount(Base):
         back_populates="account",
         cascade="all, delete-orphan",
     )
+    audit_logs: Mapped[list["XboxAccountAuditLog"]] = relationship(
+        back_populates="account",
+        cascade="all, delete-orphan",
+        order_by="XboxAccountAuditLog.id.desc()",
+    )
+
+
+class XboxAccountAuditLog(Base):
+    """账号变更审计日志。
+
+    每次新增 / 改字段 / 改密码 / 改状态 都写一行,用于追溯。
+    """
+
+    __tablename__ = "xbox_account_audit_logs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_accounts.id"), nullable=False, index=True
+    )
+    action: Mapped[str] = mapped_column(String(32), nullable=False)
+    # action 取值：created / updated / password_changed / status_changed
+    detail: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # detail 是变更摘要,如 "status: active → disabled" 或 "password_changed"
+    operator: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    # operator: 操作来源 / 用户标识，P0 先支持 "manual" / "kapian_system" / "internal"
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=china_now,
+    )
+
+    account: Mapped[XboxAccount] = relationship(back_populates="audit_logs")
 
 
 class XboxTransaction(Base):

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -6,17 +6,27 @@ from enum import Enum
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from src.database import get_db
 from src.models.xbox import (
     XboxAccount,
+    XboxAccountAuditLog,
+    XboxAccountStatus,
     XboxCountry,
     XboxCurrency,
     XboxTransaction,
     XboxTransactionType,
+)
+from src.services.xbox_account import (
+    change_password,
+    change_status,
+    create_account as service_create_account,
+    list_accounts as service_list_accounts,
+    list_audit_logs,
+    update_account_fields,
 )
 
 
@@ -29,20 +39,83 @@ COUNTRY_CURRENCY = {
 }
 
 
+def _to_camel(snake: str) -> str:
+    head, *tail = snake.split("_")
+    return head + "".join(part.title() for part in tail)
+
+
 class XboxAccountCreate(BaseModel):
+    """新增账号请求体（PR #103 升级,加新字段）。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
     name: str = Field(..., min_length=1, max_length=120)
     country: XboxCountry
+    account_no: Optional[str] = Field(None, max_length=64)
+    login_email: Optional[str] = Field(None, max_length=255)
+    password: Optional[str] = Field(None, min_length=1)  # 明文,后端加密
+    exchange_rate: Optional[Decimal] = None
+    status: Optional[XboxAccountStatus] = None
+    status_message: Optional[str] = None
+    rmb_cost: Optional[Decimal] = None
+    local_balance: Optional[Decimal] = None
     remark: Optional[str] = None
 
 
+class XboxAccountUpdate(BaseModel):
+    """编辑账号普通字段（不含 password / status,有专门接口）。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    name: Optional[str] = Field(None, min_length=1, max_length=120)
+    login_email: Optional[str] = Field(None, max_length=255)
+    exchange_rate: Optional[Decimal] = None
+    rmb_cost: Optional[Decimal] = None
+    local_balance: Optional[Decimal] = None
+    remark: Optional[str] = None
+
+
+class XboxAccountPasswordUpdate(BaseModel):
+    password: str = Field(..., min_length=1)
+
+
+class XboxAccountStatusUpdate(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    status: XboxAccountStatus
+    status_message: Optional[str] = None
+
+
 class XboxAccountOut(BaseModel):
+    """账号详情/列表响应（密码不返回明文,只返回 hasPassword 标记）。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
     id: int
     name: str
     country: str
     currency: str
     rmb_cost: Decimal
     local_balance: Decimal
+    account_no: Optional[str] = None
+    login_email: Optional[str] = None
+    has_password: bool = False
+    exchange_rate: Optional[Decimal] = None
+    status: str
+    status_message: Optional[str] = None
+    last_synced_at: Optional[str] = None
     remark: Optional[str]
+    created_at: str
+
+
+class XboxAccountAuditLogOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    account_id: int
+    action: str
+    detail: Optional[str] = None
+    operator: Optional[str] = None
     created_at: str
 
 
@@ -91,8 +164,26 @@ def serialize_account(account: XboxAccount) -> XboxAccountOut:
         currency=_value(account.currency),
         rmb_cost=account.rmb_cost,
         local_balance=account.local_balance,
+        account_no=account.account_no,
+        login_email=account.login_email,
+        has_password=bool(account.password_enc),
+        exchange_rate=account.exchange_rate,
+        status=account.status,
+        status_message=account.status_message,
+        last_synced_at=account.last_synced_at.isoformat() if account.last_synced_at else None,
         remark=account.remark,
         created_at=account.created_at.isoformat() if account.created_at else "",
+    )
+
+
+def serialize_audit_log(log: XboxAccountAuditLog) -> XboxAccountAuditLogOut:
+    return XboxAccountAuditLogOut(
+        id=log.id,
+        account_id=log.account_id,
+        action=log.action,
+        detail=log.detail,
+        operator=log.operator,
+        created_at=log.created_at.isoformat() if log.created_at else "",
     )
 
 
@@ -140,30 +231,131 @@ def apply_recharge_to_account(
     return transaction
 
 
-@router.post("/accounts", response_model=XboxAccountOut, status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/accounts",
+    response_model=XboxAccountOut,
+    response_model_by_alias=True,
+    status_code=status.HTTP_201_CREATED,
+)
 def create_account(request: XboxAccountCreate, db: Session = Depends(get_db)) -> XboxAccountOut:
-    account = XboxAccount(
-        name=request.name,
-        country=request.country.value,
-        currency=COUNTRY_CURRENCY[request.country].value,
-        remark=request.remark,
-    )
-    db.add(account)
+    """新增账号。可选填账号编号 / 登录邮箱 / 密码（自动加密）/ 汇率 / 状态。"""
+    try:
+        account = service_create_account(
+            db,
+            name=request.name,
+            country=request.country,
+            currency=COUNTRY_CURRENCY[request.country],
+            account_no=request.account_no,
+            login_email=request.login_email,
+            password_plain=request.password,
+            exchange_rate=request.exchange_rate,
+            status=request.status or XboxAccountStatus.ACTIVE,
+            status_message=request.status_message,
+            rmb_cost=request.rmb_cost or Decimal("0"),
+            local_balance=request.local_balance or Decimal("0"),
+            remark=request.remark,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     db.commit()
     db.refresh(account)
     return serialize_account(account)
 
 
-@router.get("/accounts", response_model=list[XboxAccountOut])
+@router.get("/accounts", response_model=list[XboxAccountOut], response_model_by_alias=True)
 def list_accounts(
     country: Optional[XboxCountry] = Query(None),
+    status_filter: Optional[XboxAccountStatus] = Query(None, alias="status"),
     db: Session = Depends(get_db),
 ) -> list[XboxAccountOut]:
-    statement = select(XboxAccount).order_by(XboxAccount.id)
-    if country is not None:
-        statement = statement.where(XboxAccount.country == country.value)
-    accounts = db.scalars(statement).all()
+    accounts = service_list_accounts(
+        db,
+        status=status_filter.value if status_filter else None,
+        country=country.value if country else None,
+    )
     return [serialize_account(account) for account in accounts]
+
+
+@router.patch(
+    "/accounts/{account_id}",
+    response_model=XboxAccountOut,
+    response_model_by_alias=True,
+)
+def patch_account(
+    account_id: int,
+    request: XboxAccountUpdate,
+    db: Session = Depends(get_db),
+) -> XboxAccountOut:
+    """更新账号普通字段（不含密码 / 状态）。"""
+    account = get_account_or_404(db, account_id)
+    update_account_fields(
+        db,
+        account,
+        name=request.name,
+        login_email=request.login_email,
+        exchange_rate=request.exchange_rate,
+        rmb_cost=request.rmb_cost,
+        local_balance=request.local_balance,
+        remark=request.remark,
+    )
+    db.commit()
+    db.refresh(account)
+    return serialize_account(account)
+
+
+@router.patch(
+    "/accounts/{account_id}/password",
+    response_model=XboxAccountOut,
+    response_model_by_alias=True,
+)
+def patch_account_password(
+    account_id: int,
+    request: XboxAccountPasswordUpdate,
+    db: Session = Depends(get_db),
+) -> XboxAccountOut:
+    """单独修改密码（加密存,记审计日志）。"""
+    account = get_account_or_404(db, account_id)
+    change_password(db, account, request.password)
+    db.commit()
+    db.refresh(account)
+    return serialize_account(account)
+
+
+@router.patch(
+    "/accounts/{account_id}/status",
+    response_model=XboxAccountOut,
+    response_model_by_alias=True,
+)
+def patch_account_status(
+    account_id: int,
+    request: XboxAccountStatusUpdate,
+    db: Session = Depends(get_db),
+) -> XboxAccountOut:
+    """单独修改状态（记审计日志）。"""
+    account = get_account_or_404(db, account_id)
+    try:
+        change_status(db, account, request.status, status_message=request.status_message)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(account)
+    return serialize_account(account)
+
+
+@router.get(
+    "/accounts/{account_id}/audit-logs",
+    response_model=list[XboxAccountAuditLogOut],
+    response_model_by_alias=True,
+)
+def get_account_audit_logs(
+    account_id: int,
+    limit: int = Query(50, ge=1, le=500),
+    db: Session = Depends(get_db),
+) -> list[XboxAccountAuditLogOut]:
+    """查账号变更审计日志（最新在前）。"""
+    get_account_or_404(db, account_id)
+    logs = list_audit_logs(db, account_id, limit=limit)
+    return [serialize_audit_log(log) for log in logs]
 
 
 @router.post(

--- a/src/services/xbox_account.py
+++ b/src/services/xbox_account.py
@@ -1,0 +1,211 @@
+"""XBOX 账号库存服务（PR #103 / issue #102）。
+
+业务能力（CEO 2026-05-08 确认）：
+- 新增 / 编辑账号
+- 单独修改密码（密文 AES-GCM 存,记审计日志）
+- 单独修改状态（记审计日志）
+- 列表 + 筛选
+- 审计日志查询
+
+密码：AES-256-GCM,密钥从 ``XBOX_ACCOUNT_PASSWORD_KEY`` env 读。
+状态枚举：active / disabled / error / need_verification。
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Iterable, Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.xbox import (
+    XboxAccount,
+    XboxAccountAuditLog,
+    XboxAccountStatus,
+    XboxCountry,
+    XboxCurrency,
+)
+from src.utils.crypto import decrypt_password, encrypt_password
+
+
+def _log(
+    session: Session,
+    account_id: int,
+    action: str,
+    detail: Optional[str] = None,
+    operator: str = "manual",
+) -> XboxAccountAuditLog:
+    log = XboxAccountAuditLog(
+        account_id=account_id,
+        action=action,
+        detail=detail,
+        operator=operator,
+    )
+    session.add(log)
+    session.flush()
+    return log
+
+
+def create_account(
+    session: Session,
+    *,
+    name: str,
+    country: XboxCountry | str,
+    currency: XboxCurrency | str,
+    account_no: Optional[str] = None,
+    login_email: Optional[str] = None,
+    password_plain: Optional[str] = None,
+    exchange_rate: Optional[Decimal] = None,
+    status: XboxAccountStatus | str = XboxAccountStatus.ACTIVE,
+    status_message: Optional[str] = None,
+    rmb_cost: Decimal = Decimal("0"),
+    local_balance: Decimal = Decimal("0"),
+    remark: Optional[str] = None,
+    operator: str = "manual",
+) -> XboxAccount:
+    """新增账号 + 自动加密密码 + 写审计日志。"""
+    if account_no:
+        existing = session.scalar(
+            select(XboxAccount).where(XboxAccount.account_no == account_no)
+        )
+        if existing is not None:
+            raise ValueError(f"账号编号 {account_no} 已存在")
+
+    password_enc = encrypt_password(password_plain) if password_plain else None
+    status_value = status.value if isinstance(status, XboxAccountStatus) else status
+    country_value = country.value if isinstance(country, XboxCountry) else country
+    currency_value = currency.value if isinstance(currency, XboxCurrency) else currency
+
+    account = XboxAccount(
+        name=name,
+        country=country_value,
+        currency=currency_value,
+        rmb_cost=rmb_cost,
+        local_balance=local_balance,
+        account_no=account_no,
+        login_email=login_email,
+        password_enc=password_enc,
+        exchange_rate=exchange_rate,
+        status=status_value,
+        status_message=status_message,
+        remark=remark,
+    )
+    session.add(account)
+    session.flush()
+
+    _log(session, account.id, "created", f"name={name}, status={status_value}", operator)
+    return account
+
+
+def update_account_fields(
+    session: Session,
+    account: XboxAccount,
+    *,
+    name: Optional[str] = None,
+    login_email: Optional[str] = None,
+    exchange_rate: Optional[Decimal] = None,
+    rmb_cost: Optional[Decimal] = None,
+    local_balance: Optional[Decimal] = None,
+    remark: Optional[str] = None,
+    operator: str = "manual",
+) -> XboxAccount:
+    """更新非敏感字段（不能在这里改 password / status,有专门接口）。"""
+    changes: list[str] = []
+    if name is not None and name != account.name:
+        changes.append(f"name: {account.name} → {name}")
+        account.name = name
+    if login_email is not None and login_email != account.login_email:
+        changes.append(f"login_email: {account.login_email} → {login_email}")
+        account.login_email = login_email
+    if exchange_rate is not None and exchange_rate != account.exchange_rate:
+        changes.append(f"exchange_rate: {account.exchange_rate} → {exchange_rate}")
+        account.exchange_rate = exchange_rate
+    if rmb_cost is not None and rmb_cost != account.rmb_cost:
+        changes.append(f"rmb_cost: {account.rmb_cost} → {rmb_cost}")
+        account.rmb_cost = rmb_cost
+    if local_balance is not None and local_balance != account.local_balance:
+        changes.append(f"local_balance: {account.local_balance} → {local_balance}")
+        account.local_balance = local_balance
+    if remark is not None and remark != account.remark:
+        changes.append("remark changed")
+        account.remark = remark
+
+    if changes:
+        _log(session, account.id, "updated", "; ".join(changes), operator)
+    session.flush()
+    return account
+
+
+def change_password(
+    session: Session,
+    account: XboxAccount,
+    new_password: str,
+    operator: str = "manual",
+) -> XboxAccount:
+    """单独修改密码（加密存 + 写审计）。"""
+    if not new_password:
+        raise ValueError("新密码不能为空")
+    account.password_enc = encrypt_password(new_password)
+    _log(session, account.id, "password_changed", "password_changed", operator)
+    session.flush()
+    return account
+
+
+def change_status(
+    session: Session,
+    account: XboxAccount,
+    new_status: XboxAccountStatus | str,
+    status_message: Optional[str] = None,
+    operator: str = "manual",
+) -> XboxAccount:
+    """单独修改状态（写审计）。"""
+    new_value = new_status.value if isinstance(new_status, XboxAccountStatus) else new_status
+    if new_value not in {s.value for s in XboxAccountStatus}:
+        raise ValueError(f"非法状态: {new_value}")
+    if account.status == new_value and account.status_message == status_message:
+        return account
+    detail = f"status: {account.status} → {new_value}"
+    if status_message:
+        detail += f" ({status_message})"
+    account.status = new_value
+    account.status_message = status_message
+    _log(session, account.id, "status_changed", detail, operator)
+    session.flush()
+    return account
+
+
+def list_accounts(
+    session: Session,
+    *,
+    status: Optional[str] = None,
+    country: Optional[str] = None,
+) -> list[XboxAccount]:
+    """列表 + 状态/国家筛选。"""
+    stmt = select(XboxAccount).order_by(XboxAccount.id.desc())
+    if status:
+        stmt = stmt.where(XboxAccount.status == status)
+    if country:
+        stmt = stmt.where(XboxAccount.country == country)
+    return list(session.scalars(stmt))
+
+
+def list_audit_logs(
+    session: Session,
+    account_id: int,
+    limit: int = 50,
+) -> list[XboxAccountAuditLog]:
+    return list(
+        session.scalars(
+            select(XboxAccountAuditLog)
+            .where(XboxAccountAuditLog.account_id == account_id)
+            .order_by(XboxAccountAuditLog.id.desc())
+            .limit(limit)
+        )
+    )
+
+
+def reveal_password(account: XboxAccount) -> str:
+    """解密返回明文密码（仅业务必要时调用,如 Microsoft 登录）。"""
+    if not account.password_enc:
+        raise ValueError("该账号未设置密码")
+    return decrypt_password(account.password_enc)

--- a/src/utils/crypto.py
+++ b/src/utils/crypto.py
@@ -1,0 +1,82 @@
+"""AES 加密工具。
+
+用于 XBOX 账号密码（必须可逆,因为 Microsoft 登录要明文）。
+
+设计：
+- AES-256-GCM（带认证,防篡改）
+- 密钥从环境变量 ``XBOX_ACCOUNT_PASSWORD_KEY`` 读（base64 编码的 32 字节）
+- 密文格式：``base64(nonce[12] + ciphertext + tag[16])``
+- 解密失败抛 ``CryptoError``
+
+密钥管理：
+1. 首次部署：``python -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode())"``
+2. 把输出写到 ``.env`` 里 ``XBOX_ACCOUNT_PASSWORD_KEY=...``
+3. ``.env`` 已 .gitignore,绝不提交
+"""
+from __future__ import annotations
+
+import base64
+import os
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+class CryptoError(Exception):
+    """加密 / 解密失败。"""
+
+
+_KEY_ENV_VAR = "XBOX_ACCOUNT_PASSWORD_KEY"
+
+
+def _load_key() -> bytes:
+    """从环境变量加载 AES key。base64 编码的 32 字节。"""
+    raw = os.environ.get(_KEY_ENV_VAR)
+    if not raw:
+        raise CryptoError(
+            f"环境变量 {_KEY_ENV_VAR} 未设置；运行 "
+            f"python -c \"import os, base64; print(base64.b64encode(os.urandom(32)).decode())\" "
+            f"生成一个 32 字节 base64 密钥写到 .env"
+        )
+    try:
+        key = base64.b64decode(raw)
+    except Exception as exc:
+        raise CryptoError(f"{_KEY_ENV_VAR} 不是合法 base64: {exc}") from exc
+    if len(key) != 32:
+        raise CryptoError(f"{_KEY_ENV_VAR} 解码后必须 32 字节,实际 {len(key)}")
+    return key
+
+
+def encrypt_password(plaintext: str) -> str:
+    """加密明文密码,返回 base64 字符串（含 nonce + 密文 + 认证 tag）。"""
+    if plaintext is None:
+        raise CryptoError("明文不能为 None")
+    key = _load_key()
+    aesgcm = AESGCM(key)
+    nonce = os.urandom(12)
+    ciphertext = aesgcm.encrypt(nonce, plaintext.encode("utf-8"), None)
+    return base64.b64encode(nonce + ciphertext).decode("ascii")
+
+
+def decrypt_password(ciphertext_b64: str) -> str:
+    """解密成明文密码。失败抛 CryptoError。"""
+    if not ciphertext_b64:
+        raise CryptoError("密文不能为空")
+    key = _load_key()
+    try:
+        blob = base64.b64decode(ciphertext_b64)
+    except Exception as exc:
+        raise CryptoError(f"密文不是合法 base64: {exc}") from exc
+    if len(blob) < 12 + 16:
+        raise CryptoError(f"密文长度不足: {len(blob)}")
+    nonce, ciphertext = blob[:12], blob[12:]
+    aesgcm = AESGCM(key)
+    try:
+        plaintext = aesgcm.decrypt(nonce, ciphertext, None)
+    except Exception as exc:
+        raise CryptoError(f"解密失败（密钥不对或密文被篡改）: {exc}") from exc
+    return plaintext.decode("utf-8")
+
+
+def generate_key_for_setup() -> str:
+    """生成新 base64 密钥（仅用于初次部署/文档示例,不在业务逻辑里调用）。"""
+    return base64.b64encode(os.urandom(32)).decode("ascii")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+"""pytest 全局配置：设置测试用的环境变量。"""
+from __future__ import annotations
+
+import base64
+import os
+
+
+def _ensure_xbox_password_key() -> None:
+    """测试用 AES key（固定 32 字节,base64 编码）。
+
+    生产用的密钥从 .env 读,测试时如果没设就用一个稳定的 zero-key,
+    保证 cryptography 不报错。CI 环境也走这条路。
+    """
+    if "XBOX_ACCOUNT_PASSWORD_KEY" in os.environ:
+        return
+    test_key = base64.b64encode(b"test-key-32-bytes!!!" + b"\x00" * 12).decode()
+    os.environ["XBOX_ACCOUNT_PASSWORD_KEY"] = test_key
+
+
+_ensure_xbox_password_key()

--- a/tests/test_xbox_api.py
+++ b/tests/test_xbox_api.py
@@ -62,8 +62,9 @@ def test_recharge_consume_and_transactions(client):
     assert [item["type"] for item in transactions.json()] == ["recharge", "consume"]
 
     refreshed = client.get("/xbox/accounts", params={"country": "US"}).json()[0]
-    assert Decimal(refreshed["rmb_cost"]) == Decimal("700.000000")
-    assert Decimal(refreshed["local_balance"]) == Decimal("64.500000")
+    # 改为 camelCase（PR #103 统一 alias）
+    assert Decimal(refreshed["rmbCost"]) == Decimal("700.000000")
+    assert Decimal(refreshed["localBalance"]) == Decimal("64.500000")
 
 
 def test_consume_rejects_insufficient_local_balance(client):
@@ -96,3 +97,147 @@ def test_summary_groups_usd_and_gbp(client):
     assert Decimal(summary.json()["USD"]["local_balance"]) == Decimal("100.000000")
     assert Decimal(summary.json()["GBP"]["rmb_cost"]) == Decimal("900.000000")
     assert Decimal(summary.json()["GBP"]["local_balance"]) == Decimal("80.000000")
+
+
+# ---------------------------------------------------------------------------
+# PR #103 (issue #102) - 账号库存升级测试
+# ---------------------------------------------------------------------------
+
+
+def test_create_account_with_new_fields(client):
+    """新增账号支持 account_no / login_email / password / exchange_rate / status。"""
+    response = client.post(
+        "/xbox/accounts",
+        json={
+            "name": "丙火 US 主号",
+            "country": "US",
+            "accountNo": "BH-US-001",
+            "loginEmail": "user1@outlook.com",
+            "password": "MySecret123!",
+            "exchangeRate": "7.20",
+            "status": "active",
+            "remark": "主账号",
+        },
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["accountNo"] == "BH-US-001"
+    assert body["loginEmail"] == "user1@outlook.com"
+    assert body["hasPassword"] is True
+    # 关键：明文密码不能出现在响应里
+    assert "password" not in body
+    assert "passwordEnc" not in body
+    assert body["status"] == "active"
+    assert Decimal(body["exchangeRate"]) == Decimal("7.20")
+
+
+def test_create_account_duplicate_account_no_400(client):
+    """同 account_no 重复 → 400。"""
+    client.post(
+        "/xbox/accounts",
+        json={"name": "A1", "country": "US", "accountNo": "DUP-001"},
+    )
+    r2 = client.post(
+        "/xbox/accounts",
+        json={"name": "A2", "country": "US", "accountNo": "DUP-001"},
+    )
+    assert r2.status_code == 400
+    assert "已存在" in r2.json()["detail"]
+
+
+def test_patch_account_updates_normal_fields_writes_audit(client):
+    """改普通字段 → 字段更新 + 审计日志记录。"""
+    body = create_account(client, "原名", "US")
+    aid = body["id"]
+
+    r = client.patch(
+        f"/xbox/accounts/{aid}",
+        json={"name": "新名", "loginEmail": "new@x.com", "exchangeRate": "7.15"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["name"] == "新名"
+    assert r.json()["loginEmail"] == "new@x.com"
+    assert Decimal(r.json()["exchangeRate"]) == Decimal("7.15")
+
+    logs = client.get(f"/xbox/accounts/{aid}/audit-logs").json()
+    assert any(log["action"] == "created" for log in logs)
+    assert any(log["action"] == "updated" for log in logs)
+
+
+def test_patch_password_and_status_audited_separately(client):
+    """改密码 / 改状态走单独端点,各写一条审计。"""
+    body = create_account(client, "测试号", "US")
+    aid = body["id"]
+
+    # 改密码
+    r = client.patch(f"/xbox/accounts/{aid}/password", json={"password": "NewPwd456"})
+    assert r.status_code == 200
+    assert r.json()["hasPassword"] is True
+
+    # 改状态
+    r = client.patch(
+        f"/xbox/accounts/{aid}/status",
+        json={"status": "error", "statusMessage": "登录失败"},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "error"
+    assert r.json()["statusMessage"] == "登录失败"
+
+    logs = client.get(f"/xbox/accounts/{aid}/audit-logs").json()
+    actions = [log["action"] for log in logs]
+    assert "password_changed" in actions
+    assert "status_changed" in actions
+
+
+def test_password_encrypt_decrypt_roundtrip():
+    """加密再解密回明文（直接调 service 验证）。"""
+    from src.utils.crypto import decrypt_password, encrypt_password
+
+    plain = "Hello世界123!"
+    enc = encrypt_password(plain)
+    assert enc != plain  # 必须加密后不同
+    assert decrypt_password(enc) == plain
+
+
+def test_password_decrypt_with_wrong_data_raises():
+    """密文被篡改 → 解密失败。"""
+    from src.utils.crypto import CryptoError, encrypt_password, decrypt_password
+
+    enc = encrypt_password("orig")
+    # 改一位
+    bad = enc[:-2] + ("AA" if enc[-2:] != "AA" else "BB")
+    with pytest.raises(CryptoError):
+        decrypt_password(bad)
+
+
+def test_list_accounts_filter_by_status(client):
+    """按 status 过滤列表。"""
+    create_account(client, "A1", "US")
+    body = create_account(client, "A2", "US")
+    client.patch(f"/xbox/accounts/{body['id']}/status", json={"status": "disabled"})
+
+    r = client.get("/xbox/accounts", params={"status": "active"})
+    assert r.status_code == 200
+    names = [a["name"] for a in r.json()]
+    assert "A1" in names
+    assert "A2" not in names
+
+
+def test_status_filter_returns_disabled(client):
+    """status=disabled 只返回停用账号。"""
+    body = create_account(client, "A1", "US")
+    client.patch(f"/xbox/accounts/{body['id']}/status", json={"status": "disabled"})
+
+    r = client.get("/xbox/accounts", params={"status": "disabled"})
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+    assert r.json()[0]["status"] == "disabled"
+
+
+def test_existing_xbox_data_compatible(client):
+    """老接口（仅 name + country）仍能创建账号,不填新字段不报错。"""
+    body = create_account(client, "兼容老逻辑", "US")
+    assert body["status"] == "active"
+    assert body["hasPassword"] is False
+    assert body["accountNo"] is None
+    assert body["loginEmail"] is None


### PR DESCRIPTION
Closes #102

## 业务背景

CEO 给的 XBOX 订单板块需求文档 v1.0 第一阶段实施。本 PR 只做 P0.1 账号库存升级,P0.2/P0.3 在后续 PR 跟进。

## CEO 2026-05-08 确认的方案

| 编号 | 选择 |
|---|---|
| Q1 | C - 资金池 = 现有 Wallet.id |
| Q2 | A - 销售记录即入账 |
| Q3 | 按 P0 → P1 → P2 节奏 |
| Q4 | A - 扩字段保留旧 XBOX 数据 |
| Q5 | 方案 3 - 订单/销售两边互引 |
| Q6 | A - AES + .env 密钥 |
| 国家 | 1A - 保留美国/英国,未来扩 |
| 状态 | 同意 - 4 种(可用/停用/异常/需验证) |
| 汇率 | 3C - 账号固定汇率 |

## 实现

### 新加 7 字段（XboxAccount）
- ``account_no`` 业务唯一编号
- ``login_email`` 登录邮箱
- ``password_enc`` AES-256-GCM 密文
- ``exchange_rate`` 账号固定汇率
- ``status`` (active/disabled/error/need_verification)
- ``status_message``
- ``last_synced_at``

### 新增表
- ``xbox_account_audit_logs``: 记录 created / updated / password_changed / status_changed

### 加密
- ``src/utils/crypto.py`` AES-256-GCM,密钥从 ``XBOX_ACCOUNT_PASSWORD_KEY`` env 读
- 密钥用 ``.env`` 管理,已 gitignore
- ``src/main.py`` 启动时简单解析 .env 注入 os.environ

### API
- ``POST /xbox/accounts`` 新增（带新字段）
- ``GET /xbox/accounts?status=&country=`` 筛选
- ``PATCH /xbox/accounts/{id}`` 改普通字段
- ``PATCH /xbox/accounts/{id}/password`` 单独改密码
- ``PATCH /xbox/accounts/{id}/status`` 单独改状态
- ``GET /xbox/accounts/{id}/audit-logs`` 查变更历史

### 兼容性
- 旧 ``XboxAccount`` 数据保留,扩字段允许 NULL
- 旧 ``XboxTransaction (recharge/consume)`` 不动
- ``database.py`` 自动 ALTER TABLE 加新列(幂等)

## 测试 162/162 通过
新增 9 个 XBOX P0.1 测试：
- 新字段创建 + camelCase 响应 + 密码不回显
- account_no 重复 → 400
- PATCH 字段 → 自动写审计
- 密码 / 状态各自单独端点 + 各写一条审计
- 加密往返 + 密文篡改报错
- 列表按 status / country 筛选
- 旧逻辑兼容（不填新字段也能创建）

## 部署后必做
1. 跑 ``python -c "import os, base64; print(base64.b64encode(os.urandom(32)).decode())"``
2. 把输出复制到 ``.env`` 的 ``XBOX_ACCOUNT_PASSWORD_KEY=``
3. 重启后端,新接口生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)