### PR TITLE
feat(xbox): 编辑账号支持改账号编号 + 列表字体恢复小字

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -277,6 +277,7 @@ function CreateAccountModal({
 // PR P0.1 编辑账号普通字段
 function EditAccountModal({ account, onClose }: { account: XboxAccount; onClose: () => void }) {
   const queryClient = useQueryClient();
+  const [accountNo, setAccountNo] = useState(account.accountNo ?? "");
   const [loginEmail, setLoginEmail] = useState(account.loginEmail ?? "");
   const [exchangeRate, setExchangeRate] = useState(
     account.exchangeRate != null ? String(account.exchangeRate) : ""
@@ -285,13 +286,16 @@ function EditAccountModal({ account, onClose }: { account: XboxAccount; onClose:
   const [error, setError] = useState<string | null>(null);
 
   const mutation = useMutation({
-    mutationFn: async () =>
-      // 不传 name 字段（后端不变更）。账号编号是不可变主标识,目前也不在此处编辑
-      updateXboxAccount(account.id, {
+    mutationFn: async () => {
+      const trimmedAccountNo = accountNo.trim();
+      if (!trimmedAccountNo) throw new Error("账号编号不能为空");
+      return updateXboxAccount(account.id, {
+        accountNo: trimmedAccountNo,
         loginEmail: loginEmail.trim(),
         exchangeRate: exchangeRate.trim() === "" ? "" : exchangeRate.trim(),
         remark: remark
-      }),
+      });
+    },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["xbox-accounts"] });
       await queryClient.invalidateQueries({ queryKey: ["xbox-summary"] });
@@ -310,6 +314,17 @@ function EditAccountModal({ account, onClose }: { account: XboxAccount; onClose:
           <CardTitle>编辑账号 · {heading}</CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">
+              账号编号 <span className="text-red-600">*</span>
+            </div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={accountNo}
+              onChange={(event) => setAccountNo(event.target.value)}
+              placeholder="如 BH-US-001"
+            />
+          </div>
           <div className="space-y-1">
             <div className="text-sm text-muted-foreground">登录邮箱</div>
             <input
@@ -838,7 +853,7 @@ function AccountsTable({
       <TableBody>
         {accounts.map((account) => (
           <TableRow key={account.id}>
-            <TableCell className="font-medium">
+            <TableCell className="text-xs tabular-nums text-muted-foreground">
               {account.accountNo ?? account.name}
             </TableCell>
             <TableCell className="text-xs text-muted-foreground">

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -461,6 +461,7 @@ export async function updateXboxAccount(
   accountId: string,
   payload: {
     name?: string;
+    accountNo?: string;
     loginEmail?: string;
     exchangeRate?: string;
     rmbCost?: string;
@@ -470,6 +471,7 @@ export async function updateXboxAccount(
 ): Promise<XboxAccount> {
   const body: Record<string, unknown> = {};
   if (payload.name !== undefined) body.name = payload.name;
+  if (payload.accountNo !== undefined) body.accountNo = payload.accountNo;
   if (payload.loginEmail !== undefined) body.loginEmail = payload.loginEmail;
   if (payload.exchangeRate !== undefined) body.exchangeRate = payload.exchangeRate;
   if (payload.rmbCost !== undefined) body.rmbCost = payload.rmbCost;

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -63,11 +63,15 @@ class XboxAccountCreate(BaseModel):
 
 
 class XboxAccountUpdate(BaseModel):
-    """编辑账号普通字段（不含 password / status,有专门接口）。"""
+    """编辑账号普通字段（不含 password / status,有专门接口）。
+
+    ``account_no`` 也可在此修改（PR 后续）,会校验唯一性 + 同步 name。
+    """
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
 
     name: Optional[str] = Field(None, min_length=1, max_length=120)
+    account_no: Optional[str] = Field(None, max_length=64)
     login_email: Optional[str] = Field(None, max_length=255)
     exchange_rate: Optional[Decimal] = None
     rmb_cost: Optional[Decimal] = None
@@ -288,16 +292,20 @@ def patch_account(
 ) -> XboxAccountOut:
     """更新账号普通字段（不含密码 / 状态）。"""
     account = get_account_or_404(db, account_id)
-    update_account_fields(
-        db,
-        account,
-        name=request.name,
-        login_email=request.login_email,
-        exchange_rate=request.exchange_rate,
-        rmb_cost=request.rmb_cost,
-        local_balance=request.local_balance,
-        remark=request.remark,
-    )
+    try:
+        update_account_fields(
+            db,
+            account,
+            name=request.name,
+            account_no=request.account_no,
+            login_email=request.login_email,
+            exchange_rate=request.exchange_rate,
+            rmb_cost=request.rmb_cost,
+            local_balance=request.local_balance,
+            remark=request.remark,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     db.commit()
     db.refresh(account)
     return serialize_account(account)

--- a/src/services/xbox_account.py
+++ b/src/services/xbox_account.py
@@ -102,6 +102,7 @@ def update_account_fields(
     account: XboxAccount,
     *,
     name: Optional[str] = None,
+    account_no: Optional[str] = None,
     login_email: Optional[str] = None,
     exchange_rate: Optional[Decimal] = None,
     rmb_cost: Optional[Decimal] = None,
@@ -109,8 +110,28 @@ def update_account_fields(
     remark: Optional[str] = None,
     operator: str = "manual",
 ) -> XboxAccount:
-    """更新非敏感字段（不能在这里改 password / status,有专门接口）。"""
+    """更新非敏感字段（不能在这里改 password / status,有专门接口）。
+
+    ``account_no`` 也可在此修改,会校验唯一性 + 同步更新 ``name`` 字段
+    （前端把 account_no 当主标识,name 是兼容字段,保持二者一致）。
+    """
     changes: list[str] = []
+    if account_no is not None and account_no != account.account_no:
+        # 唯一性校验
+        if account_no:  # 非空才查重(空字符串等同于清除)
+            existing = session.scalar(
+                select(XboxAccount).where(
+                    XboxAccount.account_no == account_no,
+                    XboxAccount.id != account.id,
+                )
+            )
+            if existing is not None:
+                raise ValueError(f"账号编号 {account_no} 已被其他账号占用")
+        changes.append(f"account_no: {account.account_no} → {account_no}")
+        account.account_no = account_no or None
+        # 同步 name 字段(前端用 account_no 作主标识,保持二者一致)
+        if account_no:
+            account.name = account_no
     if name is not None and name != account.name:
         changes.append(f"name: {account.name} → {name}")
         account.name = name

--- a/tests/test_xbox_api.py
+++ b/tests/test_xbox_api.py
@@ -241,3 +241,40 @@ def test_existing_xbox_data_compatible(client):
     assert body["hasPassword"] is False
     assert body["accountNo"] is None
     assert body["loginEmail"] is None
+
+
+def test_patch_account_can_change_account_no(client):
+    """编辑接口支持改 account_no,会同步 name + 写审计。"""
+    body = client.post(
+        "/xbox/accounts",
+        json={"name": "TMP", "country": "US", "accountNo": "OLD-001"},
+    ).json()
+    aid = body["id"]
+
+    r = client.patch(f"/xbox/accounts/{aid}", json={"accountNo": "NEW-002"})
+    assert r.status_code == 200, r.text
+    assert r.json()["accountNo"] == "NEW-002"
+    # name 也应同步成新 account_no(前端用 account_no 作主标识)
+    assert r.json()["name"] == "NEW-002"
+
+    logs = client.get(f"/xbox/accounts/{aid}/audit-logs").json()
+    detail = next(l["detail"] for l in logs if l["action"] == "updated")
+    assert "account_no" in detail
+    assert "OLD-001" in detail
+    assert "NEW-002" in detail
+
+
+def test_patch_account_no_conflict_returns_400(client):
+    """改 account_no 时新编号已被占用 → 400。"""
+    client.post(
+        "/xbox/accounts",
+        json={"name": "A1", "country": "US", "accountNo": "TAKEN"},
+    )
+    body2 = client.post(
+        "/xbox/accounts",
+        json={"name": "A2", "country": "US", "accountNo": "FREE"},
+    ).json()
+
+    r = client.patch(f"/xbox/accounts/{body2['id']}", json={"accountNo": "TAKEN"})
+    assert r.status_code == 400
+    assert "已被其他账号占用" in r.json()["detail"]


### PR DESCRIPTION
CEO 两点反馈：编辑 Modal 加账号编号输入(必填) + 列表字体恢复成小字灰色。

后端 service 加 account_no 唯一性校验 + 写审计。164/164 测试通过。