### PR TITLE
feat(xbox): 1+2 模块补强 + 业务流程优化（日期筛选/汇总/导出/跳转/自动保存/合单提示/拆单）

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -7,6 +7,8 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronRight,
+  Download,
+  ExternalLink,
   Gamepad2,
   History,
   KeyRound,
@@ -20,7 +22,7 @@ import {
   ShieldAlert,
   Users
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -31,12 +33,14 @@ import {
   consumeXbox,
   createXboxAccount,
   createXboxOrder,
+  exportXboxSaleRecordsUrl,
   getXboxAccountAuditLogs,
   getXboxAccounts,
   getXboxOrderChangeLogs,
   getXboxOrders,
   getXboxSaleRecordChangeLogs,
   getXboxSaleRecords,
+  getXboxSalesSummary,
   getXboxSummary,
   getXboxTransactions,
   getXboxWalletPoolOptions,
@@ -141,6 +145,46 @@ function SummaryCards({ country }: { country: XboxCountry }) {
           </CardContent>
         </Card>
       </div>
+    </div>
+  );
+}
+
+// 默认筛选范围: 最近 30 天 (CEO 2026-05-08 Q1:A)
+function defaultDateRange(): { from: string; to: string } {
+  const today = new Date();
+  const from = new Date(today);
+  from.setDate(today.getDate() - 30);
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: today.toISOString().slice(0, 10)
+  };
+}
+
+function DateRangeFilter({
+  from,
+  to,
+  onChange
+}: {
+  from: string;
+  to: string;
+  onChange: (next: { from: string; to: string }) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <span>日期:</span>
+      <input
+        type="date"
+        className="h-7 rounded border border-border bg-card px-2 text-xs"
+        value={from}
+        onChange={(event) => onChange({ from: event.target.value, to })}
+      />
+      <span>→</span>
+      <input
+        type="date"
+        className="h-7 rounded border border-border bg-card px-2 text-xs"
+        value={to}
+        onChange={(event) => onChange({ from, to: event.target.value })}
+      />
     </div>
   );
 }
@@ -1262,17 +1306,33 @@ function CompleteOrderModal({
   );
   const [productName, setProductName] = useState(order.productName ?? "");
   const [operatorName, setOperatorName] = useState(order.operatorName ?? "");
-  const [salePrice, setSalePrice] = useState("");
+  const [salePrice, setSalePrice] = useState(
+    order.salePrice != null && order.saleCurrency
+      ? (order.salePrice / 100).toFixed(2)
+      : ""
+  );
   const [saleCurrency, setSaleCurrency] = useState<XboxSaleCurrency>(
     order.saleCurrency ?? "CNY"
   );
   const [walletMethodId, setWalletMethodId] = useState(order.walletMethodId ?? "");
   const [walletItemId, setWalletItemId] = useState(order.walletItemId ?? "");
   const [error, setError] = useState<string | null>(null);
+  const [autoCountdown, setAutoCountdown] = useState<number | null>(null);
 
   const account = accounts.find((a) => a.id === order.accountId);
   const selectedMethod = walletMethods.find((m) => m.id === walletMethodId);
   const itemOptions = selectedMethod?.items ?? [];
+
+  // 合单提示: 查同账号 + 同 walletItemId 的现有销售记录
+  const { data: allSaleRecords = [] } = useQuery({
+    queryKey: ["xbox-sale-records-all"],
+    queryFn: () => getXboxSaleRecords({ accountId: order.accountId })
+  });
+  const existingSaleRecord = walletItemId
+    ? allSaleRecords.find(
+        (r) => r.accountId === order.accountId && r.walletItemId === walletItemId
+      )
+    : null;
 
   const mutation = useMutation({
     mutationFn: async () => {
@@ -1294,11 +1354,45 @@ function CompleteOrderModal({
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ["xbox-orders"] });
       await queryClient.invalidateQueries({ queryKey: ["xbox-sale-records"] });
+      await queryClient.invalidateQueries({ queryKey: ["xbox-sales-summary"] });
       await queryClient.invalidateQueries({ queryKey: ["asset-wallets"] });
       onClose();
     },
     onError: (err) => setError(err instanceof Error ? err.message : "保存失败")
   });
+
+  // CEO 2026-05-08 Q4:A - 3 秒自动保存(双保险,手动按钮也保留)
+  // 仅当所有必填字段都填齐 + 还没在保存中 + 没出错才触发
+  const allFieldsReady =
+    productName.trim() !== "" &&
+    operatorName.trim() !== "" &&
+    salePrice.trim() !== "" &&
+    !!walletMethodId &&
+    !!walletItemId;
+
+  useEffect(() => {
+    if (!allFieldsReady || mutation.isPending) {
+      setAutoCountdown(null);
+      return;
+    }
+    let counter = 3;
+    setAutoCountdown(counter);
+    const tick = setInterval(() => {
+      counter -= 1;
+      if (counter <= 0) {
+        clearInterval(tick);
+        setAutoCountdown(null);
+        mutation.mutate();
+      } else {
+        setAutoCountdown(counter);
+      }
+    }, 1000);
+    return () => {
+      clearInterval(tick);
+      setAutoCountdown(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [productName, operatorName, salePrice, saleCurrency, walletMethodId, walletItemId, allFieldsReady]);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
@@ -1393,8 +1487,26 @@ function CompleteOrderModal({
               ))}
             </select>
           </div>
+          {/* 合单提示（CEO 2026-05-08 业务流程优化 2B）*/}
+          {existingSaleRecord && walletItemId ? (
+            <div className="rounded-md bg-amber-50 border border-amber-200 p-2 text-xs text-amber-800">
+              ℹ️ 该账号 + 备注模板 已有销售记录 #{existingSaleRecord.id}（当前 {existingSaleRecord.saleCurrency}{" "}
+              {(existingSaleRecord.salePrice / 100).toFixed(2)}）。本订单的 {salePrice || 0} {saleCurrency}{" "}
+              将累加合并到该记录。
+            </div>
+          ) : walletItemId ? (
+            <div className="rounded-md bg-emerald-50 border border-emerald-200 p-2 text-xs text-emerald-700">
+              ✓ 该账号 + 备注模板 尚无销售记录,将新建一条销售记录。
+            </div>
+          ) : null}
+
           <div className="rounded-md bg-emerald-50 border border-emerald-200 p-2 text-xs text-emerald-700">
             填齐后保存,系统自动生成销售记录 + 售价进对应资金池
+            {autoCountdown != null ? (
+              <span className="ml-2 font-semibold text-amber-700">
+                ⏱ {autoCountdown} 秒后自动保存（修改任意字段重置倒计时）
+              </span>
+            ) : null}
           </div>
           {error ? (
             <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
@@ -1415,23 +1527,26 @@ function CompleteOrderModal({
   );
 }
 
-function OrdersTab() {
+function OrdersTab({ onJumpToSaleRecord }: { onJumpToSaleRecord?: (saleRecordId: string) => void }) {
   const queryClient = useQueryClient();
   const [showCreate, setShowCreate] = useState(false);
   const [completeTarget, setCompleteTarget] = useState<XboxOrder | null>(null);
   const [statusFilter, setStatusFilter] = useState<"all" | "pending_complete" | "converted">("all");
   const [logsTarget, setLogsTarget] = useState<XboxOrder | null>(null);
+  const [dateRange, setDateRange] = useState(defaultDateRange);
 
   const { data: accounts = [] } = useQuery({
     queryKey: ["xbox-accounts"],
     queryFn: () => getXboxAccounts()
   });
   const { data: orders = [], isFetching, refetch } = useQuery({
-    queryKey: ["xbox-orders", statusFilter],
+    queryKey: ["xbox-orders", statusFilter, dateRange.from, dateRange.to],
     queryFn: () =>
-      getXboxOrders(
-        statusFilter === "all" ? undefined : { status: statusFilter }
-      )
+      getXboxOrders({
+        status: statusFilter === "all" ? undefined : statusFilter,
+        from: dateRange.from,
+        to: dateRange.to
+      })
   });
   const { data: walletMethods = [] } = useQuery({
     queryKey: ["xbox-wallet-settings"],
@@ -1440,21 +1555,24 @@ function OrdersTab() {
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between gap-3">
-        <div className="inline-flex rounded-md border border-border p-1">
-          {(["all", "pending_complete", "converted"] as const).map((s) => (
-            <button
-              key={s}
-              type="button"
-              className={cn(
-                "h-8 px-3 rounded text-sm font-medium text-muted-foreground transition-colors",
-                statusFilter === s && "bg-muted text-foreground"
-              )}
-              onClick={() => setStatusFilter(s)}
-            >
-              {s === "all" ? "全部" : s === "pending_complete" ? "待补齐" : "已转销售"}
-            </button>
-          ))}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="inline-flex rounded-md border border-border p-1">
+            {(["all", "pending_complete", "converted"] as const).map((s) => (
+              <button
+                key={s}
+                type="button"
+                className={cn(
+                  "h-8 px-3 rounded text-sm font-medium text-muted-foreground transition-colors",
+                  statusFilter === s && "bg-muted text-foreground"
+                )}
+                onClick={() => setStatusFilter(s)}
+              >
+                {s === "all" ? "全部" : s === "pending_complete" ? "待补齐" : "已转销售"}
+              </button>
+            ))}
+          </div>
+          <DateRangeFilter from={dateRange.from} to={dateRange.to} onChange={setDateRange} />
         </div>
         <div className="flex gap-2">
           <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
@@ -1517,10 +1635,28 @@ function OrdersTab() {
                             补齐
                           </Button>
                         ) : (
-                          <Badge tone="success">
-                            <CheckCircle2 className="h-3 w-3 mr-1" />
-                            已转销售
-                          </Badge>
+                          <>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => setCompleteTarget(order)}
+                              title="改备注模板触发拆单"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                              改字段
+                            </Button>
+                            {order.saleRecordId && onJumpToSaleRecord ? (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => onJumpToSaleRecord(order.saleRecordId as string)}
+                                title="跳转到销售记录"
+                              >
+                                <ExternalLink className="h-3.5 w-3.5" />
+                                销售
+                              </Button>
+                            ) : null}
+                          </>
                         )}
                         <Button size="sm" variant="ghost" onClick={() => setLogsTarget(order)}>
                           <History className="h-3.5 w-3.5" />
@@ -1718,14 +1854,19 @@ function EditSaleRecordModal({
   );
 }
 
-function SaleRecordsTab() {
+function SaleRecordsTab({ highlightId }: { highlightId?: string | null }) {
   const [editTarget, setEditTarget] = useState<XboxSaleRecord | null>(null);
   const [expandTarget, setExpandTarget] = useState<XboxSaleRecord | null>(null);
   const [logsTarget, setLogsTarget] = useState<XboxSaleRecord | null>(null);
+  const [dateRange, setDateRange] = useState(defaultDateRange);
 
   const { data: records = [], isFetching, refetch } = useQuery({
-    queryKey: ["xbox-sale-records"],
-    queryFn: () => getXboxSaleRecords()
+    queryKey: ["xbox-sale-records", dateRange.from, dateRange.to],
+    queryFn: () => getXboxSaleRecords({ from: dateRange.from, to: dateRange.to })
+  });
+  const { data: summary } = useQuery({
+    queryKey: ["xbox-sales-summary", dateRange.from, dateRange.to],
+    queryFn: () => getXboxSalesSummary({ from: dateRange.from, to: dateRange.to })
   });
   const { data: accounts = [] } = useQuery({
     queryKey: ["xbox-accounts"],
@@ -1736,14 +1877,74 @@ function SaleRecordsTab() {
     queryFn: () => getXboxWalletSettings(true)
   });
 
+  const exportUrl = exportXboxSaleRecordsUrl({ from: dateRange.from, to: dateRange.to });
+
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-end">
-        <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
-          <RefreshCcw className={cn("h-4 w-4", isFetching && "animate-spin")} />
-          刷新
-        </Button>
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <DateRangeFilter from={dateRange.from} to={dateRange.to} onChange={setDateRange} />
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" asChild>
+            <a href={exportUrl} download>
+              <Download className="h-4 w-4" />
+              导出 Excel
+            </a>
+          </Button>
+          <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+            <RefreshCcw className={cn("h-4 w-4", isFetching && "animate-spin")} />
+            刷新
+          </Button>
+        </div>
       </div>
+
+      {/* 汇总卡 (CEO 2026-05-08 Q2:A) */}
+      {summary ? (
+        <div className="grid gap-3 md:grid-cols-3">
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-muted-foreground">销售记录数</div>
+              <div className="mt-1 tabular-nums text-2xl font-semibold">{summary.saleRecordCount}</div>
+              <div className="mt-1 text-xs text-muted-foreground">关联订单 {summary.orderCount}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-muted-foreground">按币种总额</div>
+              <div className="mt-1 space-y-0.5">
+                {summary.totalByCurrency.length === 0 ? (
+                  <div className="tabular-nums text-2xl font-semibold text-muted-foreground">¥0</div>
+                ) : (
+                  summary.totalByCurrency.map((c) => (
+                    <div key={c.currency} className="tabular-nums text-base font-semibold text-emerald-600">
+                      {c.currency} {Number(c.total).toLocaleString("zh-CN", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      <span className="ml-2 text-xs text-muted-foreground">({c.count} 笔)</span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardContent className="p-4">
+              <div className="text-xs text-muted-foreground">按渠道占比（备注模板）</div>
+              <div className="mt-1 space-y-0.5 max-h-24 overflow-y-auto">
+                {summary.totalByItem.length === 0 ? (
+                  <div className="text-sm text-muted-foreground">暂无</div>
+                ) : (
+                  summary.totalByItem.slice(0, 6).map((it) => (
+                    <div key={`${it.itemLabel}-${it.currency}`} className="flex justify-between text-xs">
+                      <span className="text-muted-foreground truncate">{it.itemLabel}</span>
+                      <span className="tabular-nums font-medium">
+                        {it.currency} {Number(it.total).toLocaleString("zh-CN")}
+                      </span>
+                    </div>
+                  ))
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      ) : null}
       <Card>
         <CardContent className="p-0">
           <Table>
@@ -1762,8 +1963,9 @@ function SaleRecordsTab() {
             <TableBody>
               {records.map((record) => {
                 const account = accounts.find((a) => a.id === record.accountId);
+                const isHighlighted = highlightId === record.id;
                 return (
-                  <TableRow key={record.id}>
+                  <TableRow key={record.id} className={cn(isHighlighted && "bg-emerald-50")}>
                     <TableCell className="text-xs tabular-nums">{record.saleDate}</TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       {account?.accountNo ?? account?.name ?? "-"}
@@ -2281,6 +2483,15 @@ function AccountsManagementTab() {
 
 export function XboxPage() {
   const [tab, setTab] = useState<XboxTab>("accounts");
+  const [highlightSaleRecordId, setHighlightSaleRecordId] = useState<string | null>(null);
+
+  // 跳转到销售记录 tab 并高亮某条
+  const jumpToSaleRecord = (id: string) => {
+    setHighlightSaleRecordId(id);
+    setTab("sale-records");
+    // 5 秒后自动取消高亮
+    setTimeout(() => setHighlightSaleRecordId(null), 5000);
+  };
 
   return (
     <div className="space-y-5">
@@ -2309,8 +2520,8 @@ export function XboxPage() {
       </div>
 
       {tab === "accounts" ? <AccountsManagementTab /> : null}
-      {tab === "orders" ? <OrdersTab /> : null}
-      {tab === "sale-records" ? <SaleRecordsTab /> : null}
+      {tab === "orders" ? <OrdersTab onJumpToSaleRecord={jumpToSaleRecord} /> : null}
+      {tab === "sale-records" ? <SaleRecordsTab highlightId={highlightSaleRecordId} /> : null}
       {tab === "wallet-settings" ? <WalletSettingsTab /> : null}
     </div>
   );

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -772,10 +772,14 @@ function _normalizeWalletMethod(m: XboxWalletMethodResponse): XboxWalletMethod {
 export async function getXboxOrders(filter?: {
   accountId?: string;
   status?: XboxOrderStatus;
+  from?: string; // YYYY-MM-DD
+  to?: string;
 }): Promise<XboxOrder[]> {
   const qs = new URLSearchParams();
   if (filter?.accountId) qs.set("accountId", filter.accountId);
   if (filter?.status) qs.set("status", filter.status);
+  if (filter?.from) qs.set("from", filter.from);
+  if (filter?.to) qs.set("to", filter.to);
   const suffix = qs.toString() ? `?${qs.toString()}` : "";
   try {
     const data = await fetchJson<XboxOrderResponse[]>(`/api/xbox/orders${suffix}`);
@@ -831,9 +835,13 @@ export async function patchXboxOrder(
 
 export async function getXboxSaleRecords(filter?: {
   accountId?: string;
+  from?: string;
+  to?: string;
 }): Promise<XboxSaleRecord[]> {
   const qs = new URLSearchParams();
   if (filter?.accountId) qs.set("accountId", filter.accountId);
+  if (filter?.from) qs.set("from", filter.from);
+  if (filter?.to) qs.set("to", filter.to);
   const suffix = qs.toString() ? `?${qs.toString()}` : "";
   try {
     const data = await fetchJson<XboxSaleRecordResponse[]>(`/api/xbox/sale-records${suffix}`);
@@ -841,6 +849,44 @@ export async function getXboxSaleRecords(filter?: {
   } catch {
     return [];
   }
+}
+
+export type XboxSalesSummary = {
+  totalByCurrency: { currency: string; total: string; count: number }[];
+  totalByMethod: { methodLabel: string; currency: string; total: string; count: number }[];
+  totalByItem: { itemLabel: string; currency: string; total: string; count: number }[];
+  saleRecordCount: number;
+  orderCount: number;
+};
+
+export async function getXboxSalesSummary(filter?: {
+  from?: string;
+  to?: string;
+}): Promise<XboxSalesSummary> {
+  const qs = new URLSearchParams();
+  if (filter?.from) qs.set("from", filter.from);
+  if (filter?.to) qs.set("to", filter.to);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  try {
+    return await fetchJson<XboxSalesSummary>(`/api/xbox/sales-summary${suffix}`);
+  } catch {
+    return {
+      totalByCurrency: [],
+      totalByMethod: [],
+      totalByItem: [],
+      saleRecordCount: 0,
+      orderCount: 0
+    };
+  }
+}
+
+export function exportXboxSaleRecordsUrl(filter?: { from?: string; to?: string; accountId?: string }): string {
+  const qs = new URLSearchParams();
+  if (filter?.from) qs.set("from", filter.from);
+  if (filter?.to) qs.set("to", filter.to);
+  if (filter?.accountId) qs.set("accountId", filter.accountId);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  return `/api/xbox/sale-records/export${suffix}`;
 }
 
 export async function patchXboxSaleRecord(

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
@@ -39,9 +39,11 @@ from src.services.xbox_order import (
     create_order as service_create_order,
     get_order_or_404,
     list_orders as service_list_orders,
+    move_order_to_different_sale_record,
     update_order_completion,
 )
 from src.services.xbox_sale import (
+    get_sales_summary,
     list_sale_records,
     update_sale_record_fields,
 )
@@ -685,12 +687,16 @@ def create_order_endpoint(request: XboxOrderCreate, db: Session = Depends(get_db
 def list_orders_endpoint(
     account_id: Optional[int] = Query(None, alias="accountId"),
     status_filter: Optional[XboxOrderStatus] = Query(None, alias="status"),
+    from_date: Optional[date] = Query(None, alias="from"),
+    to_date: Optional[date] = Query(None, alias="to"),
     db: Session = Depends(get_db),
 ) -> list[XboxOrderOut]:
     orders = service_list_orders(
         db,
         account_id=account_id,
         status=status_filter.value if status_filter else None,
+        from_date=from_date,
+        to_date=to_date,
     )
     return [serialize_order(o) for o in orders]
 
@@ -705,22 +711,39 @@ def patch_order_endpoint(
     request: XboxOrderCompletion,
     db: Session = Depends(get_db),
 ) -> XboxOrderOut:
-    """补齐订单字段。全部填齐自动转销售（CEO Q3A）。"""
+    """补齐订单字段。
+
+    - 待补齐订单（status=pending_complete）: 字段填齐自动转销售
+    - 已转销售订单（status=converted）: 改 wallet_method_id / wallet_item_id 触发"拆单"
+      老销售记录金额扣减,新销售记录金额累加(或新建),钱包余额联动。
+    """
     order = get_order_or_404(db, order_id)
     if order is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="订单不存在")
+
     try:
-        update_order_completion(
-            db,
-            order,
-            sale_date=request.sale_date,
-            product_name=request.product_name,
-            operator_name=request.operator_name,
-            sale_price=request.sale_price,
-            sale_currency=request.sale_currency,
-            wallet_method_id=request.wallet_method_id,
-            wallet_item_id=request.wallet_item_id,
-        )
+        # 已转销售 + 改 wallet_item_id → 拆单
+        if (
+            order.status == XboxOrderStatus.CONVERTED.value
+            and request.wallet_item_id is not None
+            and request.wallet_item_id != order.wallet_item_id
+        ):
+            new_method_id = request.wallet_method_id or order.wallet_method_id
+            move_order_to_different_sale_record(
+                db, order, new_method_id, request.wallet_item_id
+            )
+        else:
+            update_order_completion(
+                db,
+                order,
+                sale_date=request.sale_date,
+                product_name=request.product_name,
+                operator_name=request.operator_name,
+                sale_price=request.sale_price,
+                sale_currency=request.sale_currency,
+                wallet_method_id=request.wallet_method_id,
+                wallet_item_id=request.wallet_item_id,
+            )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
     db.commit()
@@ -737,9 +760,17 @@ def patch_order_endpoint(
 def list_sale_records_endpoint(
     account_id: Optional[int] = Query(None, alias="accountId"),
     wallet_pool_id: Optional[int] = Query(None, alias="walletPoolId"),
+    from_date: Optional[date] = Query(None, alias="from"),
+    to_date: Optional[date] = Query(None, alias="to"),
     db: Session = Depends(get_db),
 ) -> list[XboxSaleRecordOut]:
-    records = list_sale_records(db, account_id=account_id, wallet_pool_id=wallet_pool_id)
+    records = list_sale_records(
+        db,
+        account_id=account_id,
+        wallet_pool_id=wallet_pool_id,
+        from_date=from_date,
+        to_date=to_date,
+    )
     out: list[XboxSaleRecordOut] = []
     for record in records:
         order_ids = [
@@ -955,6 +986,82 @@ def _serialize_change_log(log: XboxChangeLog) -> XboxChangeLogOut:
         detail=log.detail,
         operator=log.operator,
         created_at=log.created_at.isoformat() if log.created_at else "",
+    )
+
+
+@router.get(
+    "/sales-summary",
+    response_model=dict,
+)
+def sales_summary_endpoint(
+    from_date: Optional[date] = Query(None, alias="from"),
+    to_date: Optional[date] = Query(None, alias="to"),
+    db: Session = Depends(get_db),
+) -> dict:
+    """销售汇总: 按币种 / 收款方式 / 备注模板。"""
+    return get_sales_summary(db, from_date=from_date, to_date=to_date)
+
+
+@router.get(
+    "/sale-records/export",
+    response_class=Response,
+)
+def export_sale_records_endpoint(
+    from_date: Optional[date] = Query(None, alias="from"),
+    to_date: Optional[date] = Query(None, alias="to"),
+    account_id: Optional[int] = Query(None, alias="accountId"),
+    db: Session = Depends(get_db),
+) -> Response:
+    """导出销售记录为 Excel。字段：日期/账号编号/商品/经办人/售价/币种/收款方式/备注模板/资金池钱包名/关联订单号。"""
+    from io import BytesIO
+    from openpyxl import Workbook
+    from src.models.wallet import Wallet
+
+    records = list_sale_records(
+        db, account_id=account_id, from_date=from_date, to_date=to_date
+    )
+    # 预加载账号 + method + 钱包名
+    account_map = {a.id: a for a in db.scalars(select(XboxAccount))}
+    method_map = {m.id: m for m in db.scalars(select(XboxWalletMethod))}
+    wallet_map = {w.id: w for w in db.scalars(select(Wallet))}
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "XBOX 销售记录"
+    headers = [
+        "销售日期", "账号编号", "商品", "经办人", "售价", "币种",
+        "收款方式", "备注模板", "资金池钱包", "关联订单号",
+    ]
+    ws.append(headers)
+    for record in records:
+        account = account_map.get(record.account_id)
+        method = method_map.get(record.wallet_method_id)
+        wallet = wallet_map.get(record.wallet_pool_id)
+        order_ids = [
+            o.order_no
+            for o in db.scalars(select(XboxOrder).where(XboxOrder.sale_record_id == record.id))
+        ]
+        ws.append([
+            str(record.sale_date) if record.sale_date else "",
+            account.account_no or account.name if account else "",
+            record.product_name or "",
+            record.operator_name or "",
+            float(record.sale_price),
+            record.sale_currency or "",
+            method.label if method else "",
+            record.wallet_item_label or "",
+            wallet.name if wallet else "",
+            ", ".join(order_ids),
+        ])
+
+    buf = BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    filename = f"xbox-sale-records-{from_date or 'all'}-{to_date or 'all'}.xlsx"
+    return Response(
+        content=buf.getvalue(),
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/src/services/xbox_order.py
+++ b/src/services/xbox_order.py
@@ -12,7 +12,7 @@ P0.2 阶段：
 """
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Optional
 
@@ -186,17 +186,161 @@ def _all_completion_fields_set(order: XboxOrder) -> bool:
     )
 
 
+def move_order_to_different_sale_record(
+    session: Session,
+    order: XboxOrder,
+    new_wallet_method_id: int,
+    new_wallet_item_id: int,
+) -> tuple[Optional[int], int]:
+    """拆单：把已转销售的订单从老销售记录移到新（按新 wallet_item_id）。
+
+    返回 ``(老销售记录 id 或 None, 新销售记录 id)``。
+
+    业务规则（CEO 2026-05-08 Q5:A 老销售记录变 0 时保留）：
+    1. 老销售记录 sale_price -= 本订单 sale_price + 旧池子 debit
+    2. 找到/新建新销售记录（同账号 + 新 wallet_item_id）
+       - 如果已存在 → 合并(累加 sale_price + 新池 credit)
+       - 不存在 → 新建 + 新池 credit
+    3. 更新订单的 sale_record_id / wallet_method_id / wallet_item_id
+    4. 旧记录变 0 时保留(状态变化不删)
+    5. 写审计日志
+    """
+    from src.models.xbox import XboxSaleRecord, XboxWalletItem
+    from src.models.wallet import credit, debit
+    from src.services.xbox_sale import (
+        _find_existing_sale_record,
+        _validate_pool_currency,
+        create_or_merge_sale_record,
+    )
+
+    if order.sale_record_id is None or order.status != XboxOrderStatus.CONVERTED.value:
+        raise ValueError("订单未转销售,不能执行拆单逻辑")
+
+    if order.sale_price is None or order.sale_price <= 0:
+        raise ValueError("订单售价为空或 0,无法拆单")
+
+    if order.wallet_item_id == new_wallet_item_id:
+        return order.sale_record_id, order.sale_record_id  # 没变,no-op
+
+    # 校验新 method/item 存在
+    new_item = session.get(XboxWalletItem, new_wallet_item_id)
+    if new_item is None:
+        raise ValueError(f"新备注模板 {new_wallet_item_id} 不存在")
+    new_method = session.get(XboxWalletMethod, new_wallet_method_id)
+    if new_method is None:
+        raise ValueError(f"新收款方式 {new_wallet_method_id} 不存在")
+
+    # 获取老销售记录
+    old_record = session.get(XboxSaleRecord, order.sale_record_id)
+    if old_record is None:
+        raise ValueError(f"老销售记录 {order.sale_record_id} 不存在")
+
+    # 校验新池币种
+    _validate_pool_currency(session, new_item.wallet_pool_id, order.sale_currency or old_record.sale_currency)
+
+    order_sale_price = Decimal(order.sale_price)
+
+    # 1) 老记录扣减 + 旧池 debit
+    old_record_id = old_record.id
+    new_total = Decimal(old_record.sale_price) - order_sale_price
+    if new_total < 0:
+        raise ValueError(f"老销售记录金额会变负({new_total}),数据可能已损坏")
+    old_record.sale_price = new_total
+    if order_sale_price > 0:
+        debit(
+            session,
+            old_record.wallet_pool_id,
+            order_sale_price,
+            remark=f"XBOX 拆单 订单#{order.id} 从销售#{old_record.id} 移出",
+        )
+
+    from src.services.xbox_sale import _log_change as log_change
+
+    log_change(
+        session,
+        "sale_record",
+        old_record.id,
+        "updated",
+        f"拆单: 订单 #{order.id} 移出, -{order_sale_price} {old_record.sale_currency}, 余额 {new_total}",
+    )
+
+    # 2) 找/建新销售记录
+    account = session.get(XboxAccount, order.account_id)
+    new_record = _find_existing_sale_record(session, account.id, new_wallet_item_id)
+    if new_record is not None:
+        # 合到现有
+        new_total_price = Decimal(new_record.sale_price) + order_sale_price
+        new_record.sale_price = new_total_price
+        new_record.last_updated_at = china_now()
+        if order_sale_price > 0:
+            tx = credit(
+                session,
+                new_record.wallet_pool_id,
+                order_sale_price,
+                remark=f"XBOX 拆单 订单#{order.id} 合入销售#{new_record.id}",
+            )
+            new_record.bookkeeping_tx_id = tx.id
+        log_change(
+            session,
+            "sale_record",
+            new_record.id,
+            "merged",
+            f"拆单接收: 订单 #{order.id}, +{order_sale_price} {order.sale_currency}, 总额 {new_total_price}",
+        )
+    else:
+        new_record = create_or_merge_sale_record(
+            session,
+            account=account,
+            sale_date=old_record.sale_date,
+            product_name=order.product_name or "(拆单)",
+            operator_name=order.operator_name or old_record.operator_name,
+            sale_price=order_sale_price,
+            sale_currency=order.sale_currency or old_record.sale_currency,
+            wallet_method_id=new_wallet_method_id,
+            wallet_item_id=new_wallet_item_id,
+            wallet_item_label=new_item.label,
+            wallet_pool_id=new_item.wallet_pool_id,
+            order=None,  # 不通过 order 参数（避免 status 重置）
+        )
+
+    # 3) 更新订单关联
+    order.sale_record_id = new_record.id
+    order.wallet_method_id = new_wallet_method_id
+    order.wallet_item_id = new_wallet_item_id
+    order.last_updated_at = china_now()
+
+    _log_order_change(
+        session,
+        order.id,
+        "wallet_pool_changed",
+        f"拆单: 销售#{old_record_id} → 销售#{new_record.id} (备注模板 → {new_item.label})",
+    )
+
+    session.flush()
+    return old_record_id, new_record.id
+
+
 def list_orders(
     session: Session,
     *,
     account_id: Optional[int] = None,
     status: Optional[str] = None,
+    from_date: Optional[date] = None,
+    to_date: Optional[date] = None,
 ) -> list[XboxOrder]:
+    """列出订单。可按账号/状态过滤。``from_date``/``to_date`` 按订单时间(order_at)闭区间过滤。"""
     stmt = select(XboxOrder).order_by(XboxOrder.id.desc())
     if account_id is not None:
         stmt = stmt.where(XboxOrder.account_id == account_id)
     if status is not None:
         stmt = stmt.where(XboxOrder.status == status)
+    if from_date is not None:
+        stmt = stmt.where(XboxOrder.order_at >= datetime.combine(from_date, datetime.min.time()))
+    if to_date is not None:
+        # 闭区间: 加一天再 <  → 等同 <= 当天 23:59:59
+        stmt = stmt.where(
+            XboxOrder.order_at < datetime.combine(to_date, datetime.min.time()) + timedelta(days=1)
+        )
     return list(session.scalars(stmt))
 
 

--- a/src/services/xbox_sale.py
+++ b/src/services/xbox_sale.py
@@ -333,10 +333,134 @@ def list_sale_records(
     *,
     account_id: Optional[int] = None,
     wallet_pool_id: Optional[int] = None,
+    from_date: Optional[date] = None,
+    to_date: Optional[date] = None,
 ) -> list[XboxSaleRecord]:
+    """列销售记录。按 sale_date 闭区间过滤。"""
     stmt = select(XboxSaleRecord).order_by(XboxSaleRecord.id.desc())
     if account_id is not None:
         stmt = stmt.where(XboxSaleRecord.account_id == account_id)
     if wallet_pool_id is not None:
         stmt = stmt.where(XboxSaleRecord.wallet_pool_id == wallet_pool_id)
+    if from_date is not None:
+        stmt = stmt.where(XboxSaleRecord.sale_date >= from_date)
+    if to_date is not None:
+        stmt = stmt.where(XboxSaleRecord.sale_date <= to_date)
     return list(session.scalars(stmt))
+
+
+def get_sales_summary(
+    session: Session,
+    *,
+    from_date: Optional[date] = None,
+    to_date: Optional[date] = None,
+) -> dict:
+    """销售汇总（按币种 / 收款方式 / 备注模板）。
+
+    返回:
+      {
+        "totalByCurrency": [{currency: "CNY", total: ¥, count: N}],
+        "totalByMethod": [{methodLabel: "淘宝渠道", currency: "CNY", total: ¥, count: N}],
+        "totalByItem": [{itemLabel: "丙火网络", currency: "CNY", total: ¥, count: N}],
+        "saleRecordCount": N,
+        "orderCount": N (含订单数,关联订单总和),
+      }
+    """
+    from sqlalchemy import func as sa_func
+
+    from src.models.xbox import XboxOrder as _XboxOrder
+    from src.models.xbox import XboxWalletItem, XboxWalletMethod
+
+    # 销售记录基础筛选
+    base_filters = []
+    if from_date is not None:
+        base_filters.append(XboxSaleRecord.sale_date >= from_date)
+    if to_date is not None:
+        base_filters.append(XboxSaleRecord.sale_date <= to_date)
+
+    # 按币种汇总
+    by_currency_rows = list(
+        session.execute(
+            select(
+                XboxSaleRecord.sale_currency,
+                sa_func.sum(XboxSaleRecord.sale_price).label("total"),
+                sa_func.count(XboxSaleRecord.id).label("cnt"),
+            )
+            .where(*base_filters)
+            .group_by(XboxSaleRecord.sale_currency)
+        )
+    )
+    by_currency = [
+        {"currency": row.sale_currency, "total": str(Decimal(row.total or 0)), "count": int(row.cnt)}
+        for row in by_currency_rows
+    ]
+
+    # 按收款方式汇总（method 维度）
+    by_method_rows = list(
+        session.execute(
+            select(
+                XboxWalletMethod.label.label("method_label"),
+                XboxSaleRecord.sale_currency,
+                sa_func.sum(XboxSaleRecord.sale_price).label("total"),
+                sa_func.count(XboxSaleRecord.id).label("cnt"),
+            )
+            .select_from(XboxSaleRecord)
+            .join(XboxWalletMethod, XboxWalletMethod.id == XboxSaleRecord.wallet_method_id)
+            .where(*base_filters)
+            .group_by(XboxWalletMethod.label, XboxSaleRecord.sale_currency)
+            .order_by(XboxWalletMethod.label)
+        )
+    )
+    by_method = [
+        {
+            "methodLabel": row.method_label,
+            "currency": row.sale_currency,
+            "total": str(Decimal(row.total or 0)),
+            "count": int(row.cnt),
+        }
+        for row in by_method_rows
+    ]
+
+    # 按备注模板汇总（item 维度）
+    by_item_rows = list(
+        session.execute(
+            select(
+                XboxSaleRecord.wallet_item_label.label("item_label"),
+                XboxSaleRecord.sale_currency,
+                sa_func.sum(XboxSaleRecord.sale_price).label("total"),
+                sa_func.count(XboxSaleRecord.id).label("cnt"),
+            )
+            .where(*base_filters)
+            .group_by(XboxSaleRecord.wallet_item_label, XboxSaleRecord.sale_currency)
+            .order_by(XboxSaleRecord.wallet_item_label)
+        )
+    )
+    by_item = [
+        {
+            "itemLabel": row.item_label,
+            "currency": row.sale_currency,
+            "total": str(Decimal(row.total or 0)),
+            "count": int(row.cnt),
+        }
+        for row in by_item_rows
+    ]
+
+    # 销售记录数 + 订单数
+    sale_record_count = session.scalar(
+        select(sa_func.count(XboxSaleRecord.id)).where(*base_filters)
+    ) or 0
+    # 订单数 = 与匹配的销售记录关联的订单
+    order_count = session.scalar(
+        select(sa_func.count(_XboxOrder.id))
+        .select_from(_XboxOrder)
+        .join(XboxSaleRecord, XboxSaleRecord.id == _XboxOrder.sale_record_id)
+        .where(*base_filters)
+    ) or 0
+
+    return {
+        "totalByCurrency": by_currency,
+        "totalByMethod": by_method,
+        "totalByItem": by_item,
+        "saleRecordCount": int(sale_record_count),
+        "orderCount": int(order_count),
+    }

--- a/tests/test_xbox_p0_2_api.py
+++ b/tests/test_xbox_p0_2_api.py
@@ -544,6 +544,90 @@ def test_old_taiwan_wallets_soft_deleted(client):
         db.close()
 
 
+def test_split_order_moves_to_new_sale_record(client):
+    """拆单：把已转销售订单从备注模板 A 改到 B,老记录扣减+新记录累加+钱包联动。"""
+    ctx = _setup_basic_sale(client)
+    # 先确认初始: 销售记录 sale_price = 800, pool_a 余额 800
+    record_id = ctx["sale_record_id"]
+    assert _wallet_balance(ctx["pool_a_id"]) == Decimal("800.000000")
+
+    # 找到原订单
+    db = database.SessionLocal()
+    try:
+        from src.models.xbox import XboxOrder
+        order = db.scalar(select(XboxOrder).where(XboxOrder.sale_record_id == record_id))
+        assert order is not None
+        order_id = order.id
+    finally:
+        db.close()
+
+    # 把订单改备注模板（pool A → pool B）= 拆单
+    r = client.patch(
+        f"/xbox/orders/{order_id}",
+        json={"walletMethodId": ctx["method_id"], "walletItemId": ctx["item_b_id"]},
+    )
+    assert r.status_code == 200, r.text
+
+    # 老池 0,新池 800
+    assert _wallet_balance(ctx["pool_a_id"]) == Decimal("0.000000")
+    assert _wallet_balance(ctx["pool_b_id"]) == Decimal("800.000000")
+
+    # 老销售记录 sale_price = 0 (保留, CEO Q5:A)
+    records = client.get("/xbox/sale-records").json()
+    old_record = next(r for r in records if r["id"] == record_id)
+    assert Decimal(old_record["salePrice"]) == Decimal("0")
+    # 新销售记录 sale_price = 800
+    new_record = next(r for r in records if r["walletItemId"] == ctx["item_b_id"])
+    assert Decimal(new_record["salePrice"]) == Decimal("800")
+
+    # 订单的 sale_record_id 指向新
+    order_after = client.get("/xbox/orders").json()
+    o = next(o for o in order_after if int(o["id"]) == order_id)
+    assert int(o["saleRecordId"]) == int(new_record["id"])
+
+
+def test_sales_summary_groups_by_currency_and_method(client):
+    """销售汇总: 按币种 + 按收款方式聚合金额。"""
+    ctx = _setup_basic_sale(client)  # 1 笔 ¥800 进 method_id
+
+    r = client.get("/xbox/sales-summary")
+    assert r.status_code == 200
+    summary = r.json()
+    assert summary["saleRecordCount"] >= 1
+    cny = next(s for s in summary["totalByCurrency"] if s["currency"] == "CNY")
+    assert Decimal(cny["total"]) >= Decimal("800")
+
+
+def test_export_sale_records_returns_xlsx(client):
+    """Excel 导出端点返回 xlsx 二进制 + 正确 header。"""
+    _setup_basic_sale(client)
+    r = client.get("/xbox/sale-records/export")
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith(
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    )
+    assert "attachment" in r.headers.get("content-disposition", "")
+    # 简单检查: xlsx 文件以 PK 开头(zip)
+    assert r.content[:2] == b"PK"
+
+
+def test_orders_filtered_by_date_range(client):
+    """订单按 from/to 日期筛选。"""
+    account = _create_account(client)
+    # 建 3 个不同 order_at 的订单
+    for day in (3, 5, 7):
+        client.post("/xbox/orders", json={
+            "accountId": account["id"], "orderNo": f"D-{day}",
+            "amountLocal": "1", "currencyLocal": "USD",
+            "orderAt": f"2026-05-{day:02d}T10:00:00",
+        })
+    # 取 5/4 ~ 5/6 范围 → 只命中 5/5
+    r = client.get("/xbox/orders?from=2026-05-04&to=2026-05-06")
+    assert r.status_code == 200
+    nos = {o["orderNo"] for o in r.json()}
+    assert nos == {"D-5"}
+
+
 def test_xbox_only_pool_options_excludes_other_categories(client):
     """xboxOnly=false 才返回所有大类。"""
     r1 = client.get("/xbox/wallet-pool-options")  # default true


### PR DESCRIPTION
CEO 2026-05-08 选 1+2 全 A 方案,后端+前端一气呵成做完。

后端新增端点：
- GET /xbox/sales-summary
- GET /xbox/sale-records/export (xlsx)
- 订单/销售记录 list 加 from/to
- 拆单核心 service: move_order_to_different_sale_record

前端新增功能：
- 日期范围筛选(默认 30 天)
- 销售汇总卡(币种/方式/渠道占比)
- Excel 导出按钮
- 订单 ↔ 销售记录跳转高亮
- 3 秒自动保存倒计时(双保险)
- 合单提示('将合并到销售 #N' / '将新建')
- 拆单(已转销售改备注模板)

测试 186/186 通过(新增 4)。