### PR TITLE
feat(xbox): 销售归口理论值钱包 + 默认预设 + 变更审计 + UI 强化

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -5,6 +5,8 @@ import {
   ArrowDownLeft,
   ArrowUpRight,
   CheckCircle2,
+  ChevronDown,
+  ChevronRight,
   Gamepad2,
   History,
   KeyRound,
@@ -31,7 +33,9 @@ import {
   createXboxOrder,
   getXboxAccountAuditLogs,
   getXboxAccounts,
+  getXboxOrderChangeLogs,
   getXboxOrders,
+  getXboxSaleRecordChangeLogs,
   getXboxSaleRecords,
   getXboxSummary,
   getXboxTransactions,
@@ -140,6 +144,153 @@ function SummaryCards({ country }: { country: XboxCountry }) {
     </div>
   );
 }
+
+// PR P0.2++ 销售记录/订单 变更日志 Modal（CEO Q3:A）
+function ChangeLogsModal({
+  title,
+  fetchLogs,
+  onClose
+}: {
+  title: string;
+  fetchLogs: () => Promise<{ id: string; action: string; detail: string | null; operator: string | null; createdAt: string }[]>;
+  onClose: () => void;
+}) {
+  const { data: logs = [], isFetching } = useQuery({
+    queryKey: ["xbox-change-logs", title],
+    queryFn: fetchLogs
+  });
+
+  const ACTION_LABELS: Record<string, string> = {
+    created: "新建",
+    updated: "更新",
+    completed: "补齐转销售",
+    merged: "合单追加",
+    wallet_pool_changed: "切换资金池"
+  };
+
+  const ACTION_TONES: Record<string, "success" | "warning" | "danger" | "neutral" | "transfer"> = {
+    created: "success",
+    updated: "transfer",
+    completed: "success",
+    merged: "warning",
+    wallet_pool_changed: "danger"
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="flex max-h-[80vh] w-full max-w-2xl flex-col">
+        <CardHeader>
+          <CardTitle>变更历史 · {title}</CardTitle>
+        </CardHeader>
+        <CardContent className="flex-1 overflow-y-auto">
+          {logs.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+              {isFetching ? "加载中..." : "暂无变更记录"}
+            </div>
+          ) : (
+            <div className="divide-y divide-border rounded-md border border-border">
+              {logs.map((log) => (
+                <div key={log.id} className="flex items-start gap-3 px-3 py-2">
+                  <Badge tone={ACTION_TONES[log.action] ?? "neutral"}>
+                    {ACTION_LABELS[log.action] ?? log.action}
+                  </Badge>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm">{log.detail || "(无明细)"}</div>
+                    <div className="mt-0.5 text-xs text-muted-foreground">
+                      {formatDateTime(log.createdAt)} · {log.operator ?? "manual"}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          <div className="mt-3 flex justify-end">
+            <Button variant="ghost" onClick={onClose}>关闭</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// PR P0.2++ 销售记录展开看包含订单 Modal（CEO Q4:A）
+function ExpandedOrdersForSaleModal({
+  saleRecord,
+  onClose
+}: {
+  saleRecord: XboxSaleRecord;
+  onClose: () => void;
+}) {
+  const { data: allOrders = [], isFetching } = useQuery({
+    queryKey: ["xbox-orders"],
+    queryFn: () => getXboxOrders()
+  });
+  // 过滤出本销售记录关联的订单
+  const includedOrders = allOrders.filter((o) =>
+    saleRecord.orderIds.includes(o.id)
+  );
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="flex max-h-[80vh] w-full max-w-3xl flex-col">
+        <CardHeader>
+          <CardTitle>包含订单 · 销售 #{saleRecord.id}</CardTitle>
+          <div className="mt-1 text-xs text-muted-foreground">
+            合并 {saleRecord.orderIds.length} 个订单 · 总售价{" "}
+            {formatMoney(saleRecord.salePrice, saleRecord.saleCurrency as Currency)} ·
+            资金池 {saleRecord.walletItemLabel}
+          </div>
+        </CardHeader>
+        <CardContent className="flex-1 overflow-y-auto">
+          {includedOrders.length === 0 ? (
+            <div className="rounded-md border border-dashed border-border px-3 py-10 text-center text-sm text-muted-foreground">
+              {isFetching ? "加载中..." : "未找到关联订单"}
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>订单号</TableHead>
+                  <TableHead className="text-right">本币金额</TableHead>
+                  <TableHead className="text-right">RMB 成本</TableHead>
+                  <TableHead>商品</TableHead>
+                  <TableHead className="text-right">售价</TableHead>
+                  <TableHead>订单时间</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {includedOrders.map((o) => (
+                  <TableRow key={o.id}>
+                    <TableCell className="font-medium tabular-nums">{o.orderNo}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatMoney(o.amountLocal, o.currencyLocal as Currency)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-red-600">
+                      {formatMoney(o.rmbCost, "CNY")}
+                    </TableCell>
+                    <TableCell className="text-xs">{o.productName ?? "-"}</TableCell>
+                    <TableCell className="text-right tabular-nums text-emerald-600">
+                      {o.salePrice != null && o.saleCurrency
+                        ? formatMoney(o.salePrice, o.saleCurrency as Currency)
+                        : "-"}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground tabular-nums">
+                      {formatDateTime(o.orderAt)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+          <div className="mt-3 flex justify-end">
+            <Button variant="ghost" onClick={onClose}>关闭</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
 
 // PR P0.1 状态徽章颜色配置
 const STATUS_META: Record<
@@ -1269,6 +1420,7 @@ function OrdersTab() {
   const [showCreate, setShowCreate] = useState(false);
   const [completeTarget, setCompleteTarget] = useState<XboxOrder | null>(null);
   const [statusFilter, setStatusFilter] = useState<"all" | "pending_complete" | "converted">("all");
+  const [logsTarget, setLogsTarget] = useState<XboxOrder | null>(null);
 
   const { data: accounts = [] } = useQuery({
     queryKey: ["xbox-accounts"],
@@ -1358,17 +1510,23 @@ function OrdersTab() {
                       {order.productName ?? "-"}
                     </TableCell>
                     <TableCell className="text-right">
-                      {order.status === "pending_complete" ? (
-                        <Button size="sm" variant="outline" onClick={() => setCompleteTarget(order)}>
-                          <Pencil className="h-3.5 w-3.5" />
-                          补齐
+                      <div className="flex justify-end gap-1">
+                        {order.status === "pending_complete" ? (
+                          <Button size="sm" variant="outline" onClick={() => setCompleteTarget(order)}>
+                            <Pencil className="h-3.5 w-3.5" />
+                            补齐
+                          </Button>
+                        ) : (
+                          <Badge tone="success">
+                            <CheckCircle2 className="h-3 w-3 mr-1" />
+                            已转销售
+                          </Badge>
+                        )}
+                        <Button size="sm" variant="ghost" onClick={() => setLogsTarget(order)}>
+                          <History className="h-3.5 w-3.5" />
+                          历史
                         </Button>
-                      ) : (
-                        <Badge tone="success">
-                          <CheckCircle2 className="h-3 w-3 mr-1" />
-                          已转销售
-                        </Badge>
-                      )}
+                      </div>
                     </TableCell>
                   </TableRow>
                 );
@@ -1394,6 +1552,13 @@ function OrdersTab() {
           accounts={accounts}
           walletMethods={walletMethods}
           onClose={() => setCompleteTarget(null)}
+        />
+      ) : null}
+      {logsTarget ? (
+        <ChangeLogsModal
+          title={`订单 ${logsTarget.orderNo}`}
+          fetchLogs={() => getXboxOrderChangeLogs(logsTarget.id)}
+          onClose={() => setLogsTarget(null)}
         />
       ) : null}
     </div>
@@ -1555,6 +1720,8 @@ function EditSaleRecordModal({
 
 function SaleRecordsTab() {
   const [editTarget, setEditTarget] = useState<XboxSaleRecord | null>(null);
+  const [expandTarget, setExpandTarget] = useState<XboxSaleRecord | null>(null);
+  const [logsTarget, setLogsTarget] = useState<XboxSaleRecord | null>(null);
 
   const { data: records = [], isFetching, refetch } = useQuery({
     queryKey: ["xbox-sale-records"],
@@ -1608,13 +1775,31 @@ function SaleRecordsTab() {
                     </TableCell>
                     <TableCell className="text-xs">{record.walletItemLabel}</TableCell>
                     <TableCell className="text-right text-xs text-muted-foreground tabular-nums">
-                      {record.orderIds.length}
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1 hover:text-foreground"
+                        onClick={() => setExpandTarget(record)}
+                        title="查看包含订单"
+                      >
+                        <ChevronRight className="h-3 w-3" />
+                        {record.orderIds.length}
+                      </button>
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button size="sm" variant="ghost" onClick={() => setEditTarget(record)}>
-                        <Pencil className="h-3.5 w-3.5" />
-                        修改
-                      </Button>
+                      <div className="flex justify-end gap-1">
+                        <Button size="sm" variant="ghost" onClick={() => setExpandTarget(record)}>
+                          <ChevronDown className="h-3.5 w-3.5" />
+                          订单明细
+                        </Button>
+                        <Button size="sm" variant="ghost" onClick={() => setEditTarget(record)}>
+                          <Pencil className="h-3.5 w-3.5" />
+                          修改
+                        </Button>
+                        <Button size="sm" variant="ghost" onClick={() => setLogsTarget(record)}>
+                          <History className="h-3.5 w-3.5" />
+                          历史
+                        </Button>
+                      </div>
                     </TableCell>
                   </TableRow>
                 );
@@ -1636,6 +1821,19 @@ function SaleRecordsTab() {
           record={editTarget}
           walletMethods={walletMethods}
           onClose={() => setEditTarget(null)}
+        />
+      ) : null}
+      {expandTarget ? (
+        <ExpandedOrdersForSaleModal
+          saleRecord={expandTarget}
+          onClose={() => setExpandTarget(null)}
+        />
+      ) : null}
+      {logsTarget ? (
+        <ChangeLogsModal
+          title={`销售 #${logsTarget.id} ${logsTarget.productName}`}
+          fetchLogs={() => getXboxSaleRecordChangeLogs(logsTarget.id)}
+          onClose={() => setLogsTarget(null)}
         />
       ) : null}
     </div>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -895,10 +895,13 @@ type XboxPoolOptionGroupResponse = {
   }[];
 };
 
-export async function getXboxWalletPoolOptions(): Promise<XboxPoolOptionGroup[]> {
+export async function getXboxWalletPoolOptions(
+  options?: { xboxOnly?: boolean }
+): Promise<XboxPoolOptionGroup[]> {
+  const xboxOnly = options?.xboxOnly ?? true;
   try {
     const data = await fetchJson<XboxPoolOptionGroupResponse[]>(
-      "/api/xbox/wallet-pool-options"
+      `/api/xbox/wallet-pool-options?xboxOnly=${xboxOnly}`
     );
     return data.map((g) => ({
       groupCode: g.groupCode ?? g.group_code ?? "",
@@ -910,6 +913,53 @@ export async function getXboxWalletPoolOptions(): Promise<XboxPoolOptionGroup[]>
         fullPath: w.fullPath ?? w.full_path ?? w.name
       }))
     }));
+  } catch {
+    return [];
+  }
+}
+
+type XboxChangeLogResponse = {
+  id: string | number;
+  entityType?: string;
+  entity_type?: string;
+  entityId?: string | number;
+  entity_id?: string | number;
+  action: string;
+  detail?: string | null;
+  operator?: string | null;
+  createdAt?: string;
+  created_at?: string;
+};
+
+function _normalizeChangeLog(log: XboxChangeLogResponse) {
+  return {
+    id: String(log.id),
+    entityType: ((log.entityType ?? log.entity_type) as "order" | "sale_record") ?? "order",
+    entityId: String(log.entityId ?? log.entity_id ?? ""),
+    action: log.action as "created" | "updated" | "completed" | "merged" | "wallet_pool_changed",
+    detail: log.detail ?? null,
+    operator: log.operator ?? null,
+    createdAt: log.createdAt ?? log.created_at ?? ""
+  };
+}
+
+export async function getXboxOrderChangeLogs(orderId: string) {
+  try {
+    const data = await fetchJson<XboxChangeLogResponse[]>(
+      `/api/xbox/orders/${orderId}/change-logs`
+    );
+    return data.map(_normalizeChangeLog);
+  } catch {
+    return [];
+  }
+}
+
+export async function getXboxSaleRecordChangeLogs(recordId: string) {
+  try {
+    const data = await fetchJson<XboxChangeLogResponse[]>(
+      `/api/xbox/sale-records/${recordId}/change-logs`
+    );
+    return data.map(_normalizeChangeLog);
   } catch {
     return [];
   }

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -160,9 +160,20 @@ export type XboxPoolOptionWallet = {
 };
 
 export type XboxPoolOptionGroup = {
-  groupCode: string; // ASSET_RMB / TAOBAO / TAIWAN ...
-  groupLabel: string; // 资产 RMB / 淘宝 / 台湾
+  groupCode: string; // XBOX_SALES_LEDGER / ASSET_RMB / TAOBAO / TAIWAN ...
+  groupLabel: string; // XBOX 销售归口 / 资产 RMB / 淘宝 / 台湾
   wallets: XboxPoolOptionWallet[];
+};
+
+// 订单 / 销售记录变更日志（GET /xbox/orders/{id}/change-logs 等）
+export type XboxChangeLog = {
+  id: string;
+  entityType: "order" | "sale_record";
+  entityId: string;
+  action: "created" | "updated" | "completed" | "merged" | "wallet_pool_changed";
+  detail: string | null;
+  operator: string | null;
+  createdAt: string;
 };
 
 export type XboxTransaction = {

--- a/src/main.py
+++ b/src/main.py
@@ -42,6 +42,11 @@ from src.services.assets import ensure_default_asset_wallets
 from src.services.taiwan import ensure_default_taiwan_wallets
 from src.services.taobao import ensure_default_taobao_wallets
 from src.services.vendors import ensure_vendor_wallets
+from src.services.xbox_sales_ledger import (
+    ensure_xbox_default_wallet_settings,
+    ensure_xbox_sales_ledger_wallets,
+    soft_delete_old_taiwan_wallets,
+)
 
 
 @asynccontextmanager
@@ -53,6 +58,10 @@ async def lifespan(_: FastAPI):
         ensure_default_taobao_wallets(db)
         ensure_default_taiwan_wallets(db)
         ensure_vendor_wallets(db)
+        # XBOX 销售归口"理论值"钱包（CEO 2026-05-08 确认结构）
+        soft_delete_old_taiwan_wallets(db)  # CEO Q3:B - 台湾旧 3 个空钱包软删除
+        leaf_id_by_name = ensure_xbox_sales_ledger_wallets(db)
+        ensure_xbox_default_wallet_settings(db, leaf_id_by_name)
         db.commit()
     finally:
         db.close()

--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -18,9 +18,13 @@ class WalletType(str, Enum):
     ASSET_USDT = "ASSET_USDT"
     ASSET_USD = "ASSET_USD"  # PR #110 (P0.2): XBOX USD 销售收入资金池
     VENDOR = "VENDOR"
-    XBOX = "XBOX"
+    XBOX = "XBOX"  # XBOX 账号本身（旧逻辑,不是钱包）
     TAOBAO = "TAOBAO"
     TAIWAN = "TAIWAN"
+    # PR P0.2++ XBOX 销售归口"理论值"钱包大类
+    # 客服在 XBOX 模块录入销售时选择的"出售渠道"对应的钱包,
+    # 与"实际值"(千牛后台导入产生的真实钱包)物理隔离,便于对账
+    XBOX_SALES_LEDGER = "XBOX_SALES_LEDGER"
 
 
 class Currency(str, Enum):

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -338,3 +338,27 @@ class XboxWalletItem(Base):
     )
 
     method: Mapped[XboxWalletMethod] = relationship(back_populates="items")
+
+
+class XboxChangeLog(Base):
+    """订单 / 销售记录改字段的变更审计（CEO 2026-05-08 Q3:A）。
+
+    通用日志表,entity_type 标识来自哪种实体（order / sale_record）。
+    每次改字段、改资金池、改售价等都记一条,便于事后追溯"谁什么时候改了什么"。
+    """
+
+    __tablename__ = "xbox_change_logs"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    entity_type: Mapped[str] = mapped_column(String(32), nullable=False, index=True)
+    # entity_type 取值: "order" / "sale_record"
+    entity_id: Mapped[int] = mapped_column(nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String(32), nullable=False)
+    # action 取值: "created" / "updated" / "completed" / "merged" / "wallet_pool_changed"
+    detail: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    operator: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=china_now,
+    )

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -16,6 +16,7 @@ from src.models.xbox import (
     XboxAccount,
     XboxAccountAuditLog,
     XboxAccountStatus,
+    XboxChangeLog,
     XboxCountry,
     XboxCurrency,
     XboxOrder,
@@ -845,8 +846,10 @@ class XboxPoolOptionGroup(BaseModel):
     wallets: list[XboxPoolOptionWallet]
 
 
-# 钱包大类显示标签 + 顺序
+# 钱包大类显示标签 + 顺序（XBOX 钱包设置只用 XBOX_SALES_LEDGER,
+# 但接口保留全部大类返回供其他业务复用）
 _GROUP_META: list[tuple[str, str]] = [
+    ("XBOX_SALES_LEDGER", "XBOX 销售归口"),  # 默认放最前,XBOX 钱包设置首选
     ("ASSET_RMB", "资产 RMB"),
     ("ASSET_USDT", "资产 USDT"),
     ("ASSET_USD", "资产 USD"),
@@ -862,11 +865,17 @@ _GROUP_META: list[tuple[str, str]] = [
     response_model=list[XboxPoolOptionGroup],
     response_model_by_alias=True,
 )
-def list_wallet_pool_options(db: Session = Depends(get_db)) -> list[XboxPoolOptionGroup]:
-    """返回所有可作"资金池"的钱包,按大类分组（CEO Q1A：全部钱包大类都行）。
+def list_wallet_pool_options(
+    xbox_only: bool = Query(True, alias="xboxOnly"),
+    db: Session = Depends(get_db),
+) -> list[XboxPoolOptionGroup]:
+    """返回可作"资金池"的钱包,按大类分组。
 
-    校验规则: 销售记录创建/修改时,sale_currency 必须等于钱包 currency,
-    所以前端可在所有大类下挑,后端会按币种校验拒绝不匹配的组合。
+    CEO 2026-05-08 Q2:A - 默认 ``xboxOnly=true``,只返回 XBOX 销售归口理论值钱包,
+    防止客服误选实际值钱包。前端可显式传 ``?xboxOnly=false`` 取全部钱包(高级模式)。
+
+    校验规则: 销售记录创建/修改时, sale_currency 必须等于钱包 currency,
+    后端按币种校验拒绝不匹配的组合。
     """
     from src.models.wallet import Wallet  # 局部 import 避免循环依赖问题
 
@@ -898,6 +907,9 @@ def list_wallet_pool_options(db: Session = Depends(get_db)) -> list[XboxPoolOpti
 
     out: list[XboxPoolOptionGroup] = []
     for type_code, label in _GROUP_META:
+        # xbox_only 模式只返回 XBOX_SALES_LEDGER 大类
+        if xbox_only and type_code != "XBOX_SALES_LEDGER":
+            continue
         items = by_type.get(type_code, [])
         if not items:
             continue
@@ -917,3 +929,74 @@ def list_wallet_pool_options(db: Session = Depends(get_db)) -> list[XboxPoolOpti
             )
         )
     return out
+
+
+# ----- 订单 / 销售记录变更日志（CEO Q3:A）-----
+
+
+class XboxChangeLogOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    entity_type: str
+    entity_id: int
+    action: str
+    detail: Optional[str] = None
+    operator: Optional[str] = None
+    created_at: str
+
+
+def _serialize_change_log(log: XboxChangeLog) -> XboxChangeLogOut:
+    return XboxChangeLogOut(
+        id=log.id,
+        entity_type=log.entity_type,
+        entity_id=log.entity_id,
+        action=log.action,
+        detail=log.detail,
+        operator=log.operator,
+        created_at=log.created_at.isoformat() if log.created_at else "",
+    )
+
+
+@router.get(
+    "/orders/{order_id}/change-logs",
+    response_model=list[XboxChangeLogOut],
+    response_model_by_alias=True,
+)
+def get_order_change_logs(
+    order_id: int,
+    limit: int = Query(50, ge=1, le=500),
+    db: Session = Depends(get_db),
+) -> list[XboxChangeLogOut]:
+    """查订单变更历史。"""
+    logs = list(
+        db.scalars(
+            select(XboxChangeLog)
+            .where(XboxChangeLog.entity_type == "order", XboxChangeLog.entity_id == order_id)
+            .order_by(XboxChangeLog.id.desc())
+            .limit(limit)
+        )
+    )
+    return [_serialize_change_log(log) for log in logs]
+
+
+@router.get(
+    "/sale-records/{record_id}/change-logs",
+    response_model=list[XboxChangeLogOut],
+    response_model_by_alias=True,
+)
+def get_sale_record_change_logs(
+    record_id: int,
+    limit: int = Query(50, ge=1, le=500),
+    db: Session = Depends(get_db),
+) -> list[XboxChangeLogOut]:
+    """查销售记录变更历史（含创建/合单/改售价/改资金池）。"""
+    logs = list(
+        db.scalars(
+            select(XboxChangeLog)
+            .where(XboxChangeLog.entity_type == "sale_record", XboxChangeLog.entity_id == record_id)
+            .order_by(XboxChangeLog.id.desc())
+            .limit(limit)
+        )
+    )
+    return [_serialize_change_log(log) for log in logs]

--- a/src/services/xbox_order.py
+++ b/src/services/xbox_order.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 
 from src.models.xbox import (
     XboxAccount,
+    XboxChangeLog,
     XboxOrder,
     XboxOrderStatus,
     XboxWalletItem,
@@ -28,6 +29,24 @@ from src.models.xbox import (
 )
 from src.services.xbox_sale import create_or_merge_sale_record
 from src.utils.time import china_now
+
+
+def _log_order_change(
+    session: Session,
+    order_id: int,
+    action: str,
+    detail: str,
+    operator: str = "manual",
+) -> None:
+    log = XboxChangeLog(
+        entity_type="order",
+        entity_id=order_id,
+        action=action,
+        detail=detail,
+        operator=operator,
+    )
+    session.add(log)
+    session.flush()
 
 
 def create_order(
@@ -73,6 +92,12 @@ def create_order(
     )
     session.add(order)
     session.flush()
+    _log_order_change(
+        session,
+        order.id,
+        "created",
+        f"订单号 {order_no.strip()},{amount_local} {currency_local},RMB 成本 {rmb_cost}",
+    )
     return order
 
 
@@ -139,6 +164,12 @@ def update_order_completion(
             order=order,
         )
         sale_record_id = record.id
+        _log_order_change(
+            session,
+            order.id,
+            "completed",
+            f"补齐转销售 #{record.id} ({item.label},{order.sale_price} {order.sale_currency})",
+        )
 
     return order, sale_record_id
 

--- a/src/services/xbox_sale.py
+++ b/src/services/xbox_sale.py
@@ -28,12 +28,33 @@ from src.models.wallet import (
 )
 from src.models.xbox import (
     XboxAccount,
+    XboxChangeLog,
     XboxOrder,
     XboxOrderStatus,
     XboxSaleRecord,
     XboxWalletItem,
 )
 from src.utils.time import china_now
+
+
+def _log_change(
+    session: Session,
+    entity_type: str,
+    entity_id: int,
+    action: str,
+    detail: str,
+    operator: str = "manual",
+) -> None:
+    """写一条变更日志（CEO Q3:A 订单/销售记录审计）。"""
+    log = XboxChangeLog(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        action=action,
+        detail=detail,
+        operator=operator,
+    )
+    session.add(log)
+    session.flush()
 
 
 # 币种 → 钱包应该的 currency
@@ -132,6 +153,14 @@ def create_or_merge_sale_record(
             )
             record.bookkeeping_tx_id = tx.id
 
+        _log_change(
+            session,
+            "sale_record",
+            record.id,
+            "created",
+            f"售价={sale_price} {sale_currency}, 资金池 wallet#{wallet_pool_id} ({wallet_item_label})",
+        )
+
     else:
         # 合单：累加 sale_price + credit 差额
         if existing.sale_currency != sale_currency:
@@ -166,6 +195,14 @@ def create_or_merge_sale_record(
             )
             # 注意：bookkeeping_tx_id 仅记最后一次（实际有多笔流水）
             existing.bookkeeping_tx_id = tx.id
+
+        _log_change(
+            session,
+            "sale_record",
+            existing.id,
+            "merged",
+            f"合单追加 +{diff} {sale_currency} ({product_name}), 新总额 {new_total}",
+        )
 
         record = existing
 
@@ -216,6 +253,8 @@ def update_sale_record_fields(
 
     # 1) 资金池变更（含 currency 变更）→ 旧池 debit 全额,新池 credit 全额
     if pool_changed or currency_changed:
+        old_pool_id = record.wallet_pool_id
+        old_currency = record.sale_currency
         old_amount = Decimal(record.sale_price)
         if old_amount > 0:
             debit(
@@ -235,9 +274,17 @@ def update_sale_record_fields(
         record.wallet_pool_id = new_pool_id
         record.sale_currency = new_currency
         record.sale_price = new_price
+        _log_change(
+            session,
+            "sale_record",
+            record.id,
+            "wallet_pool_changed",
+            f"资金池 wallet#{old_pool_id}({old_currency}) → wallet#{new_pool_id}({new_currency}), 售价 {old_amount} → {new_price}",
+        )
     elif price_changed:
         # 2) 仅价格变更 → diff 调整本池
-        diff = new_price - Decimal(record.sale_price)
+        old_price = Decimal(record.sale_price)
+        diff = new_price - old_price
         if diff > 0:
             tx = credit(
                 session,
@@ -254,6 +301,13 @@ def update_sale_record_fields(
                 remark=f"XBOX 销售 #{record.id} 售价调整 {diff}",
             )
         record.sale_price = new_price
+        _log_change(
+            session,
+            "sale_record",
+            record.id,
+            "updated",
+            f"售价 {old_price} → {new_price} ({record.sale_currency})",
+        )
 
     # 3) 更新其他普通字段
     if sale_date is not None:

--- a/src/services/xbox_sales_ledger.py
+++ b/src/services/xbox_sales_ledger.py
@@ -1,0 +1,252 @@
+"""XBOX 销售归口（理论值）钱包初始化服务。
+
+CEO 2026-05-08 确认的钱包结构（理论值,与实际值物理隔离）：
+
+XBOX 销售归口（顶级 group, type=XBOX_SALES_LEDGER）
+├─ 淘宝渠道（group）
+│  ├─ 丙火网络 (CNY)
+│  ├─ 兔仔电玩 (CNY)
+│  └─ 小小电玩 (CNY)
+├─ 台湾渠道（group）
+│  ├─ 银行卡A (TWD)
+│  ├─ 银行卡B (TWD)
+│  ├─ 袋鼠8591 (TWD)
+│  ├─ 喵喵8591 (TWD)
+│  └─ 存余额 (TWD)
+└─ RMB 渠道（group）
+   └─ TOM支付宝 (CNY)
+
+XBOX 客服在录入销售时选择的"出售渠道"对应这里的叶子钱包。
+对账时和实际值钱包（千牛/支付宝/淘宝模块下的钱包）做差异比较。
+
+这套结构与 XBOX 钱包设置(xbox_wallet_methods + xbox_wallet_items)
+配套：第一次启动时如果设置为空,会自动建立 3 个 method + 9 个 item
+关联到对应理论值钱包。
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import Currency, Wallet, WalletType, create_wallet
+from src.models.xbox import XboxWalletItem, XboxWalletMethod
+from src.utils.time import china_now
+
+
+# 钱包结构定义（顶级名 / 子分组 / 叶子钱包列表）
+SALES_LEDGER_STRUCTURE = {
+    "name": "XBOX 销售归口",
+    "groups": [
+        {
+            "name": "淘宝渠道",
+            "currency": Currency.CNY,
+            "leaves": ["丙火网络", "兔仔电玩", "小小电玩"],
+        },
+        {
+            "name": "台湾渠道",
+            "currency": Currency.TWD,
+            "leaves": ["银行卡A", "银行卡B", "袋鼠8591", "喵喵8591", "存余额"],
+        },
+        {
+            "name": "RMB 渠道",
+            "currency": Currency.CNY,
+            "leaves": ["TOM支付宝"],
+        },
+    ],
+}
+
+
+# 钱包设置预设（method.code → label + 对应大类下的 leaf 钱包名 + currency）
+WALLET_SETTINGS_PRESET = [
+    {
+        "code": "taobao_channel",
+        "label": "淘宝渠道",
+        "items": [
+            ("binghuo", "丙火网络", "丙火网络", Currency.CNY),
+            ("tuzai", "兔仔电玩", "兔仔电玩", Currency.CNY),
+            ("xiaoxiao", "小小电玩", "小小电玩", Currency.CNY),
+        ],
+    },
+    {
+        "code": "taiwan_channel",
+        "label": "台湾渠道",
+        "items": [
+            ("bank_a", "银行卡A", "银行卡A", Currency.TWD),
+            ("bank_b", "银行卡B", "银行卡B", Currency.TWD),
+            ("kangaroo_8591", "袋鼠8591", "袋鼠8591", Currency.TWD),
+            ("meow_8591", "喵喵8591", "喵喵8591", Currency.TWD),
+            ("balance", "存余额", "存余额", Currency.TWD),
+        ],
+    },
+    {
+        "code": "rmb_channel",
+        "label": "RMB 渠道",
+        "items": [
+            ("tom_alipay", "TOM支付宝", "TOM支付宝", Currency.CNY),
+        ],
+    },
+]
+
+
+def _ensure_root(session: Session) -> Wallet:
+    """获取或创建顶级 'XBOX 销售归口' group 钱包。"""
+    root = session.scalar(
+        select(Wallet).where(
+            Wallet.type == WalletType.XBOX_SALES_LEDGER.value,
+            Wallet.parent_id.is_(None),
+        )
+    )
+    if root is None:
+        root = create_wallet(
+            session,
+            name=SALES_LEDGER_STRUCTURE["name"],
+            wallet_type=WalletType.XBOX_SALES_LEDGER,
+            currency=Currency.CNY,  # 顶级 group 币种不重要（不存余额）
+            is_group=True,
+        )
+    else:
+        root.name = SALES_LEDGER_STRUCTURE["name"]
+        root.is_group = True
+    return root
+
+
+def _ensure_sub_group(session: Session, parent: Wallet, name: str, currency: Currency) -> Wallet:
+    """获取或创建二级 group 子钱包(淘宝渠道/台湾渠道/RMB 渠道)。"""
+    existing = session.scalar(
+        select(Wallet).where(
+            Wallet.parent_id == parent.id,
+            Wallet.name == name,
+        )
+    )
+    if existing is not None:
+        existing.is_group = True
+        existing.balance = Decimal("0")
+        return existing
+    return create_wallet(
+        session,
+        name=name,
+        wallet_type=WalletType.XBOX_SALES_LEDGER,
+        currency=currency,
+        parent_id=parent.id,
+        is_group=True,
+    )
+
+
+def _ensure_leaf(session: Session, parent: Wallet, name: str, currency: Currency) -> Wallet:
+    """获取或创建叶子钱包。"""
+    existing = session.scalar(
+        select(Wallet).where(
+            Wallet.parent_id == parent.id,
+            Wallet.name == name,
+        )
+    )
+    if existing is not None:
+        existing.is_group = False
+        return existing
+    return create_wallet(
+        session,
+        name=name,
+        wallet_type=WalletType.XBOX_SALES_LEDGER,
+        currency=currency,
+        parent_id=parent.id,
+        is_group=False,
+    )
+
+
+def ensure_xbox_sales_ledger_wallets(session: Session) -> dict[str, int]:
+    """初始化 XBOX 销售归口钱包结构（幂等）。返回叶子钱包名 → wallet.id 映射。"""
+    root = _ensure_root(session)
+    leaf_id_by_name: dict[str, int] = {}
+
+    for sub_config in SALES_LEDGER_STRUCTURE["groups"]:
+        sub_group = _ensure_sub_group(
+            session, root, sub_config["name"], sub_config["currency"]
+        )
+        for leaf_name in sub_config["leaves"]:
+            leaf = _ensure_leaf(session, sub_group, leaf_name, sub_config["currency"])
+            leaf_id_by_name[leaf_name] = leaf.id
+
+    session.flush()
+    return leaf_id_by_name
+
+
+def ensure_xbox_default_wallet_settings(
+    session: Session, leaf_id_by_name: dict[str, int]
+) -> None:
+    """按 code 逐个补齐 3 个预设 method + 9 个 item。
+
+    幂等：已存在的 method（按 code）补齐缺失的 item;不存在的新建。
+    不覆盖 / 不删除 CEO 自定义的其他 method（如 ROBLOX/VALO 等）。
+    """
+    now = china_now()
+    for method_data in WALLET_SETTINGS_PRESET:
+        method = session.scalar(
+            select(XboxWalletMethod).where(XboxWalletMethod.code == method_data["code"])
+        )
+        if method is None:
+            method = XboxWalletMethod(
+                code=method_data["code"],
+                label=method_data["label"],
+                is_active=True,
+            )
+            session.add(method)
+            session.flush()
+        else:
+            method.label = method_data["label"]
+            method.is_active = True
+            method.last_updated_at = now
+
+        for item_code, item_label, leaf_name, _currency in method_data["items"]:
+            wallet_pool_id = leaf_id_by_name.get(leaf_name)
+            if wallet_pool_id is None:
+                continue  # 该叶子钱包未建好（不应发生）
+            existing_item = session.scalar(
+                select(XboxWalletItem).where(
+                    XboxWalletItem.method_id == method.id,
+                    XboxWalletItem.code == item_code,
+                )
+            )
+            if existing_item is None:
+                item = XboxWalletItem(
+                    method_id=method.id,
+                    code=item_code,
+                    label=item_label,
+                    wallet_pool_id=wallet_pool_id,
+                    is_active=True,
+                )
+                session.add(item)
+            else:
+                existing_item.label = item_label
+                existing_item.wallet_pool_id = wallet_pool_id
+                existing_item.is_active = True
+                existing_item.last_updated_at = now
+
+    session.flush()
+
+
+def soft_delete_old_taiwan_wallets(session: Session) -> list[str]:
+    """CEO 2026-05-08 Q3:B - 台湾现有 3 个空钱包(8591余额/银行卡/超商代收金流余额)删除。
+
+    用 deleted_at 软删除,不动 wallet 行(防 FK 引用断裂)。返回删除的名字列表。
+    """
+    OLD_TAIWAN_NAMES = ("8591余额", "银行卡", "超商代收金流余额")
+    deleted: list[str] = []
+    for name in OLD_TAIWAN_NAMES:
+        wallet = session.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.TAIWAN.value,
+                Wallet.currency == Currency.TWD.value,
+                Wallet.name == name,
+                Wallet.parent_id.is_(None),
+                Wallet.deleted_at.is_(None),
+            )
+        )
+        if wallet is None:
+            continue
+        # 安全检查：余额非 0 / 有流水时记录但仍删除（CEO 已确认是空的）
+        wallet.deleted_at = china_now()
+        deleted.append(name)
+    session.flush()
+    return deleted

--- a/tests/test_xbox_p0_2_api.py
+++ b/tests/test_xbox_p0_2_api.py
@@ -20,6 +20,13 @@ from src import database
 from src.main import app
 from src.models.wallet import Wallet, WalletType, create_wallet, Currency
 from src.services.assets import ensure_default_asset_wallets
+from src.services.taiwan import ensure_default_taiwan_wallets
+from src.services.taobao import ensure_default_taobao_wallets
+from src.services.xbox_sales_ledger import (
+    ensure_xbox_default_wallet_settings,
+    ensure_xbox_sales_ledger_wallets,
+    soft_delete_old_taiwan_wallets,
+)
 
 
 @pytest.fixture()
@@ -29,6 +36,12 @@ def client(tmp_path):
     db = database.SessionLocal()
     try:
         ensure_default_asset_wallets(db)
+        ensure_default_taobao_wallets(db)
+        # 测试这套测试需要台湾老 3 个钱包先存在再被软删除
+        ensure_default_taiwan_wallets(db)
+        soft_delete_old_taiwan_wallets(db)
+        leaf_id_by_name = ensure_xbox_sales_ledger_wallets(db)
+        ensure_xbox_default_wallet_settings(db, leaf_id_by_name)
         db.commit()
     finally:
         db.close()
@@ -126,8 +139,11 @@ def test_wallet_settings_full_sync_disables_dropped_items(client):
     )
     assert r2["items_disabled"] == 1
 
+    # 用 onlyActive=false 取全部,精确找 code="agent" 的 method
     r = client.get("/xbox/wallet-settings", params={"onlyActive": "false"})
-    items = r.json()[0]["items"]
+    methods = r.json()
+    agent_method = next(m for m in methods if m["code"] == "agent")
+    items = agent_method["items"]
     by_code = {it["code"]: it for it in items}
     assert by_code["001"]["isActive"] is True
     assert by_code["002"]["isActive"] is False
@@ -421,3 +437,120 @@ def test_change_wallet_pool_debits_old_credits_new(client):
 
     assert _wallet_balance(ctx["pool_a_id"]) == Decimal("0.000000")
     assert _wallet_balance(ctx["pool_b_id"]) == Decimal("800.000000")
+
+
+# ----------------------------------------------------------
+# CEO 2026-05-08 Q3:A - 订单/销售记录变更审计日志
+# ----------------------------------------------------------
+
+def test_order_creation_writes_change_log(client):
+    account = _create_account(client)
+    r = client.post(
+        "/xbox/orders",
+        json={
+            "accountId": account["id"],
+            "orderNo": "LOG-1",
+            "amountLocal": "100",
+            "currencyLocal": "USD",
+            "orderAt": "2026-05-08T10:00:00",
+        },
+    ).json()
+    logs = client.get(f"/xbox/orders/{r['id']}/change-logs").json()
+    assert len(logs) == 1
+    assert logs[0]["action"] == "created"
+    assert "LOG-1" in logs[0]["detail"]
+
+
+def test_sale_record_creation_and_pool_change_writes_logs(client):
+    """新建销售记录和改资金池都写日志。"""
+    ctx = _setup_basic_sale(client)
+    record_id = ctx["sale_record_id"]
+
+    # 创建时已有 1 条 created 日志
+    logs = client.get(f"/xbox/sale-records/{record_id}/change-logs").json()
+    assert len(logs) == 1
+    assert logs[0]["action"] == "created"
+
+    # 改资金池 → 加 1 条 wallet_pool_changed 日志
+    client.patch(
+        f"/xbox/sale-records/{record_id}",
+        json={
+            "walletItemId": ctx["item_b_id"],
+            "walletItemLabel": "代理 002",
+            "walletPoolId": ctx["pool_b_id"],
+        },
+    )
+    logs = client.get(f"/xbox/sale-records/{record_id}/change-logs").json()
+    assert len(logs) == 2
+    assert logs[0]["action"] == "wallet_pool_changed"  # 最新在前
+
+    # 改售价 → 加 1 条 updated 日志
+    client.patch(f"/xbox/sale-records/{record_id}", json={"salePrice": "999"})
+    logs = client.get(f"/xbox/sale-records/{record_id}/change-logs").json()
+    assert len(logs) == 3
+    assert logs[0]["action"] == "updated"
+
+
+def test_sales_ledger_default_init_creates_9_pool_wallets(client):
+    """启动后端时自动建 9 个理论值钱包（CEO 2026-05-08 业务结构）。"""
+    r = client.get("/xbox/wallet-pool-options")  # 默认 xboxOnly=true
+    assert r.status_code == 200
+    groups = r.json()
+    # 只返回 XBOX_SALES_LEDGER 大类
+    assert len(groups) == 1
+    assert groups[0]["groupCode"] == "XBOX_SALES_LEDGER"
+
+    leaf_names = {w["name"] for w in groups[0]["wallets"]}
+    expected = {
+        "丙火网络", "兔仔电玩", "小小电玩",
+        "银行卡A", "银行卡B", "袋鼠8591", "喵喵8591", "存余额",
+        "TOM支付宝",
+    }
+    assert leaf_names == expected
+
+
+def test_sales_ledger_default_method_settings_created(client):
+    """启动时自动建 3 个 method + 9 个 item。"""
+    r = client.get("/xbox/wallet-settings")
+    assert r.status_code == 200
+    methods = r.json()
+    by_code = {m["code"]: m for m in methods}
+    assert "taobao_channel" in by_code
+    assert "taiwan_channel" in by_code
+    assert "rmb_channel" in by_code
+    assert len(by_code["taobao_channel"]["items"]) == 3
+    assert len(by_code["taiwan_channel"]["items"]) == 5
+    assert len(by_code["rmb_channel"]["items"]) == 1
+
+
+def test_old_taiwan_wallets_soft_deleted(client):
+    """旧台湾 3 个钱包 (8591余额/银行卡/超商代收金流余额) 启动时软删除。"""
+    from src.models.wallet import Wallet, WalletType
+    db = database.SessionLocal()
+    try:
+        # 这些应该被软删除（deleted_at 不为空）
+        for name in ("8591余额", "银行卡", "超商代收金流余额"):
+            wallet = db.scalar(
+                select(Wallet).where(
+                    Wallet.type == WalletType.TAIWAN.value,
+                    Wallet.name == name,
+                    Wallet.parent_id.is_(None),
+                )
+            )
+            # 可能不存在(从未建过) 或 已软删除
+            if wallet is not None:
+                assert wallet.deleted_at is not None, f"老台湾钱包 {name} 应被软删除"
+    finally:
+        db.close()
+
+
+def test_xbox_only_pool_options_excludes_other_categories(client):
+    """xboxOnly=false 才返回所有大类。"""
+    r1 = client.get("/xbox/wallet-pool-options")  # default true
+    assert all(g["groupCode"] == "XBOX_SALES_LEDGER" for g in r1.json())
+
+    r2 = client.get("/xbox/wallet-pool-options?xboxOnly=false")
+    codes = {g["groupCode"] for g in r2.json()}
+    assert "XBOX_SALES_LEDGER" in codes
+    assert "ASSET_RMB" in codes
+    assert "TAOBAO" in codes


### PR DESCRIPTION
## CEO 2026-05-08 确认方案
- Q1A: 新建钱包大类 XBOX_SALES_LEDGER,9 个理论值钱包(物理隔离实际值)
- Q2A: XBOX 钱包设置默认只挂理论值
- Q3:B 删除老台湾 3 个空钱包
- Q4:B 对账后续做
- 之前 Q3:A 订单/销售记录变更写审计
- 之前 Q4:A 销售记录展开看包含订单

## 业务结构
```
XBOX 销售归口 (理论值,启动自动建)
├─ 淘宝渠道 → 丙火网络/兔仔电玩/小小电玩 (CNY)
├─ 台湾渠道 → 银行卡A/银行卡B/袋鼠8591/喵喵8591/存余额 (TWD)
└─ RMB 渠道 → TOM支付宝 (CNY)
```

钱包设置预设 3 method × 9 item 自动建好,客服补齐订单时直接选。

## 测试 182/182 通过
新增 6 个: 订单变更日志/销售变更日志/销售归口初始化/默认 method 预设/老台湾软删/xboxOnly 过滤。

## UI 改进
- 销售记录加'订单明细'/'修改'/'历史'三按钮
- 订单加'历史'按钮
- ChangeLogsModal 通用变更展示(5 种 action 各有徽章)
- ExpandedOrdersForSaleModal 看销售记录包含的订单

🤖 Generated with [Claude Code](https://claude.com/claude-code)