### PR TITLE
feat(frontend): XBOX P0.1 账号管理 UI 升级

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -5,9 +5,13 @@ import {
   ArrowDownLeft,
   ArrowUpRight,
   Gamepad2,
+  History,
+  KeyRound,
   ListOrdered,
+  Pencil,
   Plus,
-  RefreshCcw
+  RefreshCcw,
+  ShieldAlert
 } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -15,16 +19,26 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import {
+  changeXboxAccountPassword,
+  changeXboxAccountStatus,
   consumeXbox,
   createXboxAccount,
+  getXboxAccountAuditLogs,
   getXboxAccounts,
   getXboxSummary,
   getXboxTransactions,
-  rechargeXbox
+  rechargeXbox,
+  updateXboxAccount
 } from "@/lib/api";
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
-import type { Currency, XboxAccount, XboxCountry } from "@/types";
+import type {
+  Currency,
+  XboxAccount,
+  XboxAccountAuditLog,
+  XboxAccountStatus,
+  XboxCountry
+} from "@/types";
 
 const COUNTRY_META: Record<XboxCountry, { label: string; currency: Currency; accentBorder: string; accentText: string }> = {
   US: {
@@ -109,6 +123,17 @@ function SummaryCards({ country }: { country: XboxCountry }) {
   );
 }
 
+// PR P0.1 状态徽章颜色配置
+const STATUS_META: Record<
+  XboxAccountStatus,
+  { label: string; tone: "success" | "warning" | "danger" | "neutral" }
+> = {
+  active: { label: "可用", tone: "success" },
+  disabled: { label: "停用", tone: "neutral" },
+  error: { label: "异常", tone: "danger" },
+  need_verification: { label: "需验证", tone: "warning" }
+};
+
 function CreateAccountModal({
   defaultCountry,
   onClose
@@ -119,6 +144,10 @@ function CreateAccountModal({
   const queryClient = useQueryClient();
   const [name, setName] = useState("");
   const [country, setCountry] = useState<XboxCountry>(defaultCountry);
+  const [accountNo, setAccountNo] = useState("");
+  const [loginEmail, setLoginEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [exchangeRate, setExchangeRate] = useState("");
   const [remark, setRemark] = useState("");
   const [error, setError] = useState<string | null>(null);
 
@@ -130,6 +159,10 @@ function CreateAccountModal({
       return createXboxAccount({
         name: name.trim(),
         country,
+        accountNo: accountNo.trim() === "" ? undefined : accountNo.trim(),
+        loginEmail: loginEmail.trim() === "" ? undefined : loginEmail.trim(),
+        password: password === "" ? undefined : password,
+        exchangeRate: exchangeRate.trim() === "" ? undefined : exchangeRate.trim(),
         remark: remark.trim() === "" ? undefined : remark.trim()
       });
     },
@@ -145,7 +178,7 @@ function CreateAccountModal({
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <Card className="w-full max-w-md">
+      <Card className="w-full max-w-md max-h-[90vh] overflow-y-auto">
         <CardHeader>
           <CardTitle>新建 XBOX 账号</CardTitle>
         </CardHeader>
@@ -179,9 +212,49 @@ function CreateAccountModal({
             </div>
           </div>
           <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">账号编号（选填,加卡系统对接 ID）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={accountNo}
+              onChange={(event) => setAccountNo(event.target.value)}
+              placeholder="如 BH-US-001"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">登录邮箱（选填）</div>
+            <input
+              type="email"
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={loginEmail}
+              onChange={(event) => setLoginEmail(event.target.value)}
+              placeholder="user@outlook.com"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">登录密码（选填,加密存储）</div>
+            <input
+              type="password"
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="留空则不设密码"
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">汇率（选填,如 7.20）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={exchangeRate}
+              onChange={(event) => setExchangeRate(event.target.value)}
+              placeholder="账号固定汇率"
+              inputMode="decimal"
+            />
+          </div>
+          <div className="space-y-1">
             <div className="text-sm text-muted-foreground">备注（选填）</div>
             <textarea
-              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              className="min-h-[60px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
               value={remark}
               onChange={(event) => setRemark(event.target.value)}
               placeholder="备注"
@@ -198,6 +271,303 @@ function CreateAccountModal({
             </Button>
             <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
               {mutation.isPending ? "创建中..." : "创建"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// PR P0.1 编辑账号普通字段
+function EditAccountModal({ account, onClose }: { account: XboxAccount; onClose: () => void }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState(account.name);
+  const [loginEmail, setLoginEmail] = useState(account.loginEmail ?? "");
+  const [exchangeRate, setExchangeRate] = useState(
+    account.exchangeRate != null ? String(account.exchangeRate) : ""
+  );
+  const [remark, setRemark] = useState(account.remark ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!name.trim()) throw new Error("账号名不能为空");
+      return updateXboxAccount(account.id, {
+        name: name.trim(),
+        loginEmail: loginEmail.trim(),
+        exchangeRate: exchangeRate.trim() === "" ? "" : exchangeRate.trim(),
+        remark: remark
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-summary"] });
+      onClose();
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "保存失败")
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>编辑账号 · {account.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">账号名</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">登录邮箱</div>
+            <input
+              type="email"
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={loginEmail}
+              onChange={(event) => setLoginEmail(event.target.value)}
+              placeholder="user@outlook.com"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">汇率</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={exchangeRate}
+              onChange={(event) => setExchangeRate(event.target.value)}
+              inputMode="decimal"
+              placeholder="如 7.20"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注</div>
+            <textarea
+              className="min-h-[80px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(event) => setRemark(event.target.value)}
+            />
+          </div>
+          <div className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+            修改密码、状态请用对应的单独按钮（会写审计日志）
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "保存中..." : "保存"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// PR P0.1 修改密码（单独 Modal,写审计日志）
+function ChangePasswordModal({
+  account,
+  onClose
+}: {
+  account: XboxAccount;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!password) throw new Error("密码不能为空");
+      if (password !== confirm) throw new Error("两次输入的密码不一致");
+      return changeXboxAccountPassword(account.id, password);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+      onClose();
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "修改失败")
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle>修改密码 · {account.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">新密码</div>
+            <input
+              type="password"
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoFocus
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">确认密码</div>
+            <input
+              type="password"
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={confirm}
+              onChange={(event) => setConfirm(event.target.value)}
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+            密码会以 AES-256 加密存储,数据库里只能看到密文
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "保存中..." : "保存"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// PR P0.1 修改状态（单独 Modal,写审计日志）
+function ChangeStatusModal({
+  account,
+  onClose
+}: {
+  account: XboxAccount;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<XboxAccountStatus>(account.status);
+  const [statusMessage, setStatusMessage] = useState(account.statusMessage ?? "");
+  const [error, setError] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () =>
+      changeXboxAccountStatus(account.id, status, statusMessage.trim() === "" ? undefined : statusMessage.trim()),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
+      onClose();
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "修改失败")
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>修改状态 · {account.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">状态</div>
+            <div className="grid grid-cols-2 gap-1 rounded-md border border-border p-1">
+              {(Object.keys(STATUS_META) as XboxAccountStatus[]).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  className={cn(
+                    "flex h-9 items-center justify-center rounded text-sm font-medium text-muted-foreground",
+                    status === s && "bg-muted text-foreground"
+                  )}
+                  onClick={() => setStatus(s)}
+                >
+                  {STATUS_META[s].label}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">备注（选填,如"密码错"、"需要短信验证"）</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={statusMessage}
+              onChange={(event) => setStatusMessage(event.target.value)}
+              placeholder="状态原因"
+            />
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "保存中..." : "保存"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// PR P0.1 审计日志 Modal
+function AuditLogsModal({ account, onClose }: { account: XboxAccount; onClose: () => void }) {
+  const { data: logs = [], isFetching } = useQuery({
+    queryKey: ["xbox-audit-logs", account.id],
+    queryFn: () => getXboxAccountAuditLogs(account.id)
+  });
+
+  const ACTION_LABELS: Record<XboxAccountAuditLog["action"], string> = {
+    created: "新建",
+    updated: "更新",
+    password_changed: "改密码",
+    status_changed: "改状态"
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="flex max-h-[80vh] w-full max-w-2xl flex-col">
+        <CardHeader>
+          <CardTitle>审计日志 · {account.name}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 overflow-y-auto">
+          {logs.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+              {isFetching ? "加载中..." : "暂无变更记录"}
+            </div>
+          ) : (
+            <div className="divide-y divide-border rounded-md border border-border">
+              {logs.map((log) => (
+                <div key={log.id} className="flex items-start gap-3 px-3 py-2">
+                  <Badge tone="transfer">{ACTION_LABELS[log.action] ?? log.action}</Badge>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm">{log.detail || "(无明细)"}</div>
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      {formatDateTime(log.createdAt)} · {log.operator ?? "manual"}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 flex justify-end">
+            <Button variant="ghost" onClick={onClose}>
+              关闭
             </Button>
           </div>
         </CardContent>
@@ -442,18 +812,31 @@ function TransactionsModal({ account, onClose }: { account: XboxAccount; onClose
   );
 }
 
+function StatusBadge({ status }: { status: XboxAccountStatus }) {
+  const meta = STATUS_META[status];
+  return <Badge tone={meta.tone}>{meta.label}</Badge>;
+}
+
 function AccountsTable({
   accounts,
   country,
   onRecharge,
   onConsume,
-  onTransactions
+  onTransactions,
+  onEdit,
+  onChangePassword,
+  onChangeStatus,
+  onShowAuditLogs
 }: {
   accounts: XboxAccount[];
   country: XboxCountry;
   onRecharge: (account: XboxAccount) => void;
   onConsume: (account: XboxAccount) => void;
   onTransactions: (account: XboxAccount) => void;
+  onEdit: (account: XboxAccount) => void;
+  onChangePassword: (account: XboxAccount) => void;
+  onChangeStatus: (account: XboxAccount) => void;
+  onShowAuditLogs: (account: XboxAccount) => void;
 }) {
   const meta = COUNTRY_META[country];
   return (
@@ -461,6 +844,9 @@ function AccountsTable({
       <TableHeader>
         <TableRow>
           <TableHead>账号名</TableHead>
+          <TableHead>账号编号</TableHead>
+          <TableHead>登录邮箱</TableHead>
+          <TableHead>状态</TableHead>
           <TableHead className="text-right">RMB 累计成本</TableHead>
           <TableHead className="text-right">本地余额</TableHead>
           <TableHead>备注</TableHead>
@@ -471,26 +857,63 @@ function AccountsTable({
         {accounts.map((account) => (
           <TableRow key={account.id}>
             <TableCell className="font-medium">{account.name}</TableCell>
+            <TableCell className="text-xs tabular-nums text-muted-foreground">
+              {account.accountNo ?? "-"}
+            </TableCell>
+            <TableCell className="text-xs text-muted-foreground">
+              <div className="flex items-center gap-1">
+                <span className="truncate max-w-[160px]">{account.loginEmail ?? "-"}</span>
+                {account.hasPassword ? (
+                  <KeyRound className="h-3 w-3 text-emerald-600" aria-label="已设密码" />
+                ) : null}
+              </div>
+            </TableCell>
+            <TableCell>
+              <div className="flex flex-col gap-0.5">
+                <StatusBadge status={account.status} />
+                {account.statusMessage ? (
+                  <span className="text-[10px] text-muted-foreground truncate max-w-[120px]">
+                    {account.statusMessage}
+                  </span>
+                ) : null}
+              </div>
+            </TableCell>
             <TableCell className="text-right tabular-nums text-red-600">
               {formatMoney(account.rmbCostMinor, "CNY")}
             </TableCell>
             <TableCell className={cn("text-right tabular-nums font-semibold", meta.accentText)}>
               {formatMoney(account.localBalanceMinor, account.currency)}
             </TableCell>
-            <TableCell className="text-muted-foreground">{account.remark ?? "-"}</TableCell>
+            <TableCell className="text-muted-foreground text-xs">{account.remark ?? "-"}</TableCell>
             <TableCell className="text-right">
-              <div className="flex justify-end gap-2">
+              <div className="flex flex-wrap justify-end gap-1">
                 <Button size="sm" variant="outline" onClick={() => onRecharge(account)}>
-                  <ArrowDownLeft className="h-4 w-4 text-green-600" aria-hidden="true" />
+                  <ArrowDownLeft className="h-3.5 w-3.5 text-green-600" aria-hidden="true" />
                   充值
                 </Button>
                 <Button size="sm" variant="outline" onClick={() => onConsume(account)}>
-                  <ArrowUpRight className="h-4 w-4 text-red-600" aria-hidden="true" />
+                  <ArrowUpRight className="h-3.5 w-3.5 text-red-600" aria-hidden="true" />
                   消费
                 </Button>
                 <Button size="sm" variant="ghost" onClick={() => onTransactions(account)}>
-                  <ListOrdered className="h-4 w-4" aria-hidden="true" />
+                  <ListOrdered className="h-3.5 w-3.5" aria-hidden="true" />
                   流水
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => onEdit(account)}>
+                  <Pencil className="h-3.5 w-3.5" aria-hidden="true" />
+                  编辑
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => onChangePassword(account)}>
+                  <KeyRound className="h-3.5 w-3.5" aria-hidden="true" />
+                  改密码
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => onChangeStatus(account)}>
+                  <ShieldAlert className="h-3.5 w-3.5" aria-hidden="true" />
+                  改状态
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => onShowAuditLogs(account)}>
+                  <History className="h-3.5 w-3.5" aria-hidden="true" />
+                  审计
                 </Button>
               </div>
             </TableCell>
@@ -498,7 +921,7 @@ function AccountsTable({
         ))}
         {accounts.length === 0 ? (
           <TableRow>
-            <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+            <TableCell colSpan={8} className="py-8 text-center text-muted-foreground">
               当前 Tab 暂无账号，点击右上角「+ 新建账号」开始
             </TableCell>
           </TableRow>
@@ -514,6 +937,10 @@ export function XboxPage() {
   const [rechargeTarget, setRechargeTarget] = useState<XboxAccount | null>(null);
   const [consumeTarget, setConsumeTarget] = useState<XboxAccount | null>(null);
   const [transactionsTarget, setTransactionsTarget] = useState<XboxAccount | null>(null);
+  const [editTarget, setEditTarget] = useState<XboxAccount | null>(null);
+  const [passwordTarget, setPasswordTarget] = useState<XboxAccount | null>(null);
+  const [statusTarget, setStatusTarget] = useState<XboxAccount | null>(null);
+  const [auditTarget, setAuditTarget] = useState<XboxAccount | null>(null);
 
   const { data: accounts = [], isFetching, refetch } = useQuery({
     queryKey: ["xbox-accounts", country],
@@ -572,6 +999,10 @@ export function XboxPage() {
             onRecharge={setRechargeTarget}
             onConsume={setConsumeTarget}
             onTransactions={setTransactionsTarget}
+            onEdit={setEditTarget}
+            onChangePassword={setPasswordTarget}
+            onChangeStatus={setStatusTarget}
+            onShowAuditLogs={setAuditTarget}
           />
         </CardContent>
       </Card>
@@ -587,6 +1018,18 @@ export function XboxPage() {
       ) : null}
       {transactionsTarget ? (
         <TransactionsModal account={transactionsTarget} onClose={() => setTransactionsTarget(null)} />
+      ) : null}
+      {editTarget ? (
+        <EditAccountModal account={editTarget} onClose={() => setEditTarget(null)} />
+      ) : null}
+      {passwordTarget ? (
+        <ChangePasswordModal account={passwordTarget} onClose={() => setPasswordTarget(null)} />
+      ) : null}
+      {statusTarget ? (
+        <ChangeStatusModal account={statusTarget} onClose={() => setStatusTarget(null)} />
+      ) : null}
+      {auditTarget ? (
+        <AuditLogsModal account={auditTarget} onClose={() => setAuditTarget(null)} />
       ) : null}
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -37,6 +37,8 @@ import type {
   WalletBalance,
   WalletType,
   XboxAccount,
+  XboxAccountAuditLog,
+  XboxAccountStatus,
   XboxCountry,
   XboxSummary,
   XboxTransaction,
@@ -323,6 +325,31 @@ type XboxAccountResponse = {
   remark?: string | null;
   created_at?: string;
   createdAt?: string;
+  // PR #103 新字段
+  account_no?: string | null;
+  accountNo?: string | null;
+  login_email?: string | null;
+  loginEmail?: string | null;
+  has_password?: boolean;
+  hasPassword?: boolean;
+  exchange_rate?: string | number | null;
+  exchangeRate?: string | number | null;
+  status?: string;
+  status_message?: string | null;
+  statusMessage?: string | null;
+  last_synced_at?: string | null;
+  lastSyncedAt?: string | null;
+};
+
+type XboxAccountAuditLogResponse = {
+  id: string | number;
+  account_id?: string | number;
+  accountId?: string | number;
+  action: string;
+  detail?: string | null;
+  operator?: string | null;
+  created_at?: string;
+  createdAt?: string;
 };
 
 type XboxTransactionResponse = {
@@ -347,6 +374,7 @@ type XboxSummaryResponse = {
 function normalizeXboxAccount(account: XboxAccountResponse): XboxAccount {
   const country = (account.country === "UK" ? "UK" : "US") as XboxCountry;
   const currency: Currency = country === "US" ? "USD" : "GBP";
+  const exchangeRateRaw = account.exchange_rate ?? account.exchangeRate ?? null;
   return {
     id: String(account.id),
     name: account.name,
@@ -355,7 +383,28 @@ function normalizeXboxAccount(account: XboxAccountResponse): XboxAccount {
     rmbCostMinor: decimalToMinor(account.rmb_cost ?? account.rmbCost ?? 0, "CNY"),
     localBalanceMinor: decimalToMinor(account.local_balance ?? account.localBalance ?? 0, currency),
     remark: account.remark ?? null,
-    createdAt: account.created_at ?? account.createdAt ?? ""
+    createdAt: account.created_at ?? account.createdAt ?? "",
+    accountNo: account.account_no ?? account.accountNo ?? null,
+    loginEmail: account.login_email ?? account.loginEmail ?? null,
+    hasPassword: Boolean(account.has_password ?? account.hasPassword ?? false),
+    exchangeRate:
+      exchangeRateRaw == null || exchangeRateRaw === ""
+        ? null
+        : Number(exchangeRateRaw),
+    status: ((account.status as XboxAccount["status"]) ?? "active"),
+    statusMessage: account.status_message ?? account.statusMessage ?? null,
+    lastSyncedAt: account.last_synced_at ?? account.lastSyncedAt ?? null
+  };
+}
+
+function normalizeXboxAuditLog(log: XboxAccountAuditLogResponse): XboxAccountAuditLog {
+  return {
+    id: String(log.id),
+    accountId: String(log.account_id ?? log.accountId ?? ""),
+    action: (log.action as XboxAccountAuditLog["action"]) ?? "updated",
+    detail: log.detail ?? null,
+    operator: log.operator ?? null,
+    createdAt: log.created_at ?? log.createdAt ?? ""
   };
 }
 
@@ -386,16 +435,82 @@ export async function createXboxAccount(payload: {
   name: string;
   country: XboxCountry;
   remark?: string;
+  accountNo?: string;
+  loginEmail?: string;
+  password?: string;
+  exchangeRate?: string;
+  status?: XboxAccountStatus;
+  statusMessage?: string;
 }): Promise<XboxAccount> {
   const body: Record<string, unknown> = {
     name: payload.name,
     country: payload.country
   };
-  if (payload.remark) {
-    body.remark = payload.remark;
-  }
+  if (payload.remark) body.remark = payload.remark;
+  if (payload.accountNo) body.accountNo = payload.accountNo;
+  if (payload.loginEmail) body.loginEmail = payload.loginEmail;
+  if (payload.password) body.password = payload.password;
+  if (payload.exchangeRate) body.exchangeRate = payload.exchangeRate;
+  if (payload.status) body.status = payload.status;
+  if (payload.statusMessage) body.statusMessage = payload.statusMessage;
   const data = (await postJson("/api/xbox/accounts", body)) as XboxAccountResponse;
   return normalizeXboxAccount(data);
+}
+
+export async function updateXboxAccount(
+  accountId: string,
+  payload: {
+    name?: string;
+    loginEmail?: string;
+    exchangeRate?: string;
+    rmbCost?: string;
+    localBalance?: string;
+    remark?: string;
+  }
+): Promise<XboxAccount> {
+  const body: Record<string, unknown> = {};
+  if (payload.name !== undefined) body.name = payload.name;
+  if (payload.loginEmail !== undefined) body.loginEmail = payload.loginEmail;
+  if (payload.exchangeRate !== undefined) body.exchangeRate = payload.exchangeRate;
+  if (payload.rmbCost !== undefined) body.rmbCost = payload.rmbCost;
+  if (payload.localBalance !== undefined) body.localBalance = payload.localBalance;
+  if (payload.remark !== undefined) body.remark = payload.remark;
+  const data = (await sendJson(`/api/xbox/accounts/${accountId}`, "PATCH", body)) as XboxAccountResponse;
+  return normalizeXboxAccount(data);
+}
+
+export async function changeXboxAccountPassword(
+  accountId: string,
+  password: string
+): Promise<XboxAccount> {
+  const data = (await sendJson(`/api/xbox/accounts/${accountId}/password`, "PATCH", {
+    password
+  })) as XboxAccountResponse;
+  return normalizeXboxAccount(data);
+}
+
+export async function changeXboxAccountStatus(
+  accountId: string,
+  status: XboxAccountStatus,
+  statusMessage?: string
+): Promise<XboxAccount> {
+  const body: Record<string, unknown> = { status };
+  if (statusMessage !== undefined) body.statusMessage = statusMessage;
+  const data = (await sendJson(`/api/xbox/accounts/${accountId}/status`, "PATCH", body)) as XboxAccountResponse;
+  return normalizeXboxAccount(data);
+}
+
+export async function getXboxAccountAuditLogs(
+  accountId: string
+): Promise<XboxAccountAuditLog[]> {
+  try {
+    const data = await fetchJson<XboxAccountAuditLogResponse[]>(
+      `/api/xbox/accounts/${accountId}/audit-logs`
+    );
+    return data.map(normalizeXboxAuditLog);
+  } catch {
+    return [];
+  }
 }
 
 export async function rechargeXbox(

--- a/frontend/lib/mock-data.ts
+++ b/frontend/lib/mock-data.ts
@@ -294,6 +294,16 @@ export const mockVendorTransactions: Record<string, VendorTransaction[]> = {
   ]
 };
 
+const _xboxStubExtra = {
+  accountNo: null,
+  loginEmail: null,
+  hasPassword: false,
+  exchangeRate: null,
+  status: "active" as const,
+  statusMessage: null,
+  lastSyncedAt: null
+};
+
 export const mockXboxAccounts: XboxAccount[] = [
   {
     id: "xbox-us-1",
@@ -303,7 +313,8 @@ export const mockXboxAccounts: XboxAccount[] = [
     rmbCostMinor: 28_000_00,
     localBalanceMinor: 3_840_00,
     remark: "主号",
-    createdAt: "2026-03-12T08:00:00.000Z"
+    createdAt: "2026-03-12T08:00:00.000Z",
+    ..._xboxStubExtra
   },
   {
     id: "xbox-us-2",
@@ -313,7 +324,8 @@ export const mockXboxAccounts: XboxAccount[] = [
     rmbCostMinor: 12_500_00,
     localBalanceMinor: 1_720_00,
     remark: null,
-    createdAt: "2026-03-30T03:20:00.000Z"
+    createdAt: "2026-03-30T03:20:00.000Z",
+    ..._xboxStubExtra
   },
   {
     id: "xbox-uk-1",
@@ -323,7 +335,8 @@ export const mockXboxAccounts: XboxAccount[] = [
     rmbCostMinor: 18_400_00,
     localBalanceMinor: 2_100_00,
     remark: "英区主力",
-    createdAt: "2026-04-02T05:00:00.000Z"
+    createdAt: "2026-04-02T05:00:00.000Z",
+    ..._xboxStubExtra
   }
 ];
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -52,6 +52,9 @@ export type XboxCountry = "US" | "UK";
 
 export type XboxTransactionType = "recharge" | "consume";
 
+// PR #103 (issue #102) 加的账号状态
+export type XboxAccountStatus = "active" | "disabled" | "error" | "need_verification";
+
 export type XboxAccount = {
   id: string;
   name: string;
@@ -60,6 +63,24 @@ export type XboxAccount = {
   rmbCostMinor: number;
   localBalanceMinor: number;
   remark: string | null;
+  createdAt: string;
+  // PR #103 新字段
+  accountNo: string | null;
+  loginEmail: string | null;
+  hasPassword: boolean;
+  exchangeRate: number | null; // 账号固定汇率（取后端 string,前端转 number）
+  status: XboxAccountStatus;
+  statusMessage: string | null;
+  lastSyncedAt: string | null;
+};
+
+// 账号变更审计日志
+export type XboxAccountAuditLog = {
+  id: string;
+  accountId: string;
+  action: "created" | "updated" | "password_changed" | "status_changed";
+  detail: string | null;
+  operator: string | null;
   createdAt: string;
 };
 


### PR DESCRIPTION
## CEO 反馈
之前 PR #103 后端做完了 P0.1,但前端 XBOX 页面没动,看不到新功能。本 PR 补前端。

## CEO UI 决策
- Q1: 1A 列表加 3 列(账号编号/登录邮箱/状态徽章)
- Q2: 2A 表单一次加全字段
- Q3: 3A 每行加 4 个新按钮(编辑/改密码/改状态/审计)
- Q4: 4A 审计日志独立 Modal
- 风格: 沿用现有 Modal + Card + Badge

## 新组件
4 个新 Modal + 1 个状态徽章
- EditAccountModal 改普通字段
- ChangePasswordModal 单独改密码（双输入确认）
- ChangeStatusModal 4 状态选择 + 备注
- AuditLogsModal 审计日志列表（按动作类型 Badge）
- StatusBadge: 绿(可用)/灰(停用)/红(异常)/黄(需验证)

## 升级
- 创建账号表单加 5 字段(账号编号/邮箱/密码/汇率/备注),max-h-90vh 滚动
- 表格加 3 列 + 每行 7 个操作按钮(原 3 + 新 4)
- 表格 colspan 从 5 → 8

## 类型/API
新增类型 XboxAccountStatus XboxAccountAuditLog,
XboxAccount 加 7 字段。
新增接口函数 updateXboxAccount / changeXboxAccountPassword /
changeXboxAccountStatus / getXboxAccountAuditLogs。

## 验证
- TS 类型检查通过
- http://127.0.0.1:3000/xbox 页面 200
- 后端已有 1 个老账号 US1,新字段自动 status=active 兼容显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)