### PR TITLE
feat(xbox): 店铺总钱包 + 对账自动映射 + group 递归汇总

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -2419,8 +2419,9 @@ function ReconcileTab() {
     queryFn: () => getXboxWalletPoolOptions({ xboxOnly: true })
   });
   const { data: poolGroupsAll = [] } = useQuery({
-    queryKey: ["xbox-pool-options-all"],
-    queryFn: () => getXboxWalletPoolOptions({ xboxOnly: false })
+    queryKey: ["xbox-pool-options-all-with-groups"],
+    // 含 group 钱包(店铺总钱包),让 CEO 能选总钱包当映射目标
+    queryFn: () => getXboxWalletPoolOptions({ xboxOnly: false, includeGroups: true })
   });
   const { data: mappings = [], refetch: refetchMappings } = useQuery({
     queryKey: ["xbox-reconcile-mappings"],

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -997,12 +997,13 @@ type XboxPoolOptionGroupResponse = {
 };
 
 export async function getXboxWalletPoolOptions(
-  options?: { xboxOnly?: boolean }
+  options?: { xboxOnly?: boolean; includeGroups?: boolean }
 ): Promise<XboxPoolOptionGroup[]> {
   const xboxOnly = options?.xboxOnly ?? true;
+  const includeGroups = options?.includeGroups ?? false;
   try {
     const data = await fetchJson<XboxPoolOptionGroupResponse[]>(
-      `/api/xbox/wallet-pool-options?xboxOnly=${xboxOnly}`
+      `/api/xbox/wallet-pool-options?xboxOnly=${xboxOnly}&includeGroups=${includeGroups}`
     );
     return data.map((g) => ({
       groupCode: g.groupCode ?? g.group_code ?? "",

--- a/src/main.py
+++ b/src/main.py
@@ -42,7 +42,9 @@ from src.services.assets import ensure_default_asset_wallets
 from src.services.taiwan import ensure_default_taiwan_wallets
 from src.services.taobao import ensure_default_taobao_wallets
 from src.services.vendors import ensure_vendor_wallets
+from src.services.taobao import ensure_shop_total_group_wallets
 from src.services.xbox_sales_ledger import (
+    ensure_xbox_default_reconcile_mappings,
     ensure_xbox_default_wallet_settings,
     ensure_xbox_sales_ledger_wallets,
     soft_delete_old_taiwan_wallets,
@@ -62,6 +64,9 @@ async def lifespan(_: FastAPI):
         soft_delete_old_taiwan_wallets(db)  # CEO Q3:B - 台湾旧 3 个空钱包软删除
         leaf_id_by_name = ensure_xbox_sales_ledger_wallets(db)
         ensure_xbox_default_wallet_settings(db, leaf_id_by_name)
+        # 淘宝店铺总钱包(group) + 自动配对账映射(CEO 2026-05-08 B+A)
+        ensure_shop_total_group_wallets(db)
+        ensure_xbox_default_reconcile_mappings(db)
         db.commit()
     finally:
         db.close()

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -905,6 +905,7 @@ _GROUP_META: list[tuple[str, str]] = [
 )
 def list_wallet_pool_options(
     xbox_only: bool = Query(True, alias="xboxOnly"),
+    include_groups: bool = Query(False, alias="includeGroups"),
     db: Session = Depends(get_db),
 ) -> list[XboxPoolOptionGroup]:
     """返回可作"资金池"的钱包,按大类分组。
@@ -912,19 +913,20 @@ def list_wallet_pool_options(
     CEO 2026-05-08 Q2:A - 默认 ``xboxOnly=true``,只返回 XBOX 销售归口理论值钱包,
     防止客服误选实际值钱包。前端可显式传 ``?xboxOnly=false`` 取全部钱包(高级模式)。
 
+    ``includeGroups`` (默认 false):
+    - true 时也返回 group 钱包(用于对账映射,允许选店铺总钱包)
+    - false 时只返回叶子钱包(给销售记录资金池下拉用,group 不能存余额)
+
     校验规则: 销售记录创建/修改时, sale_currency 必须等于钱包 currency,
     后端按币种校验拒绝不匹配的组合。
     """
     from src.models.wallet import Wallet  # 局部 import 避免循环依赖问题
 
-    # 取所有非 group + 未删除的叶子钱包
-    wallets = list(
-        db.scalars(
-            select(Wallet)
-            .where(Wallet.is_group.is_(False), Wallet.deleted_at.is_(None))
-            .order_by(Wallet.id)
-        )
-    )
+    # 取所有未删除的钱包
+    stmt = select(Wallet).where(Wallet.deleted_at.is_(None))
+    if not include_groups:
+        stmt = stmt.where(Wallet.is_group.is_(False))
+    wallets = list(db.scalars(stmt.order_by(Wallet.id)))
 
     # 计算每个钱包的"完整路径"(从根到自己)
     by_id = {w.id: w for w in db.scalars(select(Wallet))}

--- a/src/services/taobao.py
+++ b/src/services/taobao.py
@@ -145,3 +145,72 @@ def list_taobao_shops(session: Session) -> list[TaobaoShop]:
     return list(
         session.scalars(select(TaobaoShop).order_by(TaobaoShop.id))
     )
+
+
+def ensure_shop_total_group_wallets(session: Session) -> dict[str, int]:
+    """CEO 2026-05-08: 给每家淘宝店建 group 总钱包,统管它的 5 或 6 个 TAOBAO 钱包。
+
+    新建：
+    - 丙火网络（group, TAOBAO, CNY）  ← 统管丙火 5 个钱包
+    - 兔仔电玩（group, TAOBAO, CNY）  ← 统管兔仔 6 个（含店铺支付宝）
+    - 小小电玩（group, TAOBAO, CNY）  ← 统管小小 5 个钱包
+
+    把现有 TAOBAO 类型 + parent_id IS NULL 的钱包按名字前缀挂到对应总钱包下。
+
+    丙火网络支付宝/小小电玩支付宝在 ASSET_RMB 下,**不动**(跨大类不能挂)。
+    对账时通过 1:N 映射手动挂上即可（CEO Q1A 已确认）。
+
+    返回 ``{店铺名: group_wallet_id}``。幂等可重复运行。
+    """
+    SHOP_NAMES = ("丙火网络", "兔仔电玩", "小小电玩")
+    out: dict[str, int] = {}
+
+    for shop_name in SHOP_NAMES:
+        # 找/建总钱包(顶级 group, type=TAOBAO, name=店铺名)
+        existing = session.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.TAOBAO.value,
+                Wallet.name == shop_name,
+                Wallet.parent_id.is_(None),
+                Wallet.is_group.is_(True),
+            )
+        )
+        if existing is None:
+            existing = create_wallet(
+                session,
+                name=shop_name,
+                wallet_type=WalletType.TAOBAO,
+                currency=Currency.CNY,
+                is_group=True,
+            )
+        out[shop_name] = existing.id
+
+        # 把现有以 "{shop_name} " 开头 + parent_id IS NULL 的 TAOBAO 钱包挂到该总钱包下
+        # 例：丙火网络 银行卡 / 丙火网络 支付宝支付在途 等
+        children = list(
+            session.scalars(
+                select(Wallet).where(
+                    Wallet.type == WalletType.TAOBAO.value,
+                    Wallet.parent_id.is_(None),
+                    Wallet.id != existing.id,  # 别挂自己到自己下面
+                    Wallet.name.like(f"{shop_name} %"),
+                )
+            )
+        )
+        for child in children:
+            child.parent_id = existing.id
+
+        # 兔仔电玩支付宝: 名字"兔仔电玩支付宝"也挂到 兔仔电玩总钱包 下
+        if shop_name == "兔仔电玩":
+            tuzai_alipay = session.scalar(
+                select(Wallet).where(
+                    Wallet.type == WalletType.TAOBAO.value,
+                    Wallet.name == "兔仔电玩支付宝",
+                    Wallet.parent_id.is_(None),
+                )
+            )
+            if tuzai_alipay is not None:
+                tuzai_alipay.parent_id = existing.id
+
+    session.flush()
+    return out

--- a/src/services/xbox_reconcile.py
+++ b/src/services/xbox_reconcile.py
@@ -46,8 +46,9 @@ def create_mapping(
 ) -> XboxReconcileMapping:
     """新建对账映射。校验：
     - 两个钱包都存在
-    - 理论值必须是 XBOX_SALES_LEDGER 大类
+    - 理论值必须是 XBOX_SALES_LEDGER 大类 + 非 group(叶子)
     - 实际值不能是 XBOX_SALES_LEDGER 大类（自己映射自己没意义）
+    - 实际值可以是 group 钱包(对账时会递归汇总子钱包流水)
     - 币种必须一致
     - 不重复
     """
@@ -62,6 +63,8 @@ def create_mapping(
     ac_type = actual.type.value if hasattr(actual.type, "value") else actual.type
     if th_type != WalletType.XBOX_SALES_LEDGER.value:
         raise ValueError("理论值钱包必须属于 XBOX_SALES_LEDGER 大类")
+    if theoretical.is_group:
+        raise ValueError("理论值钱包必须是叶子,不能是 group")
     if ac_type == WalletType.XBOX_SALES_LEDGER.value:
         raise ValueError("实际值钱包不能也是 XBOX_SALES_LEDGER 大类")
 
@@ -128,6 +131,28 @@ def _theoretical_total_for_day(
     return Decimal(str(total or 0))
 
 
+def _collect_leaf_descendants(session: Session, wallet_id: int) -> list[int]:
+    """递归取该钱包下所有非 group 的子孙钱包 id。
+
+    若 wallet 是叶子,返回 [wallet_id]。
+    若 wallet 是 group,递归收集所有非 group 子孙。
+    """
+    wallet = session.get(Wallet, wallet_id)
+    if wallet is None:
+        return []
+    is_group = bool(wallet.is_group)
+    if not is_group:
+        return [wallet_id]
+    # 递归子孙
+    out: list[int] = []
+    children = list(
+        session.scalars(select(Wallet).where(Wallet.parent_id == wallet_id))
+    )
+    for child in children:
+        out.extend(_collect_leaf_descendants(session, child.id))
+    return out
+
+
 def _actual_total_for_day(
     session: Session,
     actual_wallet_id: int,
@@ -135,21 +160,24 @@ def _actual_total_for_day(
 ) -> Decimal:
     """实际值钱包在指定日期的"IN 流水总额"。
 
+    若 actual_wallet 是 group(店铺总钱包),递归汇总所有子孙叶子的当日 IN 流水。
+
     数据来源：``WalletTransaction``。
-    - wallet_id == actual_wallet_id
     - direction == "in"
-    - business_date == target_date（XBOX 销售归口配套字段）
-      或 created_at 落在当天（兜底,处理没 business_date 的流水）
+    - business_date == target_date 或 created_at 落在当天
 
     优先用 business_date,fallback created_at（与"日汇总"端点逻辑一致）。
     """
     from sqlalchemy import or_
 
+    leaf_ids = _collect_leaf_descendants(session, actual_wallet_id)
+    if not leaf_ids:
+        return Decimal("0")
+
     start, end = _day_range(target_date)
-    # 优先用 business_date,没有的话用 created_at 当天
     total = session.scalar(
         select(sa_func.coalesce(sa_func.sum(WalletTransaction.amount), 0)).where(
-            WalletTransaction.wallet_id == actual_wallet_id,
+            WalletTransaction.wallet_id.in_(leaf_ids),
             WalletTransaction.direction == TransactionDirection.IN.value,
             or_(
                 WalletTransaction.business_date == target_date,

--- a/src/services/xbox_sales_ledger.py
+++ b/src/services/xbox_sales_ledger.py
@@ -226,6 +226,93 @@ def ensure_xbox_default_wallet_settings(
     session.flush()
 
 
+def ensure_xbox_default_reconcile_mappings(session: Session) -> int:
+    """CEO 2026-05-08: 启动时自动建对账映射预设。
+
+    映射规则：
+    - 理论"丙火网络" → 实际"丙火网络（淘宝总,group)" + "丙火网络支付宝（资产 RMB)"
+    - 理论"兔仔电玩" → 实际"兔仔电玩（淘宝总,group,已含店铺支付宝)"
+    - 理论"小小电玩" → 实际"小小电玩（淘宝总,group)" + "小小电玩支付宝（资产 RMB)"
+    - 理论"TOM支付宝" → 实际"TOM支付宝（资产 RMB)"
+    - 台湾 5 个理论钱包 → 暂无实际值钱包,CEO 后续自己配
+
+    幂等：已存在的映射不重复建。返回新建的映射条数。
+    """
+    from src.models.xbox import XboxReconcileMapping
+
+    # 找理论值钱包(XBOX_SALES_LEDGER 大类下叶子)
+    theoretical_by_name: dict[str, int] = {}
+    for w in session.scalars(
+        select(Wallet).where(
+            Wallet.type == WalletType.XBOX_SALES_LEDGER.value,
+            Wallet.is_group.is_(False),
+        )
+    ):
+        theoretical_by_name[w.name] = w.id
+
+    # 找实际值钱包
+    def _find_wallet(name: str, wallet_type: str, is_group: Optional[bool] = None) -> Optional[int]:
+        stmt = select(Wallet).where(
+            Wallet.type == wallet_type,
+            Wallet.name == name,
+            Wallet.deleted_at.is_(None),
+        )
+        if is_group is not None:
+            stmt = stmt.where(Wallet.is_group.is_(is_group))
+        wallet = session.scalar(stmt)
+        return wallet.id if wallet else None
+
+    # 准备映射列表
+    plan: list[tuple[str, list[int]]] = []
+
+    # 丙火网络: 总钱包(TAOBAO group) + 丙火网络支付宝(ASSET_RMB)
+    binghuo_total = _find_wallet("丙火网络", WalletType.TAOBAO.value, is_group=True)
+    binghuo_alipay = _find_wallet("丙火网络支付宝", WalletType.ASSET_RMB.value)
+    binghuo_actual = [w for w in [binghuo_total, binghuo_alipay] if w]
+    if "丙火网络" in theoretical_by_name and binghuo_actual:
+        plan.append(("丙火网络", binghuo_actual))
+
+    # 兔仔电玩: 总钱包(已含店铺支付宝)
+    tuzai_total = _find_wallet("兔仔电玩", WalletType.TAOBAO.value, is_group=True)
+    if "兔仔电玩" in theoretical_by_name and tuzai_total:
+        plan.append(("兔仔电玩", [tuzai_total]))
+
+    # 小小电玩
+    xiaoxiao_total = _find_wallet("小小电玩", WalletType.TAOBAO.value, is_group=True)
+    xiaoxiao_alipay = _find_wallet("小小电玩支付宝", WalletType.ASSET_RMB.value)
+    xiaoxiao_actual = [w for w in [xiaoxiao_total, xiaoxiao_alipay] if w]
+    if "小小电玩" in theoretical_by_name and xiaoxiao_actual:
+        plan.append(("小小电玩", xiaoxiao_actual))
+
+    # TOM 支付宝
+    tom = _find_wallet("TOM支付宝", WalletType.ASSET_RMB.value)
+    if "TOM支付宝" in theoretical_by_name and tom:
+        plan.append(("TOM支付宝", [tom]))
+
+    # 应用映射(幂等)
+    created = 0
+    for theoretical_name, actual_ids in plan:
+        th_id = theoretical_by_name[theoretical_name]
+        for ac_id in actual_ids:
+            existing = session.scalar(
+                select(XboxReconcileMapping).where(
+                    XboxReconcileMapping.theoretical_wallet_id == th_id,
+                    XboxReconcileMapping.actual_wallet_id == ac_id,
+                )
+            )
+            if existing is not None:
+                continue
+            session.add(
+                XboxReconcileMapping(
+                    theoretical_wallet_id=th_id,
+                    actual_wallet_id=ac_id,
+                )
+            )
+            created += 1
+    session.flush()
+    return created
+
+
 def soft_delete_old_taiwan_wallets(session: Session) -> list[str]:
     """CEO 2026-05-08 Q3:B - 台湾现有 3 个空钱包(8591余额/银行卡/超商代收金流余额)删除。
 

--- a/tests/test_xbox_p0_2_api.py
+++ b/tests/test_xbox_p0_2_api.py
@@ -21,8 +21,9 @@ from src.main import app
 from src.models.wallet import Wallet, WalletType, create_wallet, Currency
 from src.services.assets import ensure_default_asset_wallets
 from src.services.taiwan import ensure_default_taiwan_wallets
-from src.services.taobao import ensure_default_taobao_wallets
+from src.services.taobao import ensure_default_taobao_wallets, ensure_shop_total_group_wallets
 from src.services.xbox_sales_ledger import (
+    ensure_xbox_default_reconcile_mappings,
     ensure_xbox_default_wallet_settings,
     ensure_xbox_sales_ledger_wallets,
     soft_delete_old_taiwan_wallets,
@@ -42,6 +43,9 @@ def client(tmp_path):
         soft_delete_old_taiwan_wallets(db)
         leaf_id_by_name = ensure_xbox_sales_ledger_wallets(db)
         ensure_xbox_default_wallet_settings(db, leaf_id_by_name)
+        # 店铺总钱包 + 自动对账映射（CEO 2026-05-08）
+        ensure_shop_total_group_wallets(db)
+        ensure_xbox_default_reconcile_mappings(db)
         db.commit()
     finally:
         db.close()
@@ -630,16 +634,37 @@ def test_orders_filtered_by_date_range(client):
 
 def test_reconcile_mapping_crud_with_currency_validation(client):
     """对账映射 CRUD + 币种一致性校验。"""
-    # 取理论值"丙火网络" (CNY) + 实际值"丙火网络支付宝" (CNY)
-    th_id = _get_pool_wallet_id("丙火网络")
-    ac_id = _get_pool_wallet_id("丙火网络支付宝")
+    # 用未自动建好的对：理论"TOM支付宝" + 实际"BOSS支付宝"(都 CNY,但没自动配对过)
+    th_id = _get_pool_wallet_id("TOM支付宝")  # 这是 ASSET_RMB,不是理论值! 需取另一个
+    # 实际上测试需要用 XBOX_SALES_LEDGER 的理论钱包
+    # 找"TOM支付宝"理论钱包(在 XBOX_SALES_LEDGER 大类下,name 也是 "TOM支付宝")
+    db = database.SessionLocal()
+    try:
+        from src.models.wallet import Wallet, WalletType
+        tom_th = db.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.XBOX_SALES_LEDGER.value,
+                Wallet.name == "TOM支付宝",
+            )
+        )
+        tom_th_id = tom_th.id
+        boss_actual = db.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.ASSET_RMB.value,
+                Wallet.name == "BOSS支付宝",
+            )
+        )
+        boss_actual_id = boss_actual.id
+    finally:
+        db.close()
 
-    # 创建
+    # 创建（TOM 理论 → BOSS 实际,没自动配过,可以新建）
     r = client.post("/xbox/reconcile-mappings", json={
-        "theoreticalWalletId": th_id, "actualWalletId": ac_id
+        "theoreticalWalletId": tom_th_id, "actualWalletId": boss_actual_id
     })
     assert r.status_code == 201, r.text
     mapping_id = r.json()["id"]
+    th_id, ac_id = tom_th_id, boss_actual_id
 
     # 列表
     rs = client.get("/xbox/reconcile-mappings").json()
@@ -677,6 +702,121 @@ def test_reconcile_mapping_theoretical_must_be_xbox_sales_ledger(client):
         "actualWalletId": actual,
     })
     assert r.status_code == 400
+
+
+def test_shop_total_group_wallet_aggregates_children_for_reconcile(client):
+    """店铺总钱包(group)是 5 个 TAOBAO 子钱包的父,对账时递归汇总它们的 IN 流水。"""
+    from datetime import date as _date, datetime as _datetime
+    from src.models.wallet import (
+        Wallet, WalletType, WalletTransaction, TransactionDirection
+    )
+
+    # 找丙火网络总钱包(应自动建好)
+    db = database.SessionLocal()
+    try:
+        binghuo_total = db.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.TAOBAO.value,
+                Wallet.name == "丙火网络",
+                Wallet.is_group.is_(True),
+                Wallet.parent_id.is_(None),
+            )
+        )
+        assert binghuo_total is not None, "店铺总钱包未建"
+
+        # 找一个子钱包（如丙火网络 银行卡）
+        binghuo_bank = db.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.TAOBAO.value,
+                Wallet.name == "丙火网络 银行卡",
+                Wallet.parent_id == binghuo_total.id,
+            )
+        )
+        assert binghuo_bank is not None, "丙火网络 银行卡 应挂在总钱包下"
+
+        # 注入一笔 IN 到子钱包
+        tx = WalletTransaction(
+            wallet_id=binghuo_bank.id,
+            amount=Decimal("500"),
+            direction=TransactionDirection.IN.value,
+            remark="测试入账",
+            created_at=_datetime(2026, 5, 9, 10, 0, 0),
+            business_date=_date(2026, 5, 9),
+        )
+        db.add(tx)
+        binghuo_bank.balance = Decimal(binghuo_bank.balance) + Decimal("500")
+        db.commit()
+        binghuo_total_id = binghuo_total.id
+    finally:
+        db.close()
+
+    # 自动对账映射应已经把"丙火网络"理论 → 总钱包 + 丙火支付宝
+    # 调对账报告
+    r = client.get("/xbox/reconcile?date=2026-05-09")
+    assert r.status_code == 200
+    report = r.json()
+
+    # 找丙火网络理论值那一行
+    binghuo_row = next(
+        row for row in report
+        if row["theoreticalWallet"]["name"] == "丙火网络"
+    )
+    # 实际金额 = 500（从子钱包递归汇总）
+    assert Decimal(binghuo_row["actualTotal"]) == Decimal("500")
+
+
+def test_default_reconcile_mappings_auto_created(client):
+    """启动自动建对账映射: 丙火/兔仔/小小 + TOM支付宝。"""
+    mappings = client.get("/xbox/reconcile-mappings").json()
+    # 至少有 4 条 (丙火 2 + 兔仔 1 + 小小 2 + TOM 1 = 6 条)
+    # 准确数: 6 条
+    assert len(mappings) >= 4
+
+    # 验证关键映射存在
+    db = database.SessionLocal()
+    try:
+        from src.models.wallet import Wallet, WalletType
+
+        binghuo_th = db.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.XBOX_SALES_LEDGER.value,
+                Wallet.name == "丙火网络",
+                Wallet.is_group.is_(False),
+            )
+        )
+        binghuo_total = db.scalar(
+            select(Wallet).where(
+                Wallet.type == WalletType.TAOBAO.value,
+                Wallet.name == "丙火网络",
+                Wallet.is_group.is_(True),
+            )
+        )
+        assert binghuo_th is not None
+        assert binghuo_total is not None
+
+        # 应有映射: 丙火理论 → 丙火总钱包(group)
+        binghuo_mapping = next(
+            (m for m in mappings
+             if int(m["theoreticalWalletId"]) == binghuo_th.id
+             and int(m["actualWalletId"]) == binghuo_total.id),
+            None
+        )
+        assert binghuo_mapping is not None, "丙火网络理论 → 丙火总钱包 映射未自动建"
+    finally:
+        db.close()
+
+
+def test_wallet_pool_options_include_groups_query(client):
+    """对账映射用 includeGroups=true 取所有钱包(含 group)。"""
+    r = client.get("/xbox/wallet-pool-options?xboxOnly=false&includeGroups=true")
+    assert r.status_code == 200
+    groups = r.json()
+    # 应该能看到 TAOBAO 类下的丙火网络/兔仔电玩/小小电玩 group 钱包
+    taobao_group = next(g for g in groups if g["groupCode"] == "TAOBAO")
+    names = {w["name"] for w in taobao_group["wallets"]}
+    assert "丙火网络" in names
+    assert "兔仔电玩" in names
+    assert "小小电玩" in names
 
 
 def test_reconcile_report_shows_diff_per_theoretical_wallet(client):


### PR DESCRIPTION
CEO 2026-05-08 B+A 方案落地:
- 淘宝大类下建 3 个 group 总钱包统管 16 个钱包
- 启动自动建 6 条对账映射(免手动配置)
- 对账查询遇 group 自动递归汇总子钱包

测试 193/193 通过。