### PR TITLE
feat(xbox): 资金池可选所有钱包大类 + 分组下拉框

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -29,13 +29,13 @@ import {
   consumeXbox,
   createXboxAccount,
   createXboxOrder,
-  getAssetWallets,
   getXboxAccountAuditLogs,
   getXboxAccounts,
   getXboxOrders,
   getXboxSaleRecords,
   getXboxSummary,
   getXboxTransactions,
+  getXboxWalletPoolOptions,
   getXboxWalletSettings,
   patchXboxOrder,
   patchXboxSaleRecord,
@@ -47,12 +47,12 @@ import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import type {
   Currency,
-  WalletBalance,
   XboxAccount,
   XboxAccountAuditLog,
   XboxAccountStatus,
   XboxCountry,
   XboxOrder,
+  XboxPoolOptionGroup,
   XboxSaleCurrency,
   XboxSaleRecord,
   XboxWalletMethod
@@ -1647,27 +1647,22 @@ function SaleRecordsTab() {
 // PR P0.2 - 钱包设置 Tab
 // ===================================================================
 
-function findWalletByIdRecursive(wallets: WalletBalance[], id: string): WalletBalance | null {
-  for (const w of wallets) {
-    if (w.id === id) return w;
-    if (w.children && w.children.length > 0) {
-      const found = findWalletByIdRecursive(w.children, id);
-      if (found) return found;
+// 把所有分组里的钱包扁平索引,方便按 id 找
+function buildPoolWalletIndex(
+  groups: XboxPoolOptionGroup[]
+): Map<string, { name: string; currency: string; fullPath: string; groupLabel: string }> {
+  const idx = new Map<string, { name: string; currency: string; fullPath: string; groupLabel: string }>();
+  for (const g of groups) {
+    for (const w of g.wallets) {
+      idx.set(w.id, {
+        name: w.name,
+        currency: w.currency,
+        fullPath: w.fullPath,
+        groupLabel: g.groupLabel
+      });
     }
   }
-  return null;
-}
-
-function flattenLeafWallets(wallets: WalletBalance[]): WalletBalance[] {
-  const out: WalletBalance[] = [];
-  const walk = (nodes: WalletBalance[]) => {
-    for (const n of nodes) {
-      if (!n.isGroup) out.push(n);
-      if (n.children && n.children.length > 0) walk(n.children);
-    }
-  };
-  walk(wallets);
-  return out;
+  return idx;
 }
 
 type DraftItem = { id?: string; code: string; label: string; walletPoolId: string; isActive: boolean };
@@ -1675,11 +1670,11 @@ type DraftMethod = { id?: string; code: string; label: string; isActive: boolean
 
 function WalletSettingsEditModal({
   initial,
-  walletPoolOptions,
+  poolGroups,
   onClose
 }: {
   initial: XboxWalletMethod[];
-  walletPoolOptions: WalletBalance[];
+  poolGroups: XboxPoolOptionGroup[];
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
@@ -1805,7 +1800,8 @@ function WalletSettingsEditModal({
                 <div className="ml-4 space-y-1">
                   <div className="text-xs text-muted-foreground">备注模板</div>
                   {m.items.map((it, iIdx) => {
-                    const pool = walletPoolOptions.find((w) => w.id === it.walletPoolId);
+                    const idx = buildPoolWalletIndex(poolGroups);
+                    const pool = idx.get(it.walletPoolId);
                     return (
                       <div key={iIdx} className="grid grid-cols-12 gap-1 items-center">
                         <input
@@ -1826,10 +1822,14 @@ function WalletSettingsEditModal({
                           onChange={(e) => updateItem(mIdx, iIdx, "walletPoolId", e.target.value)}
                         >
                           <option value="">-- 资金池 --</option>
-                          {walletPoolOptions.map((w) => (
-                            <option key={w.id} value={w.id}>
-                              {w.name} ({w.currency})
-                            </option>
+                          {poolGroups.map((g) => (
+                            <optgroup key={g.groupCode} label={`── ${g.groupLabel} ──`}>
+                              {g.wallets.map((w) => (
+                                <option key={w.id} value={w.id}>
+                                  {w.fullPath} ({w.currency})
+                                </option>
+                              ))}
+                            </optgroup>
                           ))}
                         </select>
                         <span className="col-span-1 text-xs text-muted-foreground truncate">
@@ -1880,18 +1880,18 @@ function WalletSettingsTab() {
     queryKey: ["xbox-wallet-settings"],
     queryFn: () => getXboxWalletSettings(false)
   });
-  const { data: assets = [] } = useQuery({
-    queryKey: ["asset-wallets"],
-    queryFn: () => getAssetWallets()
+  const { data: poolGroups = [] } = useQuery({
+    queryKey: ["xbox-wallet-pool-options"],
+    queryFn: () => getXboxWalletPoolOptions()
   });
 
-  const walletPoolOptions = flattenLeafWallets(assets);
+  const poolIndex = buildPoolWalletIndex(poolGroups);
 
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <div className="text-xs text-muted-foreground">
-          财务系统钱包设置:收款方式 → 备注模板 → 资金池(具体钱包 ID)
+          财务系统钱包设置:收款方式 → 备注模板 → 资金池(可挂任何钱包：资产/淘宝/台湾/...)
         </div>
         <div className="flex gap-2">
           <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
@@ -1911,6 +1911,7 @@ function WalletSettingsTab() {
               <TableRow>
                 <TableHead>收款方式</TableHead>
                 <TableHead>备注模板</TableHead>
+                <TableHead>资金池所属</TableHead>
                 <TableHead>资金池</TableHead>
                 <TableHead>状态</TableHead>
               </TableRow>
@@ -1921,13 +1922,13 @@ function WalletSettingsTab() {
                   ? [
                       <TableRow key={m.id}>
                         <TableCell className="font-medium">{m.label}</TableCell>
-                        <TableCell colSpan={3} className="text-xs text-muted-foreground">
+                        <TableCell colSpan={4} className="text-xs text-muted-foreground">
                           (无备注模板)
                         </TableCell>
                       </TableRow>
                     ]
                   : m.items.map((it, idx) => {
-                      const pool = findWalletByIdRecursive(assets, it.walletPoolId);
+                      const pool = poolIndex.get(it.walletPoolId);
                       return (
                         <TableRow key={`${m.id}-${it.id}`}>
                           <TableCell className={cn("font-medium", idx > 0 && "text-transparent")}>
@@ -1939,8 +1940,17 @@ function WalletSettingsTab() {
                               ({it.code})
                             </span>
                           </TableCell>
+                          <TableCell>
+                            {pool ? (
+                              <Badge tone="transfer">{pool.groupLabel}</Badge>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">未知</span>
+                            )}
+                          </TableCell>
                           <TableCell className="text-xs">
-                            {pool ? `${pool.name} (${pool.currency})` : `wallet#${it.walletPoolId}`}
+                            {pool
+                              ? `${pool.fullPath} (${pool.currency})`
+                              : `wallet#${it.walletPoolId}`}
                           </TableCell>
                           <TableCell>
                             <Badge tone={it.isActive ? "success" : "neutral"}>
@@ -1953,7 +1963,7 @@ function WalletSettingsTab() {
               )}
               {methods.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
+                  <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
                     还没设钱包设置。点右上角「编辑」开始配置。
                   </TableCell>
                 </TableRow>
@@ -1966,7 +1976,7 @@ function WalletSettingsTab() {
       {showEdit ? (
         <WalletSettingsEditModal
           initial={methods}
-          walletPoolOptions={walletPoolOptions}
+          poolGroups={poolGroups}
           onClose={() => setShowEdit(false)}
         />
       ) : null}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -42,6 +42,7 @@ import type {
   XboxCountry,
   XboxOrder,
   XboxOrderStatus,
+  XboxPoolOptionGroup,
   XboxSaleCurrency,
   XboxSaleRecord,
   XboxSummary,
@@ -875,6 +876,40 @@ export async function getXboxWalletSettings(onlyActive = true): Promise<XboxWall
       `/api/xbox/wallet-settings?onlyActive=${onlyActive}`
     );
     return data.map(_normalizeWalletMethod);
+  } catch {
+    return [];
+  }
+}
+
+type XboxPoolOptionGroupResponse = {
+  groupCode?: string;
+  group_code?: string;
+  groupLabel?: string;
+  group_label?: string;
+  wallets: {
+    id: string | number;
+    name: string;
+    currency: string;
+    fullPath?: string;
+    full_path?: string;
+  }[];
+};
+
+export async function getXboxWalletPoolOptions(): Promise<XboxPoolOptionGroup[]> {
+  try {
+    const data = await fetchJson<XboxPoolOptionGroupResponse[]>(
+      "/api/xbox/wallet-pool-options"
+    );
+    return data.map((g) => ({
+      groupCode: g.groupCode ?? g.group_code ?? "",
+      groupLabel: g.groupLabel ?? g.group_label ?? "",
+      wallets: (g.wallets ?? []).map((w) => ({
+        id: String(w.id),
+        name: w.name,
+        currency: w.currency,
+        fullPath: w.fullPath ?? w.full_path ?? w.name
+      }))
+    }));
   } catch {
     return [];
   }

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -151,6 +151,20 @@ export type XboxWalletMethod = {
   items: XboxWalletItem[];
 };
 
+// 资金池下拉选项（按钱包大类分组）—— GET /xbox/wallet-pool-options
+export type XboxPoolOptionWallet = {
+  id: string;
+  name: string;
+  currency: string;
+  fullPath: string; // "RMB钱包 / 支付宝钱包 / 丙火网络支付宝"
+};
+
+export type XboxPoolOptionGroup = {
+  groupCode: string; // ASSET_RMB / TAOBAO / TAIWAN ...
+  groupLabel: string; // 资产 RMB / 淘宝 / 台湾
+  wallets: XboxPoolOptionWallet[];
+};
+
 export type XboxTransaction = {
   id: string;
   accountId: string;

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -823,3 +823,97 @@ def list_wallet_settings_endpoint(
 ) -> list[XboxWalletMethodOut]:
     methods = list_wallet_methods(db, only_active=only_active)
     return [serialize_method(m) for m in methods]
+
+
+# ----- 资金池可选钱包列表（CEO 2026-05-08 Q1A：全部钱包大类都能当资金池）-----
+
+
+class XboxPoolOptionWallet(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    name: str
+    currency: str
+    full_path: str  # 含父级路径,如 "支付宝钱包 / 丙火网络支付宝"
+
+
+class XboxPoolOptionGroup(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    group_code: str  # ASSET_RMB / ASSET_USDT / ASSET_USD / TAOBAO / TAIWAN / VENDOR / XBOX
+    group_label: str
+    wallets: list[XboxPoolOptionWallet]
+
+
+# 钱包大类显示标签 + 顺序
+_GROUP_META: list[tuple[str, str]] = [
+    ("ASSET_RMB", "资产 RMB"),
+    ("ASSET_USDT", "资产 USDT"),
+    ("ASSET_USD", "资产 USD"),
+    ("TAOBAO", "淘宝"),
+    ("TAIWAN", "台湾"),
+    ("VENDOR", "供应商"),
+    ("XBOX", "XBOX"),
+]
+
+
+@router.get(
+    "/wallet-pool-options",
+    response_model=list[XboxPoolOptionGroup],
+    response_model_by_alias=True,
+)
+def list_wallet_pool_options(db: Session = Depends(get_db)) -> list[XboxPoolOptionGroup]:
+    """返回所有可作"资金池"的钱包,按大类分组（CEO Q1A：全部钱包大类都行）。
+
+    校验规则: 销售记录创建/修改时,sale_currency 必须等于钱包 currency,
+    所以前端可在所有大类下挑,后端会按币种校验拒绝不匹配的组合。
+    """
+    from src.models.wallet import Wallet  # 局部 import 避免循环依赖问题
+
+    # 取所有非 group + 未删除的叶子钱包
+    wallets = list(
+        db.scalars(
+            select(Wallet)
+            .where(Wallet.is_group.is_(False), Wallet.deleted_at.is_(None))
+            .order_by(Wallet.id)
+        )
+    )
+
+    # 计算每个钱包的"完整路径"(从根到自己)
+    by_id = {w.id: w for w in db.scalars(select(Wallet))}
+
+    def full_path(w: Wallet) -> str:
+        parts: list[str] = []
+        cur: Wallet | None = w
+        while cur is not None:
+            parts.append(cur.name)
+            cur = by_id.get(cur.parent_id) if cur.parent_id is not None else None
+        return " / ".join(reversed(parts))
+
+    # 按 type 分组
+    by_type: dict[str, list[Wallet]] = {}
+    for w in wallets:
+        type_value = w.type.value if hasattr(w.type, "value") else str(w.type)
+        by_type.setdefault(type_value, []).append(w)
+
+    out: list[XboxPoolOptionGroup] = []
+    for type_code, label in _GROUP_META:
+        items = by_type.get(type_code, [])
+        if not items:
+            continue
+        out.append(
+            XboxPoolOptionGroup(
+                group_code=type_code,
+                group_label=label,
+                wallets=[
+                    XboxPoolOptionWallet(
+                        id=w.id,
+                        name=w.name,
+                        currency=w.currency.value if hasattr(w.currency, "value") else str(w.currency),
+                        full_path=full_path(w),
+                    )
+                    for w in items
+                ],
+            )
+        )
+    return out


### PR DESCRIPTION
CEO Q1A+Q2A+Q3+Q4A 全开。资金池下拉支持淘宝/台湾/资产任何钱包,按大类分组显示。

新后端接口 GET /xbox/wallet-pool-options 返回 7 大类聚合,前端 <optgroup> 渲染。
176/176 通过 + TS 通过。