### PR TITLE
feat(xbox): 销售日期自动 = 微软订单时间(精确到秒) + 同步更新账号余额

### DIFF
--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -104,6 +104,12 @@ function formatDateTime(value: string) {
   return value.length >= 16 ? value.slice(0, 16).replace("T", " ") : value;
 }
 
+// CEO 2026-05-12: 销售日期/时间显示到秒(中国时区)
+function formatDateTimeSeconds(value: string) {
+  if (!value) return "-";
+  return value.length >= 19 ? value.slice(0, 19).replace("T", " ") : value;
+}
+
 function SummaryCards({ country }: { country: XboxCountry }) {
   const { data, isFetching, refetch } = useQuery({
     queryKey: ["xbox-summary"],
@@ -1611,9 +1617,8 @@ function CompleteOrderModal({
   onClose: () => void;
 }) {
   const queryClient = useQueryClient();
-  const [saleDate, setSaleDate] = useState(
-    order.saleDate ?? new Date().toISOString().slice(0, 10)
-  );
+  // CEO 2026-05-12: 销售日期 = 微软订单时间(order.orderAt),系统自动填,只读
+  const saleDate = order.saleDate ?? order.orderAt ?? "";
   const [productName, setProductName] = useState(order.productName ?? "");
   const [operatorName, setOperatorName] = useState(order.operatorName ?? "");
   const [salePrice, setSalePrice] = useState(
@@ -1651,8 +1656,8 @@ function CompleteOrderModal({
       if (!salePrice.trim()) throw new Error("售价不能为空");
       if (!walletMethodId) throw new Error("请选收款方式");
       if (!walletItemId) throw new Error("请选备注模板");
+      // saleDate 不再传 — 后端创建订单时已自动 = order_at(中国时区精确到秒)
       return patchXboxOrder(order.id, {
-        saleDate,
         productName: productName.trim(),
         operatorName: operatorName.trim(),
         salePrice: salePrice.trim(),
@@ -1717,13 +1722,10 @@ function CompleteOrderModal({
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="space-y-1">
-            <div className="text-sm text-muted-foreground">销售日期 *</div>
-            <input
-              type="date"
-              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
-              value={saleDate}
-              onChange={(event) => setSaleDate(event.target.value)}
-            />
+            <div className="text-sm text-muted-foreground">销售日期（系统自动，精确到秒）</div>
+            <div className="h-10 flex items-center rounded-md border border-border bg-muted px-3 text-sm tabular-nums text-muted-foreground">
+              {formatDateTimeSeconds(saleDate) || "-"}
+            </div>
           </div>
           <div className="space-y-1">
             <div className="text-sm text-muted-foreground">商品名 *</div>
@@ -2292,7 +2294,7 @@ function SaleRecordsTab({ highlightId }: { highlightId?: string | null }) {
                 const isHighlighted = highlightId === record.id;
                 return (
                   <TableRow key={record.id} className={cn(isHighlighted && "bg-emerald-50")}>
-                    <TableCell className="text-xs tabular-nums">{record.saleDate}</TableCell>
+                    <TableCell className="text-xs tabular-nums">{formatDateTimeSeconds(record.saleDate)}</TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       {account?.accountNo ?? account?.name ?? "-"}
                     </TableCell>

--- a/src/database.py
+++ b/src/database.py
@@ -48,6 +48,7 @@ def init_db() -> None:
     _ensure_wallet_transaction_business_date_column()
     _ensure_xbox_account_extended_columns()
     _ensure_xbox_account_is_available_for_claim_column()
+    _migrate_xbox_sale_date_to_datetime()
 
 
 def _ensure_wallet_is_group_column() -> None:
@@ -126,6 +127,40 @@ def _ensure_xbox_account_is_available_for_claim_column() -> None:
         connection.execute(
             text("ALTER TABLE xbox_accounts ADD COLUMN is_available_for_claim BOOLEAN NOT NULL DEFAULT 0")
         )
+
+
+def _migrate_xbox_sale_date_to_datetime() -> None:
+    """CEO 2026-05-12: 把 xbox_sale_records.sale_date 和 xbox_orders.sale_date
+    从 DATE (YYYY-MM-DD) 升级为 DATETIME (YYYY-MM-DD HH:MM:SS.ffffff),
+    中国时区精确到秒。
+
+    SQLite 的列类型 affinity 很松散(DATE 和 DATETIME 都是 TEXT 存),所以
+    不需要 ALTER COLUMN,只把存量"YYYY-MM-DD"格式的旧值改成
+    "YYYY-MM-DD 00:00:00" 让 SQLAlchemy 能按 datetime 解析。
+    """
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+
+    inspector = inspect(engine)
+    table_names = inspector.get_table_names()
+
+    with engine.begin() as connection:
+        # xbox_sale_records.sale_date (NOT NULL)
+        if "xbox_sale_records" in table_names:
+            connection.execute(
+                text(
+                    "UPDATE xbox_sale_records SET sale_date = sale_date || ' 00:00:00' "
+                    "WHERE sale_date IS NOT NULL AND length(sale_date) = 10"
+                )
+            )
+        # xbox_orders.sale_date (nullable)
+        if "xbox_orders" in table_names:
+            connection.execute(
+                text(
+                    "UPDATE xbox_orders SET sale_date = sale_date || ' 00:00:00' "
+                    "WHERE sale_date IS NOT NULL AND length(sale_date) = 10"
+                )
+            )
 
 
 def _ensure_wallet_transaction_business_date_column() -> None:

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -180,7 +180,9 @@ class XboxOrder(Base):
         String(32), nullable=False, default=XboxOrderStatus.PENDING_COMPLETE.value
     )
     # 补齐字段（运营填写）
-    sale_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    # CEO 2026-05-12: sale_date 从 DATE 升级为 DATETIME(中国时区,精确到秒)
+    # 销售记录创建时自动 = order_at(微软抓订单的时间),客服无需手填
+    sale_date: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     product_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     operator_name: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     sale_price: Mapped[Optional[Decimal]] = mapped_column(Numeric(18, 6), nullable=True)
@@ -218,7 +220,9 @@ class XboxSaleRecord(Base):
     account_id: Mapped[int] = mapped_column(
         ForeignKey("xbox_accounts.id"), nullable=False, index=True
     )
-    sale_date: Mapped[date] = mapped_column(Date, nullable=False)
+    # CEO 2026-05-12: sale_date 从 DATE 升级为 DATETIME(中国时区,精确到秒)
+    # 系统自动 = 对应订单的 order_at(微软抓订单的时间),客服无需手填
+    sale_date: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     product_name: Mapped[str] = mapped_column(String(255), nullable=False)
     operator_name: Mapped[str] = mapped_column(String(64), nullable=False)
     # 售价（合单后总金额,可改）

--- a/src/routers/xbox.py
+++ b/src/routers/xbox.py
@@ -543,11 +543,15 @@ class XboxOrderCreate(BaseModel):
 
 
 class XboxOrderCompletion(BaseModel):
-    """订单补齐字段。全部填齐后自动转销售记录。"""
+    """订单补齐字段。全部填齐后自动转销售记录。
+
+    CEO 2026-05-12: 销售日期(sale_date)系统自动填(= 订单时间, 中国时区精确到秒),
+    客服无需传; 传了也会接受(datetime 字符串, ISO 8601)。
+    """
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
 
-    sale_date: Optional[date] = None
+    sale_date: Optional[datetime] = None
     product_name: Optional[str] = Field(None, min_length=1, max_length=255)
     operator_name: Optional[str] = Field(None, min_length=1, max_length=64)
     sale_price: Optional[Decimal] = None
@@ -601,11 +605,14 @@ class XboxSaleRecordOut(BaseModel):
 
 
 class XboxSaleRecordUpdate(BaseModel):
-    """改销售记录字段。后端自动联动钱包余额。"""
+    """改销售记录字段。后端自动联动钱包余额。
+
+    CEO 2026-05-12: sale_date 是 datetime(中国时区精确到秒), CEO 后台可改。
+    """
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
 
-    sale_date: Optional[date] = None
+    sale_date: Optional[datetime] = None
     product_name: Optional[str] = None
     operator_name: Optional[str] = None
     sale_price: Optional[Decimal] = None

--- a/src/services/xbox_order.py
+++ b/src/services/xbox_order.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, Union
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -87,6 +87,8 @@ def create_order(
         exchange_rate=used_rate_value,
         rmb_cost=rmb_cost,
         order_at=order_at,
+        # CEO 2026-05-12: 销售日期 = 微软订单时间(中国时区精确到秒),系统自动填
+        sale_date=order_at,
         raw_data=raw_data,
         status=XboxOrderStatus.PENDING_COMPLETE.value,
     )
@@ -105,7 +107,7 @@ def update_order_completion(
     session: Session,
     order: XboxOrder,
     *,
-    sale_date: Optional[date] = None,
+    sale_date: Union[date, datetime, None] = None,
     product_name: Optional[str] = None,
     operator_name: Optional[str] = None,
     sale_price: Optional[Decimal] = None,
@@ -117,9 +119,16 @@ def update_order_completion(
     """更新订单的补齐字段。所有必填都到位时自动转销售记录。
 
     返回 ``(order, sale_record_id_or_None)``。
+
+    CEO 2026-05-12: 销售日期(sale_date)默认 = order.order_at(微软抓订单的时间,
+    中国时区精确到秒,创建订单时已自动赋值)。客服一般无需传 sale_date;
+    传了会按 datetime 升级。
     """
     if sale_date is not None:
-        order.sale_date = sale_date
+        if isinstance(sale_date, date) and not isinstance(sale_date, datetime):
+            order.sale_date = datetime.combine(sale_date, datetime.min.time())
+        else:
+            order.sale_date = sale_date
     if product_name is not None:
         order.product_name = product_name
     if operator_name is not None:

--- a/src/services/xbox_reconcile.py
+++ b/src/services/xbox_reconcile.py
@@ -117,15 +117,20 @@ def _theoretical_total_for_day(
     """理论值钱包在指定日期的"流入总额"。
 
     数据来源：``XboxSaleRecord``。
-    - sale_date == target_date 且 wallet_pool_id == theoretical_wallet_id
+    - sale_date 落在 target_date 当天 [00:00, 次日 00:00)
+      且 wallet_pool_id == theoretical_wallet_id
     - 直接 sum(sale_price)（合单后的最新值）
+
+    CEO 2026-05-12: sale_date 升级为 datetime,所以按当天 datetime 范围筛而不是相等。
 
     注意: 不是从 wallet_transactions 取(那里有合单调整流水会重复算)。
     """
+    start, end = _day_range(target_date)
     total = session.scalar(
         select(sa_func.coalesce(sa_func.sum(XboxSaleRecord.sale_price), 0)).where(
             XboxSaleRecord.wallet_pool_id == theoretical_wallet_id,
-            XboxSaleRecord.sale_date == target_date,
+            XboxSaleRecord.sale_date >= start,
+            XboxSaleRecord.sale_date < end,
         )
     )
     return Decimal(str(total or 0))

--- a/src/services/xbox_sale.py
+++ b/src/services/xbox_sale.py
@@ -12,9 +12,9 @@
 """
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from decimal import Decimal
-from typing import Optional
+from typing import Optional, Union
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -96,11 +96,22 @@ def _find_existing_sale_record(
     )
 
 
+def _coerce_sale_datetime(value: Union[date, datetime, None]) -> Optional[datetime]:
+    """把 date 自动升 datetime(00:00:00),便于和旧调用方/测试兼容。"""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, date):
+        return datetime.combine(value, datetime.min.time())
+    return value
+
+
 def create_or_merge_sale_record(
     session: Session,
     *,
     account: XboxAccount,
-    sale_date: date,
+    sale_date: Union[date, datetime],
     product_name: str,
     operator_name: str,
     sale_price: Decimal,
@@ -118,11 +129,23 @@ def create_or_merge_sale_record(
 
     传入 ``order`` 时,会把订单的 sale_record_id 指向新/旧记录,
     并把订单 status 改成 converted。
+
+    CEO 2026-05-12: sale_date 是 datetime(中国时区精确到秒)。
+    当 ``order`` 提供时,如果 sale_date 是 date(只到天),会被升级为 order.order_at
+    (微软抓订单的时间)。
     """
     pool = _validate_pool_currency(session, wallet_pool_id, sale_currency)
     sale_price = Decimal(sale_price)
     if sale_price < 0:
         raise ValueError("销售价格不能为负数")
+
+    # 销售日期 → 一律 datetime;有订单时优先取 order.order_at
+    sale_dt = _coerce_sale_datetime(sale_date)
+    if order is not None and order.order_at is not None:
+        # CEO 2026-05-12: 销售日期 = 微软订单抓取时间(中国时区精确到秒)
+        sale_dt = order.order_at
+    if sale_dt is None:
+        raise ValueError("销售日期不能为空")
 
     existing = _find_existing_sale_record(session, account.id, wallet_item_id)
 
@@ -130,7 +153,7 @@ def create_or_merge_sale_record(
         # 新建销售记录
         record = XboxSaleRecord(
             account_id=account.id,
-            sale_date=sale_date,
+            sale_date=sale_dt,
             product_name=product_name,
             operator_name=operator_name,
             sale_price=sale_price,
@@ -220,7 +243,7 @@ def update_sale_record_fields(
     session: Session,
     record: XboxSaleRecord,
     *,
-    sale_date: Optional[date] = None,
+    sale_date: Union[date, datetime, None] = None,
     product_name: Optional[str] = None,
     operator_name: Optional[str] = None,
     sale_price: Optional[Decimal] = None,
@@ -311,7 +334,7 @@ def update_sale_record_fields(
 
     # 3) 更新其他普通字段
     if sale_date is not None:
-        record.sale_date = sale_date
+        record.sale_date = _coerce_sale_datetime(sale_date) or record.sale_date
     if product_name is not None:
         record.product_name = product_name
     if operator_name is not None:
@@ -328,6 +351,23 @@ def update_sale_record_fields(
     return record
 
 
+def _date_range_to_datetime_bounds(
+    from_date: Optional[date], to_date: Optional[date]
+) -> tuple[Optional[datetime], Optional[datetime]]:
+    """把传入的 date 范围转成 datetime 闭区间(用于和 sale_date(datetime)比较):
+    [from_date 00:00:00, (to_date+1天) 00:00:00).
+    """
+    from datetime import timedelta
+
+    lower: Optional[datetime] = None
+    upper: Optional[datetime] = None
+    if from_date is not None:
+        lower = datetime.combine(from_date, datetime.min.time())
+    if to_date is not None:
+        upper = datetime.combine(to_date, datetime.min.time()) + timedelta(days=1)
+    return lower, upper
+
+
 def list_sale_records(
     session: Session,
     *,
@@ -336,16 +376,17 @@ def list_sale_records(
     from_date: Optional[date] = None,
     to_date: Optional[date] = None,
 ) -> list[XboxSaleRecord]:
-    """列销售记录。按 sale_date 闭区间过滤。"""
+    """列销售记录。按 sale_date 闭区间过滤(传 date 时按当天 0 点 ~ 次日 0 点开区间)。"""
     stmt = select(XboxSaleRecord).order_by(XboxSaleRecord.id.desc())
     if account_id is not None:
         stmt = stmt.where(XboxSaleRecord.account_id == account_id)
     if wallet_pool_id is not None:
         stmt = stmt.where(XboxSaleRecord.wallet_pool_id == wallet_pool_id)
-    if from_date is not None:
-        stmt = stmt.where(XboxSaleRecord.sale_date >= from_date)
-    if to_date is not None:
-        stmt = stmt.where(XboxSaleRecord.sale_date <= to_date)
+    lower, upper = _date_range_to_datetime_bounds(from_date, to_date)
+    if lower is not None:
+        stmt = stmt.where(XboxSaleRecord.sale_date >= lower)
+    if upper is not None:
+        stmt = stmt.where(XboxSaleRecord.sale_date < upper)
     return list(session.scalars(stmt))
 
 
@@ -371,12 +412,13 @@ def get_sales_summary(
     from src.models.xbox import XboxOrder as _XboxOrder
     from src.models.xbox import XboxWalletItem, XboxWalletMethod
 
-    # 销售记录基础筛选
+    # 销售记录基础筛选(date → datetime 边界)
     base_filters = []
-    if from_date is not None:
-        base_filters.append(XboxSaleRecord.sale_date >= from_date)
-    if to_date is not None:
-        base_filters.append(XboxSaleRecord.sale_date <= to_date)
+    lower, upper = _date_range_to_datetime_bounds(from_date, to_date)
+    if lower is not None:
+        base_filters.append(XboxSaleRecord.sale_date >= lower)
+    if upper is not None:
+        base_filters.append(XboxSaleRecord.sale_date < upper)
 
     # 按币种汇总
     by_currency_rows = list(

--- a/src/services/xbox_sync.py
+++ b/src/services/xbox_sync.py
@@ -237,13 +237,15 @@ def trigger_sync(
             exchange_rate=used_rate_value,
             rmb_cost=rmb_cost,
             order_at=fetched.order_at,
+            # CEO 2026-05-12: 销售日期 = 微软订单时间(中国时区精确到秒),自动填
+            sale_date=fetched.order_at,
             raw_data=fetched.raw_data,
             status=XboxOrderStatus.PENDING_COMPLETE.value,
         )
         session.add(order)
         orders_added += 1
 
-    # 余额快照
+    # 余额快照 + 同步更新账号当前余额(CEO 2026-05-12: 每次同步都更新 account.local_balance)
     balance_info = None
     if result.balance is not None:
         snapshot = XboxBalanceSnapshot(
@@ -253,6 +255,8 @@ def trigger_sync(
             captured_at=china_now(),
         )
         session.add(snapshot)
+        # 更新账号当前余额,前端客服 exe 直接显示这个字段
+        account.local_balance = Decimal(result.balance.balance)
         balance_info = {
             "currency": result.balance.currency,
             "balance": str(result.balance.balance),

--- a/tests/test_xbox_p0_2_api.py
+++ b/tests/test_xbox_p0_2_api.py
@@ -732,6 +732,45 @@ def test_sync_orders_mock_creates_orders_and_balance_snapshot(client):
     assert batches[0]["success"] is True
 
 
+def test_sync_orders_updates_account_local_balance(client):
+    """CEO 2026-05-12: 每次同步成功后,account.local_balance 必须更新为最新余额。
+
+    现在 mock stub 返回 balance=123.45,所以同步后账号余额应该 = 123.45。
+    """
+    account = _create_account(client)
+    # 同步前余额应为 0
+    initial = client.get("/xbox/accounts").json()
+    initial_acc = next(a for a in initial if a["id"] == int(account["id"]))
+    assert Decimal(str(initial_acc["localBalance"])) == Decimal("0")
+
+    # 触发同步
+    r = client.post("/xbox/sync/orders", json={"accountId": account["id"], "count": 10})
+    assert r.status_code == 200, r.text
+    assert r.json()["success"] is True
+
+    # 同步后账号 local_balance 应已更新 = stub 返回的 123.45
+    updated = client.get("/xbox/accounts").json()
+    updated_acc = next(a for a in updated if a["id"] == int(account["id"]))
+    assert Decimal(str(updated_acc["localBalance"])) == Decimal("123.45")
+
+
+def test_sync_orders_sets_sale_date_to_order_at(client):
+    """CEO 2026-05-12: 销售日期(sale_date) = 订单时间(order_at, 中国时区精确到秒)。
+
+    同步抓订单时 sale_date 应自动 = order_at,无需客服手填。
+    """
+    account = _create_account(client)
+    r = client.post("/xbox/sync/orders", json={"accountId": account["id"], "count": 10})
+    assert r.status_code == 200
+
+    orders = client.get(f"/xbox/orders?accountId={account['id']}").json()
+    assert len(orders) >= 1
+    for order in orders:
+        # saleDate 必须自动填了,且等于 orderAt
+        assert order["saleDate"] is not None
+        assert order["saleDate"] == order["orderAt"]
+
+
 def test_sync_orders_failure_marks_account_error_and_audits(client):
     """同步失败(账号无密码) → 账号状态变 error + 写审计 + 不发 Discord。"""
     # 创建账号但不设密码,触发 mock 失败路径


### PR DESCRIPTION
## 业务背景（CEO 2026-05-12）

客服 exe 准备工作 PR-A（共 4 个 PR 滚动推进）：
- **PR A（本 PR）**：后端 schema 升级 + 余额同步 + CEO web 销售日期只读化
- PR B：Electron 项目骨架 + 登录页 + 工作台
- PR C：账号详情页（看密码 + 余额 + 同步按钮）+ 补销售页
- PR D：历史销售 + 退出 + .exe 打包

CEO 确认：销售日期由系统自动填，**等于爬虫抓微软订单的时间，中国时区精确到秒**，客服无需手填。

## Summary

### 后端
- `XboxSaleRecord.sale_date` / `XboxOrder.sale_date`：DATE → **DATETIME**（中国时区精确到秒）
- 创建订单时（sync 抓取 / 手动建）：`order.sale_date` 自动 = `order_at`
- 转销售记录时：`record.sale_date` 自动 = `order.order_at`
- 每次同步成功后：`account.local_balance` 同步更新为最新余额（原来只写快照不更新主字段）
- `xbox_reconcile`：按当天 datetime `[00:00, 次日 00:00)` 范围筛
- `list_sale_records` / `get_sales_summary` 同步改 datetime 范围逻辑
- 迁移：SQLite 把旧的 `"YYYY-MM-DD"` sale_date 补成 `"YYYY-MM-DD 00:00:00"`

### CEO 财务 web
- 补齐订单 Modal：销售日期改**只读**（显示自动填的值，秒精度）
- 销售记录表：sale_date 显示从天精度升到秒精度
- 新工具函数 `formatDateTimeSeconds()`

## Test plan

- [x] `python -m pytest tests/` → **216 passed**（原 214 + 新 2）
- [x] `npx tsc --noEmit` 前端无类型错误
- [x] 新增 `test_sync_orders_updates_account_local_balance`：同步后 `account.localBalance == 123.45`
- [x] 新增 `test_sync_orders_sets_sale_date_to_order_at`：同步后 `order.saleDate == order.orderAt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)