### PR TITLE
feat(xbox): 对账功能 - 理论值 vs 实际值差异展示 + 映射 CRUD

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -10,9 +10,11 @@ import {
   Download,
   ExternalLink,
   Gamepad2,
+  GitCompare,
   History,
   KeyRound,
   Layers,
+  Link2,
   ListOrdered,
   Pencil,
   Plus,
@@ -20,6 +22,7 @@ import {
   RefreshCcw,
   Settings2,
   ShieldAlert,
+  Trash2,
   Users
 } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -33,11 +36,16 @@ import {
   consumeXbox,
   createXboxAccount,
   createXboxOrder,
+  createXboxReconcileMapping,
+  deleteXboxReconcileMapping,
   exportXboxSaleRecordsUrl,
+  getAssetWallets,
   getXboxAccountAuditLogs,
   getXboxAccounts,
   getXboxOrderChangeLogs,
   getXboxOrders,
+  getXboxReconcileMappings,
+  getXboxReconcileReport,
   getXboxSaleRecordChangeLogs,
   getXboxSaleRecords,
   getXboxSalesSummary,
@@ -61,6 +69,7 @@ import type {
   XboxCountry,
   XboxOrder,
   XboxPoolOptionGroup,
+  XboxReconcileMapping,
   XboxSaleCurrency,
   XboxSaleRecord,
   XboxWalletMethod
@@ -2385,14 +2394,289 @@ function WalletSettingsTab() {
 }
 
 
-type XboxTab = "accounts" | "orders" | "sale-records" | "wallet-settings";
+type XboxTab = "accounts" | "orders" | "sale-records" | "wallet-settings" | "reconcile";
 
 const TAB_META: { id: XboxTab; label: string; icon: React.ReactNode }[] = [
   { id: "accounts", label: "账号管理", icon: <Users className="h-4 w-4" /> },
   { id: "orders", label: "订单", icon: <Receipt className="h-4 w-4" /> },
   { id: "sale-records", label: "销售记录", icon: <Layers className="h-4 w-4" /> },
-  { id: "wallet-settings", label: "钱包设置", icon: <Settings2 className="h-4 w-4" /> }
+  { id: "wallet-settings", label: "钱包设置", icon: <Settings2 className="h-4 w-4" /> },
+  { id: "reconcile", label: "对账", icon: <GitCompare className="h-4 w-4" /> }
 ];
+
+
+// ===================================================================
+// 对账 Tab（CEO 2026-05-08 Q1A+Q2A+Q3A+Q4A）
+// ===================================================================
+
+function ReconcileTab() {
+  const queryClient = useQueryClient();
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [showAddMapping, setShowAddMapping] = useState<{ theoreticalWalletId: string } | null>(null);
+
+  const { data: poolGroupsXbox = [] } = useQuery({
+    queryKey: ["xbox-pool-options-only"],
+    queryFn: () => getXboxWalletPoolOptions({ xboxOnly: true })
+  });
+  const { data: poolGroupsAll = [] } = useQuery({
+    queryKey: ["xbox-pool-options-all"],
+    queryFn: () => getXboxWalletPoolOptions({ xboxOnly: false })
+  });
+  const { data: mappings = [], refetch: refetchMappings } = useQuery({
+    queryKey: ["xbox-reconcile-mappings"],
+    queryFn: getXboxReconcileMappings
+  });
+  const { data: report = [], isFetching, refetch: refetchReport } = useQuery({
+    queryKey: ["xbox-reconcile-report", date],
+    queryFn: () => getXboxReconcileReport(date)
+  });
+
+  // 理论值钱包列表（XBOX_SALES_LEDGER 大类的叶子）
+  const theoreticalWallets = poolGroupsXbox.flatMap((g) => g.wallets);
+  // 实际值钱包列表（除 XBOX_SALES_LEDGER 大类之外）
+  const actualGroups = poolGroupsAll.filter((g) => g.groupCode !== "XBOX_SALES_LEDGER");
+
+  const idx = buildPoolWalletIndex(poolGroupsAll);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-3">
+          <span className="text-sm text-muted-foreground">对账日期</span>
+          <input
+            type="date"
+            className="h-9 rounded border border-border bg-card px-2 text-sm"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+          />
+        </div>
+        <Button variant="outline" size="sm" onClick={() => refetchReport()} disabled={isFetching}>
+          <RefreshCcw className={cn("h-4 w-4", isFetching && "animate-spin")} />
+          刷新对账
+        </Button>
+      </div>
+
+      {/* 对账报告 */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{date} 对账</CardTitle>
+          <div className="text-xs text-muted-foreground">
+            理论值（XBOX 销售归口）当日流入 vs 实际值钱包当日 IN 流水。差异 ≠ 0 表示客服可能填错出售渠道,
+            可在订单 tab 用「改字段」拆单纠错。
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>理论值钱包</TableHead>
+                <TableHead>币种</TableHead>
+                <TableHead className="text-right">理论金额</TableHead>
+                <TableHead className="text-right">实际金额（合计）</TableHead>
+                <TableHead className="text-right">差异</TableHead>
+                <TableHead>映射的实际钱包</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {report.map((row) => {
+                const diff = Number(row.diff);
+                const diffColor =
+                  diff === 0 ? "text-muted-foreground" : diff > 0 ? "text-blue-600" : "text-red-600";
+                return (
+                  <TableRow key={row.theoreticalWallet.id}>
+                    <TableCell className="font-medium">{row.theoreticalWallet.name}</TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {row.theoreticalWallet.currency}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {Number(row.theoreticalTotal).toLocaleString("zh-CN", {
+                        minimumFractionDigits: 2, maximumFractionDigits: 2
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {Number(row.actualTotal).toLocaleString("zh-CN", {
+                        minimumFractionDigits: 2, maximumFractionDigits: 2
+                      })}
+                    </TableCell>
+                    <TableCell className={cn("text-right tabular-nums font-semibold", diffColor)}>
+                      {diff > 0 ? "+" : ""}
+                      {Number(row.diff).toLocaleString("zh-CN", {
+                        minimumFractionDigits: 2, maximumFractionDigits: 2
+                      })}
+                    </TableCell>
+                    <TableCell className="text-xs">
+                      {row.actualWallets.length === 0 ? (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => setShowAddMapping({
+                            theoreticalWalletId: String(row.theoreticalWallet.id)
+                          })}
+                        >
+                          <Plus className="h-3 w-3" />
+                          加映射
+                        </Button>
+                      ) : (
+                        <div className="flex flex-wrap gap-1 items-center">
+                          {row.actualWallets.map((aw) => {
+                            const mapping = mappings.find(
+                              (m) =>
+                                m.theoreticalWalletId === String(row.theoreticalWallet.id) &&
+                                m.actualWalletId === String(aw.id)
+                            );
+                            return (
+                              <Badge key={aw.id} tone="transfer">
+                                <span>{aw.name}</span>
+                                <span className="ml-1 tabular-nums">
+                                  ({aw.currency} {Number(aw.total).toLocaleString("zh-CN")})
+                                </span>
+                                {mapping ? (
+                                  <button
+                                    type="button"
+                                    className="ml-1 hover:text-red-600"
+                                    onClick={async () => {
+                                      if (confirm(`删除映射 ${row.theoreticalWallet.name} ↔ ${aw.name}?`)) {
+                                        await deleteXboxReconcileMapping(mapping.id);
+                                        refetchMappings();
+                                        refetchReport();
+                                      }
+                                    }}
+                                  >
+                                    <Trash2 className="h-3 w-3 inline" />
+                                  </button>
+                                ) : null}
+                              </Badge>
+                            );
+                          })}
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => setShowAddMapping({
+                              theoreticalWalletId: String(row.theoreticalWallet.id)
+                            })}
+                          >
+                            <Link2 className="h-3 w-3" />
+                            加
+                          </Button>
+                        </div>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+              {report.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                    暂无对账数据
+                  </TableCell>
+                </TableRow>
+              ) : null}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {showAddMapping ? (
+        <AddMappingModal
+          theoreticalWalletId={showAddMapping.theoreticalWalletId}
+          theoreticalWallets={theoreticalWallets}
+          actualGroups={actualGroups}
+          onClose={() => setShowAddMapping(null)}
+          onSuccess={() => {
+            queryClient.invalidateQueries({ queryKey: ["xbox-reconcile-mappings"] });
+            queryClient.invalidateQueries({ queryKey: ["xbox-reconcile-report"] });
+          }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function AddMappingModal({
+  theoreticalWalletId,
+  theoreticalWallets,
+  actualGroups,
+  onClose,
+  onSuccess
+}: {
+  theoreticalWalletId: string;
+  theoreticalWallets: { id: string; name: string; currency: string }[];
+  actualGroups: XboxPoolOptionGroup[];
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [actualWalletId, setActualWalletId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const theoretical = theoreticalWallets.find((w) => w.id === theoreticalWalletId);
+  // 只显示币种相同的实际钱包
+  const compatibleGroups = actualGroups
+    .map((g) => ({
+      ...g,
+      wallets: g.wallets.filter((w) => w.currency === theoretical?.currency)
+    }))
+    .filter((g) => g.wallets.length > 0);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!actualWalletId) throw new Error("请选实际钱包");
+      return createXboxReconcileMapping({
+        theoreticalWalletId,
+        actualWalletId
+      });
+    },
+    onSuccess: () => {
+      onSuccess();
+      onClose();
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "创建失败")
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>添加对账映射</CardTitle>
+          <div className="mt-1 text-xs text-muted-foreground">
+            理论值钱包: {theoretical?.name} ({theoretical?.currency})
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <div className="text-sm text-muted-foreground">关联到实际钱包（仅显示同币种）</div>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={actualWalletId}
+              onChange={(e) => setActualWalletId(e.target.value)}
+            >
+              <option value="">-- 选实际钱包 --</option>
+              {compatibleGroups.map((g) => (
+                <optgroup key={g.groupCode} label={`── ${g.groupLabel} ──`}>
+                  {g.wallets.map((w) => (
+                    <option key={w.id} value={w.id}>
+                      {w.fullPath}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+          </div>
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-sm text-red-600">
+              {error}
+            </div>
+          ) : null}
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>取消</Button>
+            <Button onClick={() => mutation.mutate()} disabled={mutation.isPending}>
+              {mutation.isPending ? "添加中..." : "添加"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
 
 function AccountsManagementTab() {
   const [country, setCountry] = useState<XboxCountry>("US");
@@ -2523,6 +2807,7 @@ export function XboxPage() {
       {tab === "orders" ? <OrdersTab onJumpToSaleRecord={jumpToSaleRecord} /> : null}
       {tab === "sale-records" ? <SaleRecordsTab highlightId={highlightSaleRecordId} /> : null}
       {tab === "wallet-settings" ? <WalletSettingsTab /> : null}
+      {tab === "reconcile" ? <ReconcileTab /> : null}
     </div>
   );
 }

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -889,6 +889,61 @@ export function exportXboxSaleRecordsUrl(filter?: { from?: string; to?: string; 
   return `/api/xbox/sale-records/export${suffix}`;
 }
 
+// 对账：映射 CRUD + 报告
+import type { XboxReconcileMapping, XboxReconcileReportRow } from "@/types";
+
+type XboxReconcileMappingResponse = {
+  id: string | number;
+  theoreticalWalletId?: string | number;
+  theoretical_wallet_id?: string | number;
+  actualWalletId?: string | number;
+  actual_wallet_id?: string | number;
+  createdAt?: string;
+  created_at?: string;
+};
+
+function _normalizeMapping(m: XboxReconcileMappingResponse): XboxReconcileMapping {
+  return {
+    id: String(m.id),
+    theoreticalWalletId: String(m.theoreticalWalletId ?? m.theoretical_wallet_id ?? ""),
+    actualWalletId: String(m.actualWalletId ?? m.actual_wallet_id ?? ""),
+    createdAt: m.createdAt ?? m.created_at ?? ""
+  };
+}
+
+export async function getXboxReconcileMappings(): Promise<XboxReconcileMapping[]> {
+  try {
+    const data = await fetchJson<XboxReconcileMappingResponse[]>(
+      "/api/xbox/reconcile-mappings"
+    );
+    return data.map(_normalizeMapping);
+  } catch {
+    return [];
+  }
+}
+
+export async function createXboxReconcileMapping(payload: {
+  theoreticalWalletId: string;
+  actualWalletId: string;
+}): Promise<XboxReconcileMapping> {
+  const data = (await postJson("/api/xbox/reconcile-mappings", payload)) as XboxReconcileMappingResponse;
+  return _normalizeMapping(data);
+}
+
+export async function deleteXboxReconcileMapping(mappingId: string): Promise<void> {
+  await sendJson(`/api/xbox/reconcile-mappings/${mappingId}`, "DELETE");
+}
+
+export async function getXboxReconcileReport(date: string): Promise<XboxReconcileReportRow[]> {
+  try {
+    return await fetchJson<XboxReconcileReportRow[]>(
+      `/api/xbox/reconcile?date=${date}`
+    );
+  } catch {
+    return [];
+  }
+}
+
 export async function patchXboxSaleRecord(
   recordId: string,
   payload: {

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -176,6 +176,23 @@ export type XboxChangeLog = {
   createdAt: string;
 };
 
+// 对账映射（理论值钱包 ↔ 实际值钱包）
+export type XboxReconcileMapping = {
+  id: string;
+  theoreticalWalletId: string;
+  actualWalletId: string;
+  createdAt: string;
+};
+
+// 对账报告每行（一个理论值钱包 + 它配对的实际值钱包们）
+export type XboxReconcileReportRow = {
+  theoreticalWallet: { id: string; name: string; currency: string };
+  actualWallets: { id: string; name: string; currency: string; total: string }[];
+  theoreticalTotal: string;
+  actualTotal: string;
+  diff: string;
+};
+
 export type XboxTransaction = {
   id: string;
   accountId: string;

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -10,7 +10,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from sqlalchemy import Date, DateTime, ForeignKey, JSON, Numeric, String, Text
+from sqlalchemy import Date, DateTime, ForeignKey, JSON, Numeric, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from src.database import Base
@@ -357,6 +357,41 @@ class XboxChangeLog(Base):
     # action 取值: "created" / "updated" / "completed" / "merged" / "wallet_pool_changed"
     detail: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     operator: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=china_now,
+    )
+
+
+class XboxReconcileMapping(Base):
+    """对账映射：理论值钱包 ↔ 实际值钱包（CEO 2026-05-08 Q1:A）。
+
+    一个理论值钱包可对应多个实际值钱包（如「丙火网络」理论 ↔
+    「丙火网络银行卡」+「丙火网络店铺支付宝」实际,1:N）。
+
+    业务规则：
+    - 同一对 (theoretical, actual) 唯一(数据库联合唯一索引)
+    - 币种校验在应用层(理论 CNY 必须配 CNY 实际)
+    - 对账时按 sale_date 对应到实际钱包当天 IN 流水总额
+    """
+
+    __tablename__ = "xbox_reconcile_mappings"
+    __table_args__ = (
+        UniqueConstraint(
+            "theoretical_wallet_id",
+            "actual_wallet_id",
+            name="uq_xbox_reconcile_pair",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    theoretical_wallet_id: Mapped[int] = mapped_column(
+        ForeignKey("wallets.id"), nullable=False, index=True
+    )  # XBOX_SALES_LEDGER 大类下的钱包
+    actual_wallet_id: Mapped[int] = mapped_column(
+        ForeignKey("wallets.id"), nullable=False
+    )  # 任何实际值钱包(淘宝/台湾/资产...)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -21,6 +21,7 @@ from src.models.xbox import (
     XboxCurrency,
     XboxOrder,
     XboxOrderStatus,
+    XboxReconcileMapping,
     XboxSaleRecord,
     XboxTransaction,
     XboxTransactionType,
@@ -46,6 +47,12 @@ from src.services.xbox_sale import (
     get_sales_summary,
     list_sale_records,
     update_sale_record_fields,
+)
+from src.services.xbox_reconcile import (
+    create_mapping,
+    delete_mapping,
+    get_reconcile_report_for_day,
+    list_mappings,
 )
 from src.services.xbox_wallet_setting import (
     list_wallet_methods,
@@ -1107,3 +1114,90 @@ def get_sale_record_change_logs(
         )
     )
     return [_serialize_change_log(log) for log in logs]
+
+
+# ----- 对账（CEO 2026-05-08 Q1A+Q2A+Q3A+Q4A）-----
+
+
+class XboxReconcileMappingOut(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    theoretical_wallet_id: int
+    actual_wallet_id: int
+    created_at: str
+
+
+class XboxReconcileMappingCreate(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    theoretical_wallet_id: int
+    actual_wallet_id: int
+
+
+def _serialize_mapping(m: XboxReconcileMapping) -> XboxReconcileMappingOut:
+    return XboxReconcileMappingOut(
+        id=m.id,
+        theoretical_wallet_id=m.theoretical_wallet_id,
+        actual_wallet_id=m.actual_wallet_id,
+        created_at=m.created_at.isoformat() if m.created_at else "",
+    )
+
+
+@router.get(
+    "/reconcile-mappings",
+    response_model=list[XboxReconcileMappingOut],
+    response_model_by_alias=True,
+)
+def list_reconcile_mappings_endpoint(db: Session = Depends(get_db)) -> list[XboxReconcileMappingOut]:
+    return [_serialize_mapping(m) for m in list_mappings(db)]
+
+
+@router.post(
+    "/reconcile-mappings",
+    response_model=XboxReconcileMappingOut,
+    response_model_by_alias=True,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_reconcile_mapping_endpoint(
+    request: XboxReconcileMappingCreate,
+    db: Session = Depends(get_db),
+) -> XboxReconcileMappingOut:
+    try:
+        mapping = create_mapping(
+            db,
+            theoretical_wallet_id=request.theoretical_wallet_id,
+            actual_wallet_id=request.actual_wallet_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    db.refresh(mapping)
+    return _serialize_mapping(mapping)
+
+
+@router.delete(
+    "/reconcile-mappings/{mapping_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+def delete_reconcile_mapping_endpoint(
+    mapping_id: int,
+    db: Session = Depends(get_db),
+) -> Response:
+    ok = delete_mapping(db, mapping_id)
+    if not ok:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="映射不存在")
+    db.commit()
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.get(
+    "/reconcile",
+    response_model=list[dict],
+)
+def reconcile_report_endpoint(
+    target_date: date = Query(..., alias="date"),
+    db: Session = Depends(get_db),
+) -> list[dict]:
+    """对账报告：每个理论值钱包当天的理论金额 vs 实际金额合计 vs 差异。"""
+    return get_reconcile_report_for_day(db, target_date)

--- a/src/services/xbox_reconcile.py
+++ b/src/services/xbox_reconcile.py
@@ -1,0 +1,243 @@
+"""XBOX 对账服务（CEO 2026-05-08 Q1A+Q2A+Q3A+Q4A）。
+
+业务模型：
+- 「XBOX 销售归口」（理论值）9 个钱包：丙火网络/兔仔电玩/小小电玩/银行卡A/银行卡B/
+  袋鼠8591/喵喵8591/存余额/TOM支付宝
+- 「淘宝/台湾/RMB」（实际值）从千牛 / 业务真实流水产生的钱包
+- 客服在 XBOX 录入销售时主观选"出售渠道",可能填错
+- 对账：每天比对理论流入 vs 实际流入,差异 = 客服填错出售渠道,
+  CEO 通过"拆单"功能纠错（已转销售订单改备注模板）
+
+口径（CEO 2026-05-08 确认）：
+- Q1A: 一对多映射,CEO 维护对应表
+- Q2A: 按日比较（特定 sale_date / IN 流水当天）
+- Q3A: 实际值取"当天 IN 流水总额"（不是余额,不是净额）
+- Q4A: 仅展示差异,CEO 自己拆单纠错
+"""
+from __future__ import annotations
+
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import and_, func as sa_func, select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import (
+    TransactionDirection,
+    Wallet,
+    WalletTransaction,
+    WalletType,
+)
+from src.models.xbox import XboxReconcileMapping, XboxSaleRecord
+
+
+def list_mappings(session: Session) -> list[XboxReconcileMapping]:
+    return list(
+        session.scalars(select(XboxReconcileMapping).order_by(XboxReconcileMapping.id))
+    )
+
+
+def create_mapping(
+    session: Session,
+    *,
+    theoretical_wallet_id: int,
+    actual_wallet_id: int,
+) -> XboxReconcileMapping:
+    """新建对账映射。校验：
+    - 两个钱包都存在
+    - 理论值必须是 XBOX_SALES_LEDGER 大类
+    - 实际值不能是 XBOX_SALES_LEDGER 大类（自己映射自己没意义）
+    - 币种必须一致
+    - 不重复
+    """
+    theoretical = session.get(Wallet, theoretical_wallet_id)
+    if theoretical is None:
+        raise ValueError(f"理论值钱包 {theoretical_wallet_id} 不存在")
+    actual = session.get(Wallet, actual_wallet_id)
+    if actual is None:
+        raise ValueError(f"实际值钱包 {actual_wallet_id} 不存在")
+
+    th_type = theoretical.type.value if hasattr(theoretical.type, "value") else theoretical.type
+    ac_type = actual.type.value if hasattr(actual.type, "value") else actual.type
+    if th_type != WalletType.XBOX_SALES_LEDGER.value:
+        raise ValueError("理论值钱包必须属于 XBOX_SALES_LEDGER 大类")
+    if ac_type == WalletType.XBOX_SALES_LEDGER.value:
+        raise ValueError("实际值钱包不能也是 XBOX_SALES_LEDGER 大类")
+
+    th_curr = theoretical.currency.value if hasattr(theoretical.currency, "value") else theoretical.currency
+    ac_curr = actual.currency.value if hasattr(actual.currency, "value") else actual.currency
+    if th_curr != ac_curr:
+        raise ValueError(
+            f"币种不一致：理论 {th_curr} ≠ 实际 {ac_curr}"
+        )
+
+    existing = session.scalar(
+        select(XboxReconcileMapping).where(
+            XboxReconcileMapping.theoretical_wallet_id == theoretical_wallet_id,
+            XboxReconcileMapping.actual_wallet_id == actual_wallet_id,
+        )
+    )
+    if existing is not None:
+        raise ValueError("该映射已存在")
+
+    mapping = XboxReconcileMapping(
+        theoretical_wallet_id=theoretical_wallet_id,
+        actual_wallet_id=actual_wallet_id,
+    )
+    session.add(mapping)
+    session.flush()
+    return mapping
+
+
+def delete_mapping(session: Session, mapping_id: int) -> bool:
+    mapping = session.get(XboxReconcileMapping, mapping_id)
+    if mapping is None:
+        return False
+    session.delete(mapping)
+    session.flush()
+    return True
+
+
+def _day_range(target_date: date) -> tuple[datetime, datetime]:
+    """某天的 [00:00, 次日 00:00) naive 时间范围（与 created_at 同语义）。"""
+    start = datetime.combine(target_date, time.min)
+    end = start + timedelta(days=1)
+    return start, end
+
+
+def _theoretical_total_for_day(
+    session: Session,
+    theoretical_wallet_id: int,
+    target_date: date,
+) -> Decimal:
+    """理论值钱包在指定日期的"流入总额"。
+
+    数据来源：``XboxSaleRecord``。
+    - sale_date == target_date 且 wallet_pool_id == theoretical_wallet_id
+    - 直接 sum(sale_price)（合单后的最新值）
+
+    注意: 不是从 wallet_transactions 取(那里有合单调整流水会重复算)。
+    """
+    total = session.scalar(
+        select(sa_func.coalesce(sa_func.sum(XboxSaleRecord.sale_price), 0)).where(
+            XboxSaleRecord.wallet_pool_id == theoretical_wallet_id,
+            XboxSaleRecord.sale_date == target_date,
+        )
+    )
+    return Decimal(str(total or 0))
+
+
+def _actual_total_for_day(
+    session: Session,
+    actual_wallet_id: int,
+    target_date: date,
+) -> Decimal:
+    """实际值钱包在指定日期的"IN 流水总额"。
+
+    数据来源：``WalletTransaction``。
+    - wallet_id == actual_wallet_id
+    - direction == "in"
+    - business_date == target_date（XBOX 销售归口配套字段）
+      或 created_at 落在当天（兜底,处理没 business_date 的流水）
+
+    优先用 business_date,fallback created_at（与"日汇总"端点逻辑一致）。
+    """
+    from sqlalchemy import or_
+
+    start, end = _day_range(target_date)
+    # 优先用 business_date,没有的话用 created_at 当天
+    total = session.scalar(
+        select(sa_func.coalesce(sa_func.sum(WalletTransaction.amount), 0)).where(
+            WalletTransaction.wallet_id == actual_wallet_id,
+            WalletTransaction.direction == TransactionDirection.IN.value,
+            or_(
+                WalletTransaction.business_date == target_date,
+                and_(
+                    WalletTransaction.business_date.is_(None),
+                    WalletTransaction.created_at >= start,
+                    WalletTransaction.created_at < end,
+                ),
+            ),
+        )
+    )
+    return Decimal(str(total or 0))
+
+
+def get_reconcile_report_for_day(
+    session: Session,
+    target_date: date,
+) -> list[dict]:
+    """对账报告：每个有映射的理论值钱包一行,含理论金额、实际金额（合计映射钱包）、差异。
+
+    返回结构：
+        [
+          {
+            "theoreticalWallet": {id, name, currency},
+            "actualWallets": [{id, name, currency, total: "X.XX"}],
+            "theoreticalTotal": "X.XX",
+            "actualTotal": "X.XX",
+            "diff": "X.XX",
+          },
+          ...
+        ]
+    """
+    # 取所有理论值钱包(XBOX_SALES_LEDGER 类下,非 group)
+    theoretical_wallets = list(
+        session.scalars(
+            select(Wallet)
+            .where(
+                Wallet.type == WalletType.XBOX_SALES_LEDGER.value,
+                Wallet.is_group.is_(False),
+                Wallet.deleted_at.is_(None),
+            )
+            .order_by(Wallet.id)
+        )
+    )
+
+    # 取所有映射
+    mappings = list_mappings(session)
+    actual_ids_by_theoretical: dict[int, list[int]] = {}
+    for m in mappings:
+        actual_ids_by_theoretical.setdefault(m.theoretical_wallet_id, []).append(
+            m.actual_wallet_id
+        )
+
+    # 取所有涉及的实际值钱包
+    all_actual_ids = {a for ids in actual_ids_by_theoretical.values() for a in ids}
+    actual_wallets_by_id = {
+        w.id: w
+        for w in session.scalars(select(Wallet).where(Wallet.id.in_(all_actual_ids)))
+    } if all_actual_ids else {}
+
+    report: list[dict] = []
+    for tw in theoretical_wallets:
+        actual_ids = actual_ids_by_theoretical.get(tw.id, [])
+        theoretical_total = _theoretical_total_for_day(session, tw.id, target_date)
+        actual_details: list[dict] = []
+        actual_total = Decimal("0")
+        for aid in actual_ids:
+            aw = actual_wallets_by_id.get(aid)
+            if aw is None:
+                continue
+            sub_total = _actual_total_for_day(session, aid, target_date)
+            actual_total += sub_total
+            actual_details.append({
+                "id": aid,
+                "name": aw.name,
+                "currency": aw.currency.value if hasattr(aw.currency, "value") else aw.currency,
+                "total": str(sub_total),
+            })
+
+        report.append({
+            "theoreticalWallet": {
+                "id": tw.id,
+                "name": tw.name,
+                "currency": tw.currency.value if hasattr(tw.currency, "value") else tw.currency,
+            },
+            "actualWallets": actual_details,
+            "theoreticalTotal": str(theoretical_total),
+            "actualTotal": str(actual_total),
+            "diff": str(theoretical_total - actual_total),
+        })
+    return report

--- a/tests/test_xbox_p0_2_api.py
+++ b/tests/test_xbox_p0_2_api.py
@@ -628,6 +628,132 @@ def test_orders_filtered_by_date_range(client):
     assert nos == {"D-5"}
 
 
+def test_reconcile_mapping_crud_with_currency_validation(client):
+    """对账映射 CRUD + 币种一致性校验。"""
+    # 取理论值"丙火网络" (CNY) + 实际值"丙火网络支付宝" (CNY)
+    th_id = _get_pool_wallet_id("丙火网络")
+    ac_id = _get_pool_wallet_id("丙火网络支付宝")
+
+    # 创建
+    r = client.post("/xbox/reconcile-mappings", json={
+        "theoreticalWalletId": th_id, "actualWalletId": ac_id
+    })
+    assert r.status_code == 201, r.text
+    mapping_id = r.json()["id"]
+
+    # 列表
+    rs = client.get("/xbox/reconcile-mappings").json()
+    assert any(m["id"] == mapping_id for m in rs)
+
+    # 重复创建 → 400
+    r2 = client.post("/xbox/reconcile-mappings", json={
+        "theoreticalWalletId": th_id, "actualWalletId": ac_id
+    })
+    assert r2.status_code == 400
+    assert "已存在" in r2.json()["detail"]
+
+    # 删除
+    rd = client.delete(f"/xbox/reconcile-mappings/{mapping_id}")
+    assert rd.status_code == 204
+
+
+def test_reconcile_mapping_currency_mismatch_400(client):
+    """理论 CNY 配实际 USDT → 400。"""
+    th_id = _get_pool_wallet_id("丙火网络")  # CNY
+    usdt = _get_pool_wallet_id("FREEMAN币安")  # USDT
+    r = client.post("/xbox/reconcile-mappings", json={
+        "theoreticalWalletId": th_id, "actualWalletId": usdt
+    })
+    assert r.status_code == 400
+    assert "币种" in r.json()["detail"]
+
+
+def test_reconcile_mapping_theoretical_must_be_xbox_sales_ledger(client):
+    """理论值必须是 XBOX_SALES_LEDGER 大类。"""
+    other = _get_pool_wallet_id("丙火网络支付宝")  # 资产 RMB
+    actual = _get_pool_wallet_id("丙火网络")  # XBOX_SALES_LEDGER
+    r = client.post("/xbox/reconcile-mappings", json={
+        "theoreticalWalletId": other,  # 不对
+        "actualWalletId": actual,
+    })
+    assert r.status_code == 400
+
+
+def test_reconcile_report_shows_diff_per_theoretical_wallet(client):
+    """对账报告：建映射 → 录入销售 → 对账显示理论 ≠ 实际差异。"""
+    from src.models.wallet import credit
+    from datetime import date as date_cls
+
+    pool_a_id = _get_pool_wallet_id("丙火网络支付宝")  # 实际值
+    th_id = _get_pool_wallet_id("丙火网络")  # 理论值
+
+    # 建映射
+    client.post("/xbox/reconcile-mappings", json={
+        "theoreticalWalletId": th_id, "actualWalletId": pool_a_id
+    })
+
+    # 在实际值钱包注入一笔 IN（5/8 ¥1000）
+    db = database.SessionLocal()
+    try:
+        from src.models.wallet import WalletTransaction, TransactionDirection
+        from datetime import datetime as datetime_cls
+
+        wallet = db.get(Wallet, pool_a_id)
+        tx = WalletTransaction(
+            wallet_id=pool_a_id,
+            amount=Decimal("1000"),
+            direction=TransactionDirection.IN.value,
+            remark="实际入账",
+            created_at=datetime_cls(2026, 5, 8, 10, 0, 0),
+            business_date=date_cls(2026, 5, 8),
+        )
+        db.add(tx)
+        wallet.balance = Decimal(wallet.balance) + Decimal("1000")
+        db.commit()
+    finally:
+        db.close()
+
+    # 录入一条 XBOX 销售记录到理论值（5/8 ¥800）
+    # 用 XboxSaleRecord 直接 insert 跳过补齐流程
+    from src.models.xbox import XboxSaleRecord
+    from datetime import date as _date
+
+    db = database.SessionLocal()
+    try:
+        # 找一个 method/item 配丙火网络
+        method_id = client.get("/xbox/wallet-settings").json()[0]["id"]
+        item_id = client.get("/xbox/wallet-settings").json()[0]["items"][0]["id"]
+
+        account = _create_account(client, "RECON-1")
+        record = XboxSaleRecord(
+            account_id=int(account["id"]),
+            sale_date=_date(2026, 5, 8),
+            product_name="测试商品",
+            operator_name="客服A",
+            sale_price=Decimal("800"),
+            sale_currency="CNY",
+            wallet_method_id=method_id,
+            wallet_item_id=item_id,
+            wallet_item_label="丙火网络",
+            wallet_pool_id=th_id,
+        )
+        db.add(record)
+        db.commit()
+    finally:
+        db.close()
+
+    # 调对账报告
+    r = client.get("/xbox/reconcile?date=2026-05-08")
+    assert r.status_code == 200, r.text
+    report = r.json()
+
+    # 找理论"丙火网络"那一行
+    binghuo = next(row for row in report if row["theoreticalWallet"]["id"] == th_id)
+    assert Decimal(binghuo["theoreticalTotal"]) == Decimal("800")
+    assert Decimal(binghuo["actualTotal"]) == Decimal("1000")
+    assert Decimal(binghuo["diff"]) == Decimal("-200")  # 理论 800 - 实际 1000
+
+
 def test_xbox_only_pool_options_excludes_other_categories(client):
     """xboxOnly=false 才返回所有大类。"""
     r1 = client.get("/xbox/wallet-pool-options")  # default true


### PR DESCRIPTION
CEO 2026-05-08 选 2 对账功能,Q1A+Q2A+Q3A+Q4A 全 A 方案。

后端: 新表 xbox_reconcile_mappings + 5 端点(映射 CRUD + 报告)。
前端: 第 5 个 tab '对账',含日期筛选 + 加映射弹窗 + 差异展示。

测试 190/190 通过(新增 4)。