### PR TITLE
feat(xbox): P0.2 销售记录数据结构 + 多币种钱包联动

### DIFF
--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -16,6 +16,7 @@ from src.utils.time import china_now
 class WalletType(str, Enum):
     ASSET_RMB = "ASSET_RMB"
     ASSET_USDT = "ASSET_USDT"
+    ASSET_USD = "ASSET_USD"  # PR #110 (P0.2): XBOX USD 销售收入资金池
     VENDOR = "VENDOR"
     XBOX = "XBOX"
     TAOBAO = "TAOBAO"

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -1,18 +1,16 @@
 """XBOX account and transaction ORM models。
 
 PR #103 (issue #102): 按 XBOX 订单板块需求文档 v1.0 升级账号库存。
-- XboxAccount 加字段：account_no / login_email / password_enc / exchange_rate / status / status_message
-- 加 XboxAccountAuditLog 表记录账号变更
-- 旧的 XboxTransaction (recharge/consume) 暂保留兼容
+PR #110 (issue P0.2): 加同步订单 / 销售记录 / 余额快照 / 同步批次 / 钱包设置。
 """
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Numeric, String, Text
+from sqlalchemy import Date, DateTime, ForeignKey, JSON, Numeric, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
@@ -135,3 +133,208 @@ class XboxTransaction(Base):
     )
 
     account: Mapped[XboxAccount] = relationship(back_populates="transactions")
+
+
+# ===================================================================
+# PR #110 P0.2 — 订单 / 销售记录 / 余额快照 / 同步批次 / 钱包设置
+# ===================================================================
+
+
+class XboxOrderStatus(str, Enum):
+    """订单状态。"""
+
+    PENDING_COMPLETE = "pending_complete"  # 待补齐业务字段
+    CONVERTED = "converted"  # 已转销售记录
+
+
+class XboxOrder(Base):
+    """同步订单（FR-04 抓取或手动建,FR-05 补齐后转销售）。"""
+
+    __tablename__ = "xbox_orders"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_accounts.id"), nullable=False, index=True
+    )
+    order_no: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    # Microsoft 订单原始信息
+    amount_local: Mapped[Decimal] = mapped_column(
+        Numeric(18, 6), nullable=False, default=Decimal("0")
+    )  # 本币消费金额（如 USD $100）
+    currency_local: Mapped[str] = mapped_column(String(8), nullable=False)  # USD / GBP
+    exchange_rate: Mapped[Optional[Decimal]] = mapped_column(
+        Numeric(12, 6), nullable=True
+    )  # 用了哪个汇率（默认从账号取）
+    rmb_cost: Mapped[Decimal] = mapped_column(
+        Numeric(18, 6), nullable=False, default=Decimal("0")
+    )  # = amount_local * exchange_rate
+    order_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    raw_data: Mapped[Optional[str]] = mapped_column(JSON, nullable=True)
+    # 状态
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default=XboxOrderStatus.PENDING_COMPLETE.value
+    )
+    # 补齐字段（运营填写）
+    sale_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    product_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    operator_name: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    sale_price: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 6), nullable=True)
+    sale_currency: Mapped[Optional[str]] = mapped_column(String(8), nullable=True)
+    wallet_method_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("xbox_wallet_methods.id"), nullable=True
+    )
+    wallet_item_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("xbox_wallet_items.id"), nullable=True
+    )
+    # 关联（方案 3 双向）
+    sale_record_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("xbox_sale_records.id"), nullable=True, index=True
+    )
+    # 时间戳
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+    last_updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+
+    account: Mapped[XboxAccount] = relationship()
+    sale_record: Mapped[Optional["XboxSaleRecord"]] = relationship(
+        back_populates="orders", foreign_keys=[sale_record_id]
+    )
+
+
+class XboxSaleRecord(Base):
+    """销售记录（订单补齐后生成,带 walletPoolId 流入资金池）。"""
+
+    __tablename__ = "xbox_sale_records"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_accounts.id"), nullable=False, index=True
+    )
+    sale_date: Mapped[date] = mapped_column(Date, nullable=False)
+    product_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    operator_name: Mapped[str] = mapped_column(String(64), nullable=False)
+    # 售价（合单后总金额,可改）
+    sale_price: Mapped[Decimal] = mapped_column(
+        Numeric(18, 6), nullable=False, default=Decimal("0")
+    )
+    sale_currency: Mapped[str] = mapped_column(String(8), nullable=False)  # CNY/USD/USDT/TWD
+    # 钱包设置映射
+    wallet_method_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_wallet_methods.id"), nullable=False
+    )
+    wallet_item_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_wallet_items.id"), nullable=False
+    )
+    wallet_item_label: Mapped[str] = mapped_column(String(120), nullable=False)  # 备注模板展示标签
+    wallet_pool_id: Mapped[int] = mapped_column(
+        ForeignKey("wallets.id"), nullable=False, index=True
+    )  # 资金池=具体钱包 id（CEO Q1C）
+    # 内部记账：本销售记录在资金池写入了一笔 IN 流水（用于改字段时反向调整）
+    bookkeeping_tx_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("wallet_transactions.id"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+    last_updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+
+    account: Mapped[XboxAccount] = relationship()
+    orders: Mapped[list["XboxOrder"]] = relationship(
+        back_populates="sale_record",
+        foreign_keys=[XboxOrder.sale_record_id],
+    )
+
+
+class XboxBalanceSnapshot(Base):
+    """账号本币余额快照（FR-04 同步时记录）。"""
+
+    __tablename__ = "xbox_balance_snapshots"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_accounts.id"), nullable=False, index=True
+    )
+    currency: Mapped[str] = mapped_column(String(8), nullable=False)
+    balance: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    captured_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+
+    account: Mapped[XboxAccount] = relationship()
+
+
+class XboxSyncBatch(Base):
+    """同步批次（FR-04 每次抓取记一条,P0.2 先建表,真同步在 P2）。"""
+
+    __tablename__ = "xbox_sync_batches"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_accounts.id"), nullable=False, index=True
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+    requested_count: Mapped[int] = mapped_column(default=0)
+    fetched_count: Mapped[int] = mapped_column(default=0)
+    success: Mapped[bool] = mapped_column(default=False)
+    failure_category: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    failure_message: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    account: Mapped[XboxAccount] = relationship()
+
+
+class XboxWalletMethod(Base):
+    """钱包设置 - 收款方式（如"代理"、"自营"）。
+
+    财务系统通过 PUT /xbox/wallet-settings 推送同步过来。
+    """
+
+    __tablename__ = "xbox_wallet_methods"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    code: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    label: Mapped[str] = mapped_column(String(120), nullable=False)
+    is_active: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+    last_updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+
+    items: Mapped[list["XboxWalletItem"]] = relationship(
+        back_populates="method",
+        cascade="all, delete-orphan",
+    )
+
+
+class XboxWalletItem(Base):
+    """钱包设置 - 备注模板（如"代理 001"、"代理 002"）→ 资金池映射。"""
+
+    __tablename__ = "xbox_wallet_items"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    method_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_wallet_methods.id"), nullable=False, index=True
+    )
+    code: Mapped[str] = mapped_column(String(64), nullable=False)
+    label: Mapped[str] = mapped_column(String(120), nullable=False)
+    wallet_pool_id: Mapped[int] = mapped_column(
+        ForeignKey("wallets.id"), nullable=False
+    )  # 资金池=具体钱包
+    is_active: Mapped[bool] = mapped_column(default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+    last_updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=china_now
+    )
+
+    method: Mapped[XboxWalletMethod] = relationship(back_populates="items")

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -1,11 +1,12 @@
 """XBOX account API routes."""
 from __future__ import annotations
 
+from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -17,8 +18,13 @@ from src.models.xbox import (
     XboxAccountStatus,
     XboxCountry,
     XboxCurrency,
+    XboxOrder,
+    XboxOrderStatus,
+    XboxSaleRecord,
     XboxTransaction,
     XboxTransactionType,
+    XboxWalletItem,
+    XboxWalletMethod,
 )
 from src.services.xbox_account import (
     change_password,
@@ -27,6 +33,20 @@ from src.services.xbox_account import (
     list_accounts as service_list_accounts,
     list_audit_logs,
     update_account_fields,
+)
+from src.services.xbox_order import (
+    create_order as service_create_order,
+    get_order_or_404,
+    list_orders as service_list_orders,
+    update_order_completion,
+)
+from src.services.xbox_sale import (
+    list_sale_records,
+    update_sale_record_fields,
+)
+from src.services.xbox_wallet_setting import (
+    list_wallet_methods,
+    upsert_wallet_settings,
 )
 
 
@@ -451,3 +471,355 @@ def xbox_summary(db: Session = Depends(get_db)) -> XboxSummaryOut:
         USD=totals.get(XboxCurrency.USD.value, empty),
         GBP=totals.get(XboxCurrency.GBP.value, empty),
     )
+
+
+# ==================================================================
+# PR #110 P0.2 — 订单 / 销售记录 / 钱包设置 端点
+# ==================================================================
+
+
+# ----- Schemas -----
+class XboxOrderCreate(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    account_id: int
+    order_no: str = Field(..., min_length=1, max_length=64)
+    amount_local: Decimal
+    currency_local: str = Field(..., min_length=1, max_length=8)
+    order_at: datetime
+    exchange_rate: Optional[Decimal] = None
+
+
+class XboxOrderCompletion(BaseModel):
+    """订单补齐字段。全部填齐后自动转销售记录。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    sale_date: Optional[date] = None
+    product_name: Optional[str] = Field(None, min_length=1, max_length=255)
+    operator_name: Optional[str] = Field(None, min_length=1, max_length=64)
+    sale_price: Optional[Decimal] = None
+    sale_currency: Optional[str] = None
+    wallet_method_id: Optional[int] = None
+    wallet_item_id: Optional[int] = None
+
+
+class XboxOrderOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    account_id: int
+    order_no: str
+    amount_local: Decimal
+    currency_local: str
+    exchange_rate: Optional[Decimal] = None
+    rmb_cost: Decimal
+    order_at: str
+    status: str
+    sale_date: Optional[str] = None
+    product_name: Optional[str] = None
+    operator_name: Optional[str] = None
+    sale_price: Optional[Decimal] = None
+    sale_currency: Optional[str] = None
+    wallet_method_id: Optional[int] = None
+    wallet_item_id: Optional[int] = None
+    sale_record_id: Optional[int] = None
+    created_at: str
+    last_updated_at: str
+
+
+class XboxSaleRecordOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    account_id: int
+    sale_date: str
+    product_name: str
+    operator_name: str
+    sale_price: Decimal
+    sale_currency: str
+    wallet_method_id: int
+    wallet_item_id: int
+    wallet_item_label: str
+    wallet_pool_id: int
+    bookkeeping_tx_id: Optional[int] = None
+    order_ids: list[int] = Field(default_factory=list)
+    created_at: str
+    last_updated_at: str
+
+
+class XboxSaleRecordUpdate(BaseModel):
+    """改销售记录字段。后端自动联动钱包余额。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    sale_date: Optional[date] = None
+    product_name: Optional[str] = None
+    operator_name: Optional[str] = None
+    sale_price: Optional[Decimal] = None
+    sale_currency: Optional[str] = None
+    wallet_method_id: Optional[int] = None
+    wallet_item_id: Optional[int] = None
+    wallet_item_label: Optional[str] = None
+    wallet_pool_id: Optional[int] = None
+
+
+class XboxWalletItemOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    code: str
+    label: str
+    wallet_pool_id: int
+    is_active: bool
+
+
+class XboxWalletMethodOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    code: str
+    label: str
+    is_active: bool
+    items: list[XboxWalletItemOut]
+
+
+# ----- Serializers -----
+def serialize_order(order: XboxOrder) -> XboxOrderOut:
+    return XboxOrderOut(
+        id=order.id,
+        account_id=order.account_id,
+        order_no=order.order_no,
+        amount_local=order.amount_local,
+        currency_local=order.currency_local,
+        exchange_rate=order.exchange_rate,
+        rmb_cost=order.rmb_cost,
+        order_at=order.order_at.isoformat() if order.order_at else "",
+        status=order.status,
+        sale_date=order.sale_date.isoformat() if order.sale_date else None,
+        product_name=order.product_name,
+        operator_name=order.operator_name,
+        sale_price=order.sale_price,
+        sale_currency=order.sale_currency,
+        wallet_method_id=order.wallet_method_id,
+        wallet_item_id=order.wallet_item_id,
+        sale_record_id=order.sale_record_id,
+        created_at=order.created_at.isoformat() if order.created_at else "",
+        last_updated_at=order.last_updated_at.isoformat() if order.last_updated_at else "",
+    )
+
+
+def serialize_sale_record(record: XboxSaleRecord, order_ids: list[int]) -> XboxSaleRecordOut:
+    return XboxSaleRecordOut(
+        id=record.id,
+        account_id=record.account_id,
+        sale_date=record.sale_date.isoformat() if record.sale_date else "",
+        product_name=record.product_name,
+        operator_name=record.operator_name,
+        sale_price=record.sale_price,
+        sale_currency=record.sale_currency,
+        wallet_method_id=record.wallet_method_id,
+        wallet_item_id=record.wallet_item_id,
+        wallet_item_label=record.wallet_item_label,
+        wallet_pool_id=record.wallet_pool_id,
+        bookkeeping_tx_id=record.bookkeeping_tx_id,
+        order_ids=order_ids,
+        created_at=record.created_at.isoformat() if record.created_at else "",
+        last_updated_at=record.last_updated_at.isoformat() if record.last_updated_at else "",
+    )
+
+
+def serialize_method(method: XboxWalletMethod) -> XboxWalletMethodOut:
+    items = sorted(method.items, key=lambda i: i.id)
+    return XboxWalletMethodOut(
+        id=method.id,
+        code=method.code,
+        label=method.label,
+        is_active=method.is_active,
+        items=[
+            XboxWalletItemOut(
+                id=it.id,
+                code=it.code,
+                label=it.label,
+                wallet_pool_id=it.wallet_pool_id,
+                is_active=it.is_active,
+            )
+            for it in items
+        ],
+    )
+
+
+# ----- Order endpoints -----
+@router.post(
+    "/orders",
+    response_model=XboxOrderOut,
+    response_model_by_alias=True,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_order_endpoint(request: XboxOrderCreate, db: Session = Depends(get_db)) -> XboxOrderOut:
+    """手动建订单（P0.2 阶段,P2 改为 Microsoft 自动同步）。"""
+    account = get_account_or_404(db, request.account_id)
+    try:
+        order = service_create_order(
+            db,
+            account=account,
+            order_no=request.order_no,
+            amount_local=request.amount_local,
+            currency_local=request.currency_local,
+            order_at=request.order_at,
+            exchange_rate=request.exchange_rate,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(order)
+    return serialize_order(order)
+
+
+@router.get(
+    "/orders",
+    response_model=list[XboxOrderOut],
+    response_model_by_alias=True,
+)
+def list_orders_endpoint(
+    account_id: Optional[int] = Query(None, alias="accountId"),
+    status_filter: Optional[XboxOrderStatus] = Query(None, alias="status"),
+    db: Session = Depends(get_db),
+) -> list[XboxOrderOut]:
+    orders = service_list_orders(
+        db,
+        account_id=account_id,
+        status=status_filter.value if status_filter else None,
+    )
+    return [serialize_order(o) for o in orders]
+
+
+@router.patch(
+    "/orders/{order_id}",
+    response_model=XboxOrderOut,
+    response_model_by_alias=True,
+)
+def patch_order_endpoint(
+    order_id: int,
+    request: XboxOrderCompletion,
+    db: Session = Depends(get_db),
+) -> XboxOrderOut:
+    """补齐订单字段。全部填齐自动转销售（CEO Q3A）。"""
+    order = get_order_or_404(db, order_id)
+    if order is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="订单不存在")
+    try:
+        update_order_completion(
+            db,
+            order,
+            sale_date=request.sale_date,
+            product_name=request.product_name,
+            operator_name=request.operator_name,
+            sale_price=request.sale_price,
+            sale_currency=request.sale_currency,
+            wallet_method_id=request.wallet_method_id,
+            wallet_item_id=request.wallet_item_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(order)
+    return serialize_order(order)
+
+
+# ----- Sale record endpoints -----
+@router.get(
+    "/sale-records",
+    response_model=list[XboxSaleRecordOut],
+    response_model_by_alias=True,
+)
+def list_sale_records_endpoint(
+    account_id: Optional[int] = Query(None, alias="accountId"),
+    wallet_pool_id: Optional[int] = Query(None, alias="walletPoolId"),
+    db: Session = Depends(get_db),
+) -> list[XboxSaleRecordOut]:
+    records = list_sale_records(db, account_id=account_id, wallet_pool_id=wallet_pool_id)
+    out: list[XboxSaleRecordOut] = []
+    for record in records:
+        order_ids = [
+            o.id
+            for o in db.scalars(
+                select(XboxOrder).where(XboxOrder.sale_record_id == record.id)
+            )
+        ]
+        out.append(serialize_sale_record(record, order_ids))
+    return out
+
+
+@router.patch(
+    "/sale-records/{record_id}",
+    response_model=XboxSaleRecordOut,
+    response_model_by_alias=True,
+)
+def patch_sale_record_endpoint(
+    record_id: int,
+    request: XboxSaleRecordUpdate,
+    db: Session = Depends(get_db),
+) -> XboxSaleRecordOut:
+    """改销售记录字段（自动联动钱包余额, CEO Q2A + Q3A）。"""
+    record = db.get(XboxSaleRecord, record_id)
+    if record is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="销售记录不存在")
+    try:
+        update_sale_record_fields(
+            db,
+            record,
+            sale_date=request.sale_date,
+            product_name=request.product_name,
+            operator_name=request.operator_name,
+            sale_price=request.sale_price,
+            sale_currency=request.sale_currency,
+            wallet_method_id=request.wallet_method_id,
+            wallet_item_id=request.wallet_item_id,
+            wallet_item_label=request.wallet_item_label,
+            wallet_pool_id=request.wallet_pool_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(record)
+    order_ids = [
+        o.id
+        for o in db.scalars(select(XboxOrder).where(XboxOrder.sale_record_id == record.id))
+    ]
+    return serialize_sale_record(record, order_ids)
+
+
+# ----- Wallet settings endpoints -----
+@router.put(
+    "/wallet-settings",
+    response_model=dict,
+)
+def upsert_wallet_settings_endpoint(
+    payload: list[dict] = Body(...),
+    db: Session = Depends(get_db),
+) -> dict:
+    """财务系统推送钱包设置（IF-02）。
+
+    Body 是 method 列表。每条 method 含 code/label/items[]。
+    item 含 code/label/walletPoolId/isActive。
+    """
+    try:
+        result = upsert_wallet_settings(db, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    return result
+
+
+@router.get(
+    "/wallet-settings",
+    response_model=list[XboxWalletMethodOut],
+    response_model_by_alias=True,
+)
+def list_wallet_settings_endpoint(
+    only_active: bool = Query(True, alias="onlyActive"),
+    db: Session = Depends(get_db),
+) -> list[XboxWalletMethodOut]:
+    methods = list_wallet_methods(db, only_active=only_active)
+    return [serialize_method(m) for m in methods]

--- a/src/services/assets.py
+++ b/src/services/assets.py
@@ -9,7 +9,11 @@ from sqlalchemy.orm import Session
 from src.models.wallet import Currency, Wallet, WalletType, create_wallet
 
 
-ASSET_TYPES = {WalletType.ASSET_RMB.value, WalletType.ASSET_USDT.value}
+ASSET_TYPES = {
+    WalletType.ASSET_RMB.value,
+    WalletType.ASSET_USDT.value,
+    WalletType.ASSET_USD.value,  # PR #110 P0.2: XBOX USD 销售收入资金池
+}
 DEFAULT_ASSET_WALLETS = (
     {
         "name": "RMB钱包",
@@ -31,6 +35,12 @@ DEFAULT_ASSET_WALLETS = (
         "wallet_type": WalletType.ASSET_USDT,
         "currency": Currency.USDT,
         "children": ("FREEMAN币安", "张总币安"),
+    },
+    {
+        "name": "USD钱包",
+        "wallet_type": WalletType.ASSET_USD,
+        "currency": Currency.USD,
+        "children": (),  # 空,CEO 自行新建子钱包(资金池)
     },
 )
 

--- a/src/services/xbox_order.py
+++ b/src/services/xbox_order.py
@@ -1,0 +1,173 @@
+"""XBOX 订单服务（FR-04 同步 + FR-05 补齐）。
+
+P0.2 阶段：
+- 支持手动建订单（CEO Q3A：让 CEO 立刻能试用整套流程）
+- 自动同步在 P2（FR-04 / IF-03）实现
+
+补齐流程：
+- 订单原始字段：order_no, amount_local, currency_local, exchange_rate, order_at
+- 待补齐：sale_date, product_name, operator_name, sale_price, sale_currency,
+         wallet_method_id, wallet_item_id
+- 全部补齐 → 调 xbox_sale.create_or_merge_sale_record 转销售记录
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.xbox import (
+    XboxAccount,
+    XboxOrder,
+    XboxOrderStatus,
+    XboxWalletItem,
+    XboxWalletMethod,
+)
+from src.services.xbox_sale import create_or_merge_sale_record
+from src.utils.time import china_now
+
+
+def create_order(
+    session: Session,
+    *,
+    account: XboxAccount,
+    order_no: str,
+    amount_local: Decimal,
+    currency_local: str,
+    order_at: datetime,
+    exchange_rate: Optional[Decimal] = None,
+    raw_data: Optional[dict] = None,
+) -> XboxOrder:
+    """新建一条同步订单（手动或来自 Microsoft 抓取）。
+
+    rmb_cost = amount_local × exchange_rate（exchange_rate 为空时取账号汇率）
+    """
+    if not order_no.strip():
+        raise ValueError("订单号不能为空")
+    existing = session.scalar(select(XboxOrder).where(XboxOrder.order_no == order_no))
+    if existing is not None:
+        raise ValueError(f"订单号 {order_no} 已存在")
+
+    used_rate = exchange_rate if exchange_rate is not None else account.exchange_rate
+    if used_rate is None:
+        # 没汇率就 0 成本（CEO 后续可补)
+        rmb_cost = Decimal("0")
+        used_rate_value = None
+    else:
+        rmb_cost = (Decimal(amount_local) * Decimal(used_rate)).quantize(Decimal("0.000001"))
+        used_rate_value = Decimal(used_rate)
+
+    order = XboxOrder(
+        account_id=account.id,
+        order_no=order_no.strip(),
+        amount_local=Decimal(amount_local),
+        currency_local=currency_local,
+        exchange_rate=used_rate_value,
+        rmb_cost=rmb_cost,
+        order_at=order_at,
+        raw_data=raw_data,
+        status=XboxOrderStatus.PENDING_COMPLETE.value,
+    )
+    session.add(order)
+    session.flush()
+    return order
+
+
+def update_order_completion(
+    session: Session,
+    order: XboxOrder,
+    *,
+    sale_date: Optional[date] = None,
+    product_name: Optional[str] = None,
+    operator_name: Optional[str] = None,
+    sale_price: Optional[Decimal] = None,
+    sale_currency: Optional[str] = None,
+    wallet_method_id: Optional[int] = None,
+    wallet_item_id: Optional[int] = None,
+    auto_convert: bool = True,
+) -> tuple[XboxOrder, Optional[int]]:
+    """更新订单的补齐字段。所有必填都到位时自动转销售记录。
+
+    返回 ``(order, sale_record_id_or_None)``。
+    """
+    if sale_date is not None:
+        order.sale_date = sale_date
+    if product_name is not None:
+        order.product_name = product_name
+    if operator_name is not None:
+        order.operator_name = operator_name
+    if sale_price is not None:
+        order.sale_price = Decimal(sale_price)
+    if sale_currency is not None:
+        order.sale_currency = sale_currency
+    if wallet_method_id is not None:
+        order.wallet_method_id = wallet_method_id
+    if wallet_item_id is not None:
+        order.wallet_item_id = wallet_item_id
+    order.last_updated_at = china_now()
+    session.flush()
+
+    sale_record_id: Optional[int] = None
+
+    # 检查是否所有补齐字段都到位 → 自动转销售
+    if auto_convert and _all_completion_fields_set(order):
+        item = session.get(XboxWalletItem, order.wallet_item_id)
+        if item is None:
+            raise ValueError(f"备注模板 {order.wallet_item_id} 不存在")
+        if not item.is_active:
+            raise ValueError(f"备注模板 {item.label} 已停用")
+        method = session.get(XboxWalletMethod, order.wallet_method_id)
+        if method is None:
+            raise ValueError(f"收款方式 {order.wallet_method_id} 不存在")
+
+        account = session.get(XboxAccount, order.account_id)
+        record = create_or_merge_sale_record(
+            session,
+            account=account,
+            sale_date=order.sale_date,
+            product_name=order.product_name,
+            operator_name=order.operator_name,
+            sale_price=order.sale_price,
+            sale_currency=order.sale_currency,
+            wallet_method_id=order.wallet_method_id,
+            wallet_item_id=order.wallet_item_id,
+            wallet_item_label=item.label,
+            wallet_pool_id=item.wallet_pool_id,
+            order=order,
+        )
+        sale_record_id = record.id
+
+    return order, sale_record_id
+
+
+def _all_completion_fields_set(order: XboxOrder) -> bool:
+    return (
+        order.sale_date is not None
+        and bool(order.product_name)
+        and bool(order.operator_name)
+        and order.sale_price is not None
+        and bool(order.sale_currency)
+        and order.wallet_method_id is not None
+        and order.wallet_item_id is not None
+    )
+
+
+def list_orders(
+    session: Session,
+    *,
+    account_id: Optional[int] = None,
+    status: Optional[str] = None,
+) -> list[XboxOrder]:
+    stmt = select(XboxOrder).order_by(XboxOrder.id.desc())
+    if account_id is not None:
+        stmt = stmt.where(XboxOrder.account_id == account_id)
+    if status is not None:
+        stmt = stmt.where(XboxOrder.status == status)
+    return list(session.scalars(stmt))
+
+
+def get_order_or_404(session: Session, order_id: int) -> Optional[XboxOrder]:
+    return session.get(XboxOrder, order_id)

--- a/src/services/xbox_sale.py
+++ b/src/services/xbox_sale.py
@@ -1,0 +1,288 @@
+"""XBOX 销售记录服务（FR-06 合单 + FR-07 资金池流入）。
+
+业务规则（CEO 2026-05-08 确认）：
+- 合单：同账号 + 同 wallet_item_id → 视为同一销售记录,售价相加
+- 销售记录创建即 credit ``sale_price`` 到 ``wallet_pool_id``（Q2A）
+- 改 sale_price → 资金池 diff 调整(Q2A)
+- 改 wallet_pool_id → 旧池 debit + 新池 credit(Q3A)
+- 不能撤销但可改字段（CEO 4B）
+- sale_currency 必须和 wallet_pool 钱包 currency 一致
+
+所有变更都通过 ``Wallet.balance`` 加减 + 写 ``WalletTransaction`` 流水。
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import (
+    TransactionDirection,
+    Wallet,
+    WalletTransaction,
+    credit,
+    debit,
+)
+from src.models.xbox import (
+    XboxAccount,
+    XboxOrder,
+    XboxOrderStatus,
+    XboxSaleRecord,
+    XboxWalletItem,
+)
+from src.utils.time import china_now
+
+
+# 币种 → 钱包应该的 currency
+CURRENCY_TO_WALLET_CURRENCY = {
+    "CNY": "CNY",
+    "USD": "USD",
+    "USDT": "USDT",
+    "TWD": "TWD",
+}
+
+
+def _validate_pool_currency(session: Session, wallet_pool_id: int, sale_currency: str) -> Wallet:
+    """校验资金池钱包存在且币种与 sale_currency 一致。返回钱包对象。"""
+    wallet = session.get(Wallet, wallet_pool_id)
+    if wallet is None:
+        raise ValueError(f"资金池钱包 {wallet_pool_id} 不存在")
+    expected = CURRENCY_TO_WALLET_CURRENCY.get(sale_currency)
+    if expected is None:
+        raise ValueError(f"不支持的销售币种: {sale_currency}")
+    actual = wallet.currency.value if hasattr(wallet.currency, "value") else wallet.currency
+    if actual != expected:
+        raise ValueError(
+            f"资金池钱包币种 {actual} 与销售币种 {sale_currency} 不一致"
+        )
+    return wallet
+
+
+def _find_existing_sale_record(
+    session: Session,
+    account_id: int,
+    wallet_item_id: int,
+) -> Optional[XboxSaleRecord]:
+    """合单查询：同账号 + 同 wallet_item_id 的现有销售记录。"""
+    return session.scalar(
+        select(XboxSaleRecord).where(
+            XboxSaleRecord.account_id == account_id,
+            XboxSaleRecord.wallet_item_id == wallet_item_id,
+        )
+    )
+
+
+def create_or_merge_sale_record(
+    session: Session,
+    *,
+    account: XboxAccount,
+    sale_date: date,
+    product_name: str,
+    operator_name: str,
+    sale_price: Decimal,
+    sale_currency: str,
+    wallet_method_id: int,
+    wallet_item_id: int,
+    wallet_item_label: str,
+    wallet_pool_id: int,
+    order: Optional[XboxOrder] = None,
+) -> XboxSaleRecord:
+    """创建销售记录或合并到现有的（FR-06）+ 资金池入账（FR-07）。
+
+    若同账号 + 同 wallet_item_id 已有销售记录 → 累加 sale_price + credit 差额。
+    否则新建销售记录 + credit 全额。
+
+    传入 ``order`` 时,会把订单的 sale_record_id 指向新/旧记录,
+    并把订单 status 改成 converted。
+    """
+    pool = _validate_pool_currency(session, wallet_pool_id, sale_currency)
+    sale_price = Decimal(sale_price)
+    if sale_price < 0:
+        raise ValueError("销售价格不能为负数")
+
+    existing = _find_existing_sale_record(session, account.id, wallet_item_id)
+
+    if existing is None:
+        # 新建销售记录
+        record = XboxSaleRecord(
+            account_id=account.id,
+            sale_date=sale_date,
+            product_name=product_name,
+            operator_name=operator_name,
+            sale_price=sale_price,
+            sale_currency=sale_currency,
+            wallet_method_id=wallet_method_id,
+            wallet_item_id=wallet_item_id,
+            wallet_item_label=wallet_item_label,
+            wallet_pool_id=wallet_pool_id,
+        )
+        session.add(record)
+        session.flush()
+
+        # credit 全额入账（除非 sale_price=0,叠加档）
+        if sale_price > 0:
+            tx = credit(
+                session,
+                wallet_pool_id,
+                sale_price,
+                remark=f"XBOX 销售 #{record.id} {product_name}",
+            )
+            record.bookkeeping_tx_id = tx.id
+
+    else:
+        # 合单：累加 sale_price + credit 差额
+        if existing.sale_currency != sale_currency:
+            raise ValueError(
+                f"合单失败：币种不一致(已有 {existing.sale_currency},新 {sale_currency})"
+            )
+        if existing.wallet_pool_id != wallet_pool_id:
+            raise ValueError(
+                f"合单失败：资金池不一致(已有 wallet_pool_id={existing.wallet_pool_id},"
+                f"新 {wallet_pool_id})"
+            )
+        old_price = Decimal(existing.sale_price)
+        new_total = old_price + sale_price
+        diff = sale_price  # 新增订单贡献的金额
+
+        existing.sale_price = new_total
+        existing.last_updated_at = china_now()
+        if existing.wallet_item_label != wallet_item_label:
+            existing.wallet_item_label = wallet_item_label
+
+        # 更新 product_name 为合单后追加（保留原来 + 新订单）
+        if product_name and product_name not in (existing.product_name or ""):
+            existing.product_name = f"{existing.product_name}; {product_name}"
+
+        # credit 差额到资金池
+        if diff > 0:
+            tx = credit(
+                session,
+                wallet_pool_id,
+                diff,
+                remark=f"XBOX 销售 #{existing.id} 合单追加 {product_name}",
+            )
+            # 注意：bookkeeping_tx_id 仅记最后一次（实际有多笔流水）
+            existing.bookkeeping_tx_id = tx.id
+
+        record = existing
+
+    # 关联订单
+    if order is not None:
+        order.sale_record_id = record.id
+        order.status = XboxOrderStatus.CONVERTED.value
+        order.last_updated_at = china_now()
+
+    session.flush()
+    return record
+
+
+def update_sale_record_fields(
+    session: Session,
+    record: XboxSaleRecord,
+    *,
+    sale_date: Optional[date] = None,
+    product_name: Optional[str] = None,
+    operator_name: Optional[str] = None,
+    sale_price: Optional[Decimal] = None,
+    sale_currency: Optional[str] = None,
+    wallet_method_id: Optional[int] = None,
+    wallet_item_id: Optional[int] = None,
+    wallet_item_label: Optional[str] = None,
+    wallet_pool_id: Optional[int] = None,
+) -> XboxSaleRecord:
+    """改销售记录字段。自动联动钱包余额（CEO Q2A + Q3A）。
+
+    - 改 sale_price: 资金池 diff 调整
+    - 改 wallet_pool_id（或 sale_currency 联动）：旧池 debit + 新池 credit
+    """
+    now = china_now()
+
+    new_currency = sale_currency if sale_currency is not None else record.sale_currency
+    new_pool_id = wallet_pool_id if wallet_pool_id is not None else record.wallet_pool_id
+    new_price = Decimal(sale_price) if sale_price is not None else Decimal(record.sale_price)
+    if new_price < 0:
+        raise ValueError("销售价格不能为负数")
+
+    pool_changed = new_pool_id != record.wallet_pool_id
+    currency_changed = new_currency != record.sale_currency
+    price_changed = new_price != Decimal(record.sale_price)
+
+    # 校验新池子币种
+    if pool_changed or currency_changed:
+        _validate_pool_currency(session, new_pool_id, new_currency)
+
+    # 1) 资金池变更（含 currency 变更）→ 旧池 debit 全额,新池 credit 全额
+    if pool_changed or currency_changed:
+        old_amount = Decimal(record.sale_price)
+        if old_amount > 0:
+            debit(
+                session,
+                record.wallet_pool_id,
+                old_amount,
+                remark=f"XBOX 销售 #{record.id} 切换资金池(撤旧池)",
+            )
+        if new_price > 0:
+            tx = credit(
+                session,
+                new_pool_id,
+                new_price,
+                remark=f"XBOX 销售 #{record.id} 切换资金池(入新池)",
+            )
+            record.bookkeeping_tx_id = tx.id
+        record.wallet_pool_id = new_pool_id
+        record.sale_currency = new_currency
+        record.sale_price = new_price
+    elif price_changed:
+        # 2) 仅价格变更 → diff 调整本池
+        diff = new_price - Decimal(record.sale_price)
+        if diff > 0:
+            tx = credit(
+                session,
+                record.wallet_pool_id,
+                diff,
+                remark=f"XBOX 销售 #{record.id} 售价调整 +{diff}",
+            )
+            record.bookkeeping_tx_id = tx.id
+        elif diff < 0:
+            debit(
+                session,
+                record.wallet_pool_id,
+                -diff,
+                remark=f"XBOX 销售 #{record.id} 售价调整 {diff}",
+            )
+        record.sale_price = new_price
+
+    # 3) 更新其他普通字段
+    if sale_date is not None:
+        record.sale_date = sale_date
+    if product_name is not None:
+        record.product_name = product_name
+    if operator_name is not None:
+        record.operator_name = operator_name
+    if wallet_method_id is not None:
+        record.wallet_method_id = wallet_method_id
+    if wallet_item_id is not None:
+        record.wallet_item_id = wallet_item_id
+    if wallet_item_label is not None:
+        record.wallet_item_label = wallet_item_label
+
+    record.last_updated_at = now
+    session.flush()
+    return record
+
+
+def list_sale_records(
+    session: Session,
+    *,
+    account_id: Optional[int] = None,
+    wallet_pool_id: Optional[int] = None,
+) -> list[XboxSaleRecord]:
+    stmt = select(XboxSaleRecord).order_by(XboxSaleRecord.id.desc())
+    if account_id is not None:
+        stmt = stmt.where(XboxSaleRecord.account_id == account_id)
+    if wallet_pool_id is not None:
+        stmt = stmt.where(XboxSaleRecord.wallet_pool_id == wallet_pool_id)
+    return list(session.scalars(stmt))

--- a/src/services/xbox_wallet_setting.py
+++ b/src/services/xbox_wallet_setting.py
@@ -1,0 +1,137 @@
+"""XBOX 钱包设置同步服务（FR-03）。
+
+财务系统通过 PUT /xbox/wallet-settings 推送 method/item 三层映射,
+XBOX 模块只消费,不在 XBOX 内单独维护资金池规则。
+
+数据结构：
+  收款方式 (method)
+    └─ 备注模板 (item) → 资金池 (wallet_pool_id, 即 wallets.id)
+
+同步语义：
+- 推送过来的 method/item 全量替换式同步:
+  - 已存在的(按 code) → 更新 label / wallet_pool_id / is_active
+  - 不在推送列表里的现有项 → is_active=False（保留历史关联）
+- 删除/停用的 item 在订单补齐页下拉框不可选,但历史销售记录的 walletPoolId 不被改写
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import Wallet
+from src.models.xbox import XboxWalletItem, XboxWalletMethod
+from src.utils.time import china_now
+
+
+def upsert_wallet_settings(session: Session, payload: list[dict]) -> dict:
+    """全量同步 method/item 树。
+
+    payload 格式：
+        [
+          {
+            "code": "agent",
+            "label": "代理",
+            "items": [
+              {"code": "001", "label": "代理 001", "walletPoolId": 12, "isActive": true},
+              ...
+            ]
+          },
+          ...
+        ]
+
+    返回简单计数 ``{methods_upserted, items_upserted, items_disabled}``。
+    """
+    incoming_method_codes = {m["code"] for m in payload}
+    incoming_item_codes_per_method: dict[str, set[str]] = {
+        m["code"]: {it["code"] for it in m.get("items", [])} for m in payload
+    }
+
+    methods_upserted = 0
+    items_upserted = 0
+    items_disabled = 0
+    now = china_now()
+
+    for method_data in payload:
+        method = session.scalar(
+            select(XboxWalletMethod).where(XboxWalletMethod.code == method_data["code"])
+        )
+        if method is None:
+            method = XboxWalletMethod(
+                code=method_data["code"],
+                label=method_data["label"],
+                is_active=method_data.get("isActive", True),
+            )
+            session.add(method)
+            session.flush()
+        else:
+            method.label = method_data["label"]
+            method.is_active = method_data.get("isActive", True)
+            method.last_updated_at = now
+        methods_upserted += 1
+
+        for item_data in method_data.get("items", []):
+            wallet_pool_id = item_data["walletPoolId"]
+            wallet = session.get(Wallet, wallet_pool_id)
+            if wallet is None:
+                raise ValueError(f"walletPoolId {wallet_pool_id} 对应的钱包不存在")
+
+            item = session.scalar(
+                select(XboxWalletItem).where(
+                    XboxWalletItem.method_id == method.id,
+                    XboxWalletItem.code == item_data["code"],
+                )
+            )
+            if item is None:
+                item = XboxWalletItem(
+                    method_id=method.id,
+                    code=item_data["code"],
+                    label=item_data["label"],
+                    wallet_pool_id=wallet_pool_id,
+                    is_active=item_data.get("isActive", True),
+                )
+                session.add(item)
+            else:
+                item.label = item_data["label"]
+                item.wallet_pool_id = wallet_pool_id
+                item.is_active = item_data.get("isActive", True)
+                item.last_updated_at = now
+            items_upserted += 1
+
+    # 不在推送列表的现有 method 全部 is_active=False（保留历史关联）
+    existing_methods = list(session.scalars(select(XboxWalletMethod)))
+    for m in existing_methods:
+        if m.code not in incoming_method_codes:
+            m.is_active = False
+            m.last_updated_at = now
+        else:
+            # 该 method 内不在推送列表的 item 也 disable
+            existing_items = list(
+                session.scalars(select(XboxWalletItem).where(XboxWalletItem.method_id == m.id))
+            )
+            keep = incoming_item_codes_per_method.get(m.code, set())
+            for it in existing_items:
+                if it.code not in keep:
+                    if it.is_active:
+                        items_disabled += 1
+                    it.is_active = False
+                    it.last_updated_at = now
+
+    session.flush()
+    return {
+        "methods_upserted": methods_upserted,
+        "items_upserted": items_upserted,
+        "items_disabled": items_disabled,
+    }
+
+
+def list_wallet_methods(session: Session, only_active: bool = True) -> list[XboxWalletMethod]:
+    stmt = select(XboxWalletMethod).order_by(XboxWalletMethod.id)
+    if only_active:
+        stmt = stmt.where(XboxWalletMethod.is_active.is_(True))
+    return list(session.scalars(stmt))
+
+
+def get_item_or_404(session: Session, item_id: int) -> Optional[XboxWalletItem]:
+    return session.get(XboxWalletItem, item_id)

--- a/tests/test_assets_api.py
+++ b/tests/test_assets_api.py
@@ -39,8 +39,8 @@ def test_default_asset_wallets_are_listed(client):
     assert response.status_code == 200, response.text
     wallets = response.json()
     names = {wallet["name"] for wallet in wallets}
-    assert {"RMB钱包", "USDT钱包"}.issubset(names)
-    assert {wallet["currency"] for wallet in wallets} == {"CNY", "USDT"}
+    assert {"RMB钱包", "USDT钱包", "USD钱包"}.issubset(names)
+    assert {wallet["currency"] for wallet in wallets} == {"CNY", "USDT", "USD"}
     assert all(wallet["parent_id"] is None for wallet in wallets)
     assert all(wallet["is_group"] for wallet in wallets)
 

--- a/tests/test_xbox_p0_2_api.py
+++ b/tests/test_xbox_p0_2_api.py
@@ -1,0 +1,423 @@
+"""XBOX P0.2 (issue #110) 测试：订单 / 销售记录 / 钱包设置 / 资金池联动。
+
+CEO 2026-05-08 确认的方案：
+- Q1A: 新建 ASSET_USD 钱包大类
+- Q2A: 改 sale_price 自动 diff 调整钱包余额
+- Q3A: 改 wallet_pool_id 旧池 debit + 新池 credit
+- 销售记录不能撤销 + 合单按"账号+wallet_item_id"
+- 多币种校验：sale_currency ↔ wallet_pool 钱包币种一致
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from src import database
+from src.main import app
+from src.models.wallet import Wallet, WalletType, create_wallet, Currency
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'xbox_p02.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def _get_pool_wallet_id(name: str) -> int:
+    """找一个具体子钱包当资金池 (按 name 唯一定位)。"""
+    db = database.SessionLocal()
+    try:
+        wallet = db.scalar(select(Wallet).where(Wallet.name == name))
+        if wallet is None:
+            raise AssertionError(f"未找到资金池钱包 {name}")
+        return wallet.id
+    finally:
+        db.close()
+
+
+def _create_account(client, account_no="P02-001"):
+    r = client.post(
+        "/xbox/accounts",
+        json={"name": account_no, "country": "US", "accountNo": account_no, "exchangeRate": "7.20"},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _push_wallet_settings(client, items: list[dict]):
+    """推送钱包设置（method "agent" + 自定义 items）。"""
+    r = client.put(
+        "/xbox/wallet-settings",
+        json=[{"code": "agent", "label": "代理", "items": items}],
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _wallet_balance(wallet_id: int) -> Decimal:
+    db = database.SessionLocal()
+    try:
+        w = db.get(Wallet, wallet_id)
+        return Decimal(w.balance)
+    finally:
+        db.close()
+
+
+# ----------------------------------------------------------
+# 钱包设置同步 (FR-03 / IF-02)
+# ----------------------------------------------------------
+
+def test_wallet_settings_sync_creates_methods_and_items(client):
+    pool_id = _get_pool_wallet_id("丙火网络支付宝")
+    result = _push_wallet_settings(
+        client,
+        [{"code": "001", "label": "代理 001", "walletPoolId": pool_id}],
+    )
+    assert result["methods_upserted"] == 1
+    assert result["items_upserted"] == 1
+
+    r = client.get("/xbox/wallet-settings")
+    assert r.status_code == 200
+    methods = r.json()
+    assert len(methods) == 1
+    assert methods[0]["code"] == "agent"
+    assert methods[0]["items"][0]["walletPoolId"] == pool_id
+
+
+def test_wallet_settings_invalid_pool_returns_400(client):
+    r = client.put(
+        "/xbox/wallet-settings",
+        json=[
+            {"code": "agent", "label": "代理", "items": [
+                {"code": "001", "label": "001", "walletPoolId": 99999}
+            ]}
+        ],
+    )
+    assert r.status_code == 400
+    assert "不存在" in r.json()["detail"]
+
+
+def test_wallet_settings_full_sync_disables_dropped_items(client):
+    pool_id = _get_pool_wallet_id("丙火网络支付宝")
+    # 第一次推 2 个 item
+    _push_wallet_settings(
+        client,
+        [
+            {"code": "001", "label": "代理 001", "walletPoolId": pool_id},
+            {"code": "002", "label": "代理 002", "walletPoolId": pool_id},
+        ],
+    )
+    # 第二次只推 001 → 002 应该 disable
+    r2 = _push_wallet_settings(
+        client,
+        [{"code": "001", "label": "代理 001", "walletPoolId": pool_id}],
+    )
+    assert r2["items_disabled"] == 1
+
+    r = client.get("/xbox/wallet-settings", params={"onlyActive": "false"})
+    items = r.json()[0]["items"]
+    by_code = {it["code"]: it for it in items}
+    assert by_code["001"]["isActive"] is True
+    assert by_code["002"]["isActive"] is False
+
+
+# ----------------------------------------------------------
+# 订单 (FR-04 + FR-05)
+# ----------------------------------------------------------
+
+def test_create_order_calculates_rmb_cost(client):
+    account = _create_account(client)
+    r = client.post(
+        "/xbox/orders",
+        json={
+            "accountId": account["id"],
+            "orderNo": "MS-001",
+            "amountLocal": "100.00",
+            "currencyLocal": "USD",
+            "orderAt": "2026-05-08T10:00:00",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    # rmb_cost = 100 * 7.20 = 720
+    assert Decimal(body["rmbCost"]) == Decimal("720.000000")
+    assert Decimal(body["exchangeRate"]) == Decimal("7.20")
+    assert body["status"] == "pending_complete"
+
+
+def test_create_order_duplicate_no_returns_400(client):
+    account = _create_account(client)
+    body = {
+        "accountId": account["id"],
+        "orderNo": "DUP-1",
+        "amountLocal": "10",
+        "currencyLocal": "USD",
+        "orderAt": "2026-05-08T10:00:00",
+    }
+    client.post("/xbox/orders", json=body)
+    r = client.post("/xbox/orders", json=body)
+    assert r.status_code == 400
+    assert "已存在" in r.json()["detail"]
+
+
+def test_complete_order_auto_converts_to_sale(client):
+    """补齐订单全部字段 → 自动转销售记录 + credit 资金池。"""
+    pool_id = _get_pool_wallet_id("丙火网络支付宝")
+    _push_wallet_settings(
+        client,
+        [{"code": "001", "label": "代理 001", "walletPoolId": pool_id}],
+    )
+    method_id = client.get("/xbox/wallet-settings").json()[0]["id"]
+    item_id = client.get("/xbox/wallet-settings").json()[0]["items"][0]["id"]
+
+    account = _create_account(client)
+    order = client.post(
+        "/xbox/orders",
+        json={
+            "accountId": account["id"],
+            "orderNo": "MS-100",
+            "amountLocal": "100",
+            "currencyLocal": "USD",
+            "orderAt": "2026-05-08T10:00:00",
+        },
+    ).json()
+
+    # 补齐字段（人民币售价 ¥800 进丙火支付宝资金池）
+    assert _wallet_balance(pool_id) == Decimal("0")
+    r = client.patch(
+        f"/xbox/orders/{order['id']}",
+        json={
+            "saleDate": "2026-05-08",
+            "productName": "Game A",
+            "operatorName": "运营 A",
+            "salePrice": "800.00",
+            "saleCurrency": "CNY",
+            "walletMethodId": method_id,
+            "walletItemId": item_id,
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "converted"
+    assert r.json()["saleRecordId"] is not None
+
+    # 资金池余额 +800
+    assert _wallet_balance(pool_id) == Decimal("800.000000")
+
+
+def test_sale_currency_pool_currency_mismatch_returns_400(client):
+    """销售币种 USD 但资金池是 RMB → 拒绝。"""
+    pool_id = _get_pool_wallet_id("丙火网络支付宝")  # CNY
+    _push_wallet_settings(
+        client,
+        [{"code": "001", "label": "代理 001", "walletPoolId": pool_id}],
+    )
+    method_id = client.get("/xbox/wallet-settings").json()[0]["id"]
+    item_id = client.get("/xbox/wallet-settings").json()[0]["items"][0]["id"]
+
+    account = _create_account(client)
+    order = client.post(
+        "/xbox/orders",
+        json={"accountId": account["id"], "orderNo": "X-1", "amountLocal": "10",
+              "currencyLocal": "USD", "orderAt": "2026-05-08T10:00:00"},
+    ).json()
+    r = client.patch(
+        f"/xbox/orders/{order['id']}",
+        json={
+            "saleDate": "2026-05-08", "productName": "X", "operatorName": "X",
+            "salePrice": "100", "saleCurrency": "USD",  # USD 但池子是 CNY
+            "walletMethodId": method_id, "walletItemId": item_id,
+        },
+    )
+    assert r.status_code == 400
+    assert "不一致" in r.json()["detail"]
+
+
+# ----------------------------------------------------------
+# USD 销售流入 ASSET_USD（CEO Q1A）
+# ----------------------------------------------------------
+
+def test_usd_sale_flows_into_asset_usd_wallet(client):
+    """USD 销售 → 自动新建 ASSET_USD 钱包大类下的子钱包应能当资金池。"""
+    # 在 USD钱包 大类下建一个子钱包当资金池
+    db = database.SessionLocal()
+    try:
+        usd_root = db.scalar(
+            select(Wallet).where(Wallet.type == WalletType.ASSET_USD.value, Wallet.parent_id.is_(None))
+        )
+        assert usd_root is not None
+        from src.services.assets import ensure_sub_wallet
+        usd_pool = ensure_sub_wallet(db, usd_root, "代理USD池", is_group=False)
+        usd_pool_id = usd_pool.id
+        db.commit()
+    finally:
+        db.close()
+
+    _push_wallet_settings(
+        client,
+        [{"code": "USD-001", "label": "代理 USD 001", "walletPoolId": usd_pool_id}],
+    )
+    method_id = client.get("/xbox/wallet-settings").json()[0]["id"]
+    item_id = client.get("/xbox/wallet-settings").json()[0]["items"][0]["id"]
+
+    account = _create_account(client)
+    order = client.post(
+        "/xbox/orders",
+        json={"accountId": account["id"], "orderNo": "USD-1", "amountLocal": "100",
+              "currencyLocal": "USD", "orderAt": "2026-05-08T10:00:00"},
+    ).json()
+    r = client.patch(
+        f"/xbox/orders/{order['id']}",
+        json={
+            "saleDate": "2026-05-08", "productName": "P1", "operatorName": "Op",
+            "salePrice": "120", "saleCurrency": "USD",  # USD 进 USD 池
+            "walletMethodId": method_id, "walletItemId": item_id,
+        },
+    )
+    assert r.status_code == 200
+    assert _wallet_balance(usd_pool_id) == Decimal("120.000000")
+
+
+# ----------------------------------------------------------
+# 合单 (FR-06)
+# ----------------------------------------------------------
+
+def test_merge_orders_same_account_same_item_increments_sale_price(client):
+    """同账号 + 同 wallet_item_id → 合单累加售价。"""
+    pool_id = _get_pool_wallet_id("丙火网络支付宝")
+    _push_wallet_settings(
+        client,
+        [{"code": "001", "label": "代理 001", "walletPoolId": pool_id}],
+    )
+    method_id = client.get("/xbox/wallet-settings").json()[0]["id"]
+    item_id = client.get("/xbox/wallet-settings").json()[0]["items"][0]["id"]
+
+    account = _create_account(client)
+
+    def _create_and_complete(order_no: str, sale_price: str):
+        order = client.post("/xbox/orders", json={
+            "accountId": account["id"], "orderNo": order_no, "amountLocal": "10",
+            "currencyLocal": "USD", "orderAt": "2026-05-08T10:00:00",
+        }).json()
+        return client.patch(f"/xbox/orders/{order['id']}", json={
+            "saleDate": "2026-05-08", "productName": f"P-{order_no}",
+            "operatorName": "Op", "salePrice": sale_price, "saleCurrency": "CNY",
+            "walletMethodId": method_id, "walletItemId": item_id,
+        }).json()
+
+    r1 = _create_and_complete("MERGE-1", "1330")
+    r2 = _create_and_complete("MERGE-2", "0")  # 叠加档（售价 0）
+    r3 = _create_and_complete("MERGE-3", "200")
+
+    # 都指向同一条销售记录
+    assert r1["saleRecordId"] == r2["saleRecordId"] == r3["saleRecordId"]
+
+    # 销售记录售价 = 1330 + 0 + 200 = 1530
+    record_id = r1["saleRecordId"]
+    records = client.get("/xbox/sale-records").json()
+    record = next(r for r in records if r["id"] == record_id)
+    assert Decimal(record["salePrice"]) == Decimal("1530.000000")
+
+    # 资金池余额也是 1530
+    assert _wallet_balance(pool_id) == Decimal("1530.000000")
+
+    # 销售记录关联 3 个订单
+    assert len(record["orderIds"]) == 3
+
+
+# ----------------------------------------------------------
+# 改销售记录字段（CEO Q2A 改售价 + Q3A 改资金池）
+# ----------------------------------------------------------
+
+def _setup_basic_sale(client):
+    """通用 helper:建账号 + 设钱包 + 转一笔 ¥800 销售记录,返回相关 id。"""
+    pool_a_id = _get_pool_wallet_id("丙火网络支付宝")
+    pool_b_id = _get_pool_wallet_id("TOM支付宝")
+    _push_wallet_settings(
+        client,
+        [
+            {"code": "001", "label": "代理 001", "walletPoolId": pool_a_id},
+            {"code": "002", "label": "代理 002", "walletPoolId": pool_b_id},
+        ],
+    )
+    methods = client.get("/xbox/wallet-settings").json()
+    method_id = methods[0]["id"]
+    items = methods[0]["items"]
+    item_a = next(it for it in items if it["code"] == "001")
+    item_b = next(it for it in items if it["code"] == "002")
+
+    account = _create_account(client)
+    order = client.post("/xbox/orders", json={
+        "accountId": account["id"], "orderNo": "EDIT-1", "amountLocal": "100",
+        "currencyLocal": "USD", "orderAt": "2026-05-08T10:00:00",
+    }).json()
+    completed = client.patch(f"/xbox/orders/{order['id']}", json={
+        "saleDate": "2026-05-08", "productName": "P1", "operatorName": "Op",
+        "salePrice": "800", "saleCurrency": "CNY",
+        "walletMethodId": method_id, "walletItemId": item_a["id"],
+    }).json()
+    return {
+        "account_id": account["id"],
+        "method_id": method_id,
+        "item_a_id": item_a["id"],
+        "item_b_id": item_b["id"],
+        "pool_a_id": pool_a_id,
+        "pool_b_id": pool_b_id,
+        "sale_record_id": completed["saleRecordId"],
+    }
+
+
+def test_update_sale_price_diff_adjusts_pool(client):
+    """改 sale_price 800 → 1000,资金池余额自动 +200。"""
+    ctx = _setup_basic_sale(client)
+    assert _wallet_balance(ctx["pool_a_id"]) == Decimal("800.000000")
+
+    r = client.patch(
+        f"/xbox/sale-records/{ctx['sale_record_id']}",
+        json={"salePrice": "1000"},
+    )
+    assert r.status_code == 200, r.text
+    assert Decimal(r.json()["salePrice"]) == Decimal("1000.000000")
+    assert _wallet_balance(ctx["pool_a_id"]) == Decimal("1000.000000")
+
+
+def test_update_sale_price_lower_debits_pool(client):
+    """改 sale_price 800 → 500,资金池 -300。"""
+    ctx = _setup_basic_sale(client)
+    r = client.patch(
+        f"/xbox/sale-records/{ctx['sale_record_id']}",
+        json={"salePrice": "500"},
+    )
+    assert r.status_code == 200
+    assert _wallet_balance(ctx["pool_a_id"]) == Decimal("500.000000")
+
+
+def test_change_wallet_pool_debits_old_credits_new(client):
+    """改 wallet_pool_id 旧池 debit 全额 + 新池 credit 全额。"""
+    ctx = _setup_basic_sale(client)
+    assert _wallet_balance(ctx["pool_a_id"]) == Decimal("800.000000")
+    assert _wallet_balance(ctx["pool_b_id"]) == Decimal("0")
+
+    r = client.patch(
+        f"/xbox/sale-records/{ctx['sale_record_id']}",
+        json={
+            "walletItemId": ctx["item_b_id"],
+            "walletItemLabel": "代理 002",
+            "walletPoolId": ctx["pool_b_id"],
+        },
+    )
+    assert r.status_code == 200, r.text
+
+    assert _wallet_balance(ctx["pool_a_id"]) == Decimal("0.000000")
+    assert _wallet_balance(ctx["pool_b_id"]) == Decimal("800.000000")


### PR DESCRIPTION
Closes #110

## CEO 2026-05-08 确认方案

| 选择 | 含义 |
|---|---|
| Q1A | 新建 ASSET_USD 钱包大类 |
| Q2A | 改 sale_price 自动 diff 调整资金池 |
| Q3A | 改 walletPoolId 旧池 debit + 新池 credit |
| 4B | 销售记录不能撤销但可改字段 |
| 多币种 | 售价支持 RMB/USD/USDT/TWD |
| 成本 | RMB 成本 = 本币金额 × 账号汇率 |

## 新增

**钱包大类：** ASSET_USD,启动自动建顶级 USD钱包(空,等 CEO 加子钱包)

**6 张新表：**
- xbox_orders 同步订单(原始字段 + 补齐字段 + sale_record_id)
- xbox_sale_records 销售记录(售价 + 币种 + walletPoolId + bookkeeping_tx_id)
- xbox_balance_snapshots 余额快照(P2 用)
- xbox_sync_batches 同步批次(P2 用)
- xbox_wallet_methods 收款方式(财务系统同步)
- xbox_wallet_items 备注模板 + walletPoolId 映射

**8 个新端点：**
- POST/GET/PATCH /xbox/orders 手动建订单 + 补齐 + 自动转销售
- GET/PATCH /xbox/sale-records 销售记录(改字段联动钱包)
- PUT/GET /xbox/wallet-settings 钱包设置同步 + 查询

## 关键业务逻辑

**自动转销售触发条件：** 订单的 7 个补齐字段全到位 → 调 service 转销售。
**合单：** 同账号 + 同 wallet_item_id → 累加 sale_price。
**资金池联动：**
- 销售创建 → credit sale_price 进 walletPoolId
- 改 sale_price → diff 调整(800→1000 进 +200)
- 改 walletPoolId → 旧池 debit 全额 + 新池 credit 全额
- 校验：sale_currency 必须和 walletPoolId 钱包 currency 一致

## 测试 176/176 通过

12 个新增覆盖：
1. 钱包设置同步 / 失效 walletPoolId 400 / 全量同步禁用 dropped item
2. 订单创建 + RMB 成本算 / 重复 order_no 400
3. 补齐字段自动转销售 + 资金池入账
4. 币种池子不一致 400
5. USD 销售进 ASSET_USD 钱包
6. 合单累加(¥1330 + ¥0 + ¥200 = ¥1530,资金池余额 = ¥1530)
7. 改售价 ¥800→¥1000 池子 +¥200
8. 改售价 ¥800→¥500 池子 -¥300
9. 改 walletPool 旧池清零 + 新池入账

## 不在范围内（后续）
- P0.2 前端 UI(下个 PR)
- Microsoft 同步(P2)
- 加卡系统接口(P2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)