### PR TITLE
fix(operator-exe): dev 启动脚本换 Node 版本 + 新 skill dev-stack-self-serve

### DIFF
--- a/.claude/skills/dev-stack-self-serve/SKILL.md
+++ b/.claude/skills/dev-stack-self-serve/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: dev-stack-self-serve
+description: 所有前后端/桌面端的启动、停止、诊断、修复都由 PM 自己端到端搞定。CEO 不应该被要求"按步骤跑命令""贴终端输出""检查端口""开第二个 terminal"。CEO 说"没启动 / 启动不了 / 没自动打开 / 看不到 / 报错"时,PM 自己用 Bash/PowerShell 工具去复现、定位、修代码、改启动脚本、重启服务,然后告诉 CEO"已经跑起来了,你在 X 看 Y"。源于 CEO 2026-05-12 明确要求 ——「比如没有主动打开,你排查好原因后帮我主动打开」。
+---
+
+# 前后端/桌面端自助运维规则
+
+## 核心一句话
+
+**CEO 不调试。PM 自己端到端把服务跑通,然后给 CEO 一个能直接用的结果。**
+
+不要让 CEO 当你的"远程双手"——不要让他贴日志、跑命令、点确认。你有 Bash 和 PowerShell 工具,自己做。
+
+## 触发场景
+
+只要 CEO 说出任一类似下面这种话,就触发本 skill:
+
+| CEO 原话 | 真正的意思 |
+|---|---|
+| "没自动打开" | 帮我把它打开 |
+| "启动不了" | 帮我把它启动 |
+| "看不到 X" | 帮我让 X 出来 |
+| "页面空白" | 帮我把页面修好 |
+| "刷不出来" | 自己定位为什么然后修 |
+| "报错了" | 看错误自己修 |
+| "怎么连不上" | 自己 curl/nc 测,自己接好 |
+| "PR B 试了下 X 没动" | 我去试一下,出问题自己排 |
+
+## 标准动作（按这个顺序做,别先反问 CEO）
+
+### 1. 复现 — 在你的工具里跑一遍
+
+- 后端：`uvicorn src.main:app --port 8000` 在 background 跑
+- CEO web：`cd frontend && npm run dev` 在 background 跑
+- 客服 exe (web 部分)：`cd frontend-operator && npx next dev -p 3100` 在 background 跑
+- 客服 exe (Electron 壳)：`cd frontend-operator && npx electron .` 在 background 跑 (有显示则成功)
+- 测试现象：`curl http://localhost:3100/login` 看 HTTP 200 不
+- 端口冲突：PowerShell `Get-NetTCPConnection -LocalPort 3100`
+
+### 2. 定位 — 直接读输出
+
+- npm/Next.js dev 输出在 stdout
+- Electron 主进程的报错在 terminal stderr
+- 用 `Read` 看 background bash 的 output
+- 用 `Grep` 在代码里搜错误关键字
+- 不要让 CEO 贴日志,自己读
+
+### 3. 修 — 直接改
+
+- 配置错 → 改 `package.json` / `next.config.js` / `electron/main.js`
+- 端口被占 → `Stop-Process -Id <pid> -Force`
+- 依赖没装 → `npm install`
+- 启动脚本不稳 → 换成更稳的实现(如 `concurrently + wait-on` → Node 写的等待脚本)
+- 静态资源路径错 → 改 main.js 的 loadFile / loadURL
+
+### 4. 启 — 自己拉起来 + 留运行
+
+- 后端、Next.js dev、Electron 都用 `run_in_background: true` 启
+- 启动后 verify (curl / Get-NetTCPConnection / log 关键字)
+- 留它跑着,告诉 CEO 哪里看
+
+### 5. 报告 — 一句话 + 入口
+
+❌ 不要这样:
+> "请按下面顺序在 PowerShell 里跑,把每一步的输出贴给我..."
+
+✅ 要这样:
+> "已经跑起来了,Electron 窗口应该弹出来了。如果没弹,任务栏看下有没有图标。
+> 后端 8000、CEO web 3000、客服 exe 3100 都在,我用 PID 12345/67890 启动。停的话告诉我。"
+
+## 启动客服 exe 的 SOP（CEO 2026-05-12 起用）
+
+CEO 当前在 Q1A 阶段(本机自测),所有服务都跑在他这台 PC 上:
+
+```
+后端       uvicorn src.main:app --port 8000 --reload    [background]
+CEO web    cd frontend && npm run dev                    [background, 3000]
+客服 web   cd frontend-operator && npx next dev -p 3100  [background]
+Electron   cd frontend-operator && npx electron .        [background, 装窗口]
+```
+
+PM 责任:
+1. CEO 一说"开下客服 exe" → PM 一条龙起 4 个服务
+2. 端口冲突 → 自己 kill 自己重启
+3. Electron 报错 → 自己读、自己修、自己重启
+4. CEO web 那边创客服 / 标可出库这种**业务操作**才让 CEO 做
+5. 服务停掉 / 端口换了 → 主动告知
+
+## 例外: 真的需要 CEO 操作的事
+
+只有这两类才让 CEO 动手:
+
+1. **CEO 浏览器里的业务操作**: 创建客服、扫码绑定 TOTP、标记账号"可出库"、点领取
+2. **CEO 拍板的业务决策**: 字段含义、UI 流程、命名 — 这是 `discuss-before-execute` 的范围
+
+**其他都 PM 自己做**。包括但不限于:
+- 跑命令 / 看输出 / 抓日志 / 改代码 / 装依赖 / 跑测试 / 重启服务 / 改端口 / 开窗口
+
+## 反例（绝不要这样做）
+
+```
+CEO: "Electron 没自动打开"
+PM:  "请打开 PowerShell 跑步骤1...步骤2...把输出贴给我..."  ← ❌
+```
+
+```
+CEO: "Electron 没自动打开"
+PM:  [自己用 Bash 跑 npm run dev:next, 验证 Next 起来]
+     [自己跑 npx electron . in background, 看报错]
+     [发现 concurrently 在 Windows 下 wait-on 卡住, 改 package.json]
+     [重新启动, 用 PowerShell 验证窗口进程在]
+     "客服 exe 已经跑起来了, Electron 窗口应该已经弹出来了。
+      如果没看到, 任务栏找'XBOX 客服销售系统'图标。我改了 dev 脚本绕过
+      concurrently 的 Windows bug, 以后 npm run dev 就稳了。"  ← ✓
+```
+
+## 与其他 skill 的关系
+
+- **`discuss-before-execute`**: 业务需求要先讨论。但"启动服务""修启动脚本""修 dev 报错"是**实现细节**,不属于业务,本 skill 直接做。
+- **`claude-pm-persona`**: 本 skill 是 PM 工作模式的具体化 —— PM 要替 CEO 兜底所有运维细节。
+
+## 修订历史
+
+- **2026-05-12** CEO 明确要求: 「之后所有遇到的问题关于前后端问题都是你来解决,我只需要看你的解决结果。比如没有主动打开,你排查好原因后帮我主动打开」

--- a/frontend-operator/package-lock.json
+++ b/frontend-operator/package-lock.json
@@ -23,13 +23,12 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "autoprefixer": "^10.4.20",
-        "concurrently": "^9.0.1",
+        "cross-env": "^7.0.3",
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8",
         "postcss": "^8.4.49",
         "tailwindcss": "^3.4.15",
-        "typescript": "^5.6.3",
-        "wait-on": "^8.0.1"
+        "typescript": "^5.6.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -437,60 +436,6 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@hapi/address": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
-      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/formula": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
-      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/hoek": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/pinpoint": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
-      "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@hapi/tlds": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
-      "integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@hapi/topo": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -1010,13 +955,6 @@
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
-    },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -1666,18 +1604,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
-    },
-    "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/balanced-match": {
@@ -2436,31 +2362,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/concurrently": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.1.tgz",
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "4.1.2",
-        "rxjs": "7.8.2",
-        "shell-quote": "1.8.3",
-        "supports-color": "8.1.1",
-        "tree-kill": "1.2.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
     "node_modules/config-file-ts": {
       "version": "0.2.8-rc1",
       "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
@@ -2589,6 +2490,25 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -3466,27 +3386,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -4302,25 +4201,6 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
-      }
-    },
-    "node_modules/joi": {
-      "version": "18.2.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
-      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.1.1",
-        "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/js-tokens": {
@@ -5655,16 +5535,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -6005,16 +5875,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -6135,19 +5995,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -6459,22 +6306,6 @@
         "node": ">= 8.0"
       }
     },
-    "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -6736,16 +6567,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
-      }
-    },
     "node_modules/truncate-utf8-bytes": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
@@ -6909,26 +6730,6 @@
       },
       "engines": {
         "node": ">=0.6.0"
-      }
-    },
-    "node_modules/wait-on": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-8.0.5.tgz",
-      "integrity": "sha512-J3WlS0txVHkhLRb2FsmRg3dkMTCV1+M6Xra3Ho7HzZDHpE7DCOnoSoCJsZotrmW3uRMhvIJGSKUKrh/MeF4iag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.12.1",
-        "joi": "^18.0.1",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.2"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/wcwidth": {

--- a/frontend-operator/package.json
+++ b/frontend-operator/package.json
@@ -5,10 +5,10 @@
   "description": "XBOX 客服销售系统 (Electron + Next.js, CEO 2026-05-12)",
   "main": "electron/main.js",
   "scripts": {
+    "dev": "node scripts/dev.js",
     "dev:next": "next dev -p 3100",
-    "dev:electron": "wait-on http://localhost:3100 && electron .",
-    "dev": "concurrently -k -n NEXT,ELECTRON -c blue,green \"npm:dev:next\" \"npm:dev:electron\"",
-    "build:next": "next build && next export -o out",
+    "dev:electron": "electron .",
+    "build:next": "cross-env NEXT_EXPORT=1 next build",
     "build:electron": "electron-builder",
     "typecheck": "tsc --noEmit",
     "start:web": "next dev -p 3100"
@@ -29,13 +29,12 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "autoprefixer": "^10.4.20",
-    "concurrently": "^9.0.1",
+    "cross-env": "^7.0.3",
     "electron": "^33.2.0",
     "electron-builder": "^25.1.8",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.15",
-    "typescript": "^5.6.3",
-    "wait-on": "^8.0.1"
+    "typescript": "^5.6.3"
   },
   "build": {
     "appId": "com.xbox-finance.operator",

--- a/frontend-operator/scripts/dev.js
+++ b/frontend-operator/scripts/dev.js
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * 客服 exe 开发模式启动器 (替代不稳定的 concurrently + wait-on 组合)
+ *
+ * 流程:
+ *   1. 起 `next dev -p 3100`
+ *   2. 轮询 http://localhost:3100/login 直到 HTTP 200
+ *   3. 起 `electron .` 弹出窗口
+ *   4. 任一进程退出 → 一并清理另一个
+ *   5. Ctrl+C → 优雅退出两个
+ *
+ * 这版主要解决 Windows + PowerShell 下:
+ *   - concurrently 的 npm: 简写偶发不识别
+ *   - wait-on 在某些网络栈下卡住不返回
+ *   - SIGINT 没传到子进程导致僵尸
+ */
+const { spawn } = require("child_process");
+const http = require("http");
+const path = require("path");
+
+const PORT = 3100;
+const PROBE_URL = `http://localhost:${PORT}/login`;
+const PROBE_INTERVAL_MS = 500;
+const PROBE_TIMEOUT_MS = 60_000;
+
+const isWindows = process.platform === "win32";
+const root = path.resolve(__dirname, "..");
+
+function color(label, code) {
+  return (line) => `\x1b[${code}m[${label}]\x1b[0m ${line}`;
+}
+const blue = color("NEXT", "34");
+const green = color("ELECTRON", "32");
+
+function pipePrefixed(child, paint) {
+  const onChunk = (chunk) => {
+    chunk
+      .toString()
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .forEach((l) => process.stdout.write(paint(l) + "\n"));
+  };
+  child.stdout && child.stdout.on("data", onChunk);
+  child.stderr && child.stderr.on("data", onChunk);
+}
+
+function runNpx(args, paint) {
+  // 用 shell=true 让 npx 的 .cmd 在 Windows 上能找到
+  const child = spawn(isWindows ? "npx.cmd" : "npx", args, {
+    cwd: root,
+    env: process.env,
+    shell: isWindows,
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  pipePrefixed(child, paint);
+  return child;
+}
+
+function probeOnce() {
+  return new Promise((resolve) => {
+    const req = http.get(PROBE_URL, (res) => {
+      res.resume();
+      resolve(res.statusCode >= 200 && res.statusCode < 500);
+    });
+    req.on("error", () => resolve(false));
+    req.setTimeout(2000, () => {
+      req.destroy();
+      resolve(false);
+    });
+  });
+}
+
+async function waitForNext() {
+  const started = Date.now();
+  while (Date.now() - started < PROBE_TIMEOUT_MS) {
+    if (await probeOnce()) return true;
+    await new Promise((r) => setTimeout(r, PROBE_INTERVAL_MS));
+  }
+  return false;
+}
+
+function killChild(child) {
+  if (!child || child.exitCode !== null) return;
+  try {
+    if (isWindows) {
+      // taskkill 整棵子进程树
+      spawn("taskkill", ["/pid", String(child.pid), "/f", "/t"], {
+        stdio: "ignore"
+      });
+    } else {
+      child.kill("SIGTERM");
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+async function main() {
+  console.log(blue("正在启动 Next.js dev server (3100)..."));
+  const nextProc = runNpx(["next", "dev", "-p", String(PORT)], blue);
+
+  let electronProc = null;
+  let shuttingDown = false;
+
+  const shutdown = (reason) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`\n[dev.js] shutdown: ${reason}`);
+    killChild(electronProc);
+    killChild(nextProc);
+    process.exit(0);
+  };
+
+  nextProc.on("exit", (code) => {
+    if (!shuttingDown) shutdown(`Next.js 退出 (code=${code})`);
+  });
+
+  process.on("SIGINT", () => shutdown("SIGINT"));
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+
+  const ready = await waitForNext();
+  if (!ready) {
+    console.error(`[dev.js] ❌ Next.js 60 秒未就绪,退出`);
+    shutdown("next 启动超时");
+    return;
+  }
+
+  console.log(green("Next.js 已就绪,启动 Electron 窗口..."));
+  electronProc = runNpx(["electron", "."], green);
+
+  electronProc.on("exit", (code) => {
+    if (!shuttingDown) shutdown(`Electron 退出 (code=${code})`);
+  });
+}
+
+main().catch((err) => {
+  console.error("[dev.js] fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 背景

CEO 反馈"没有自动打开" — 排查后发现原 `npm run dev` 用 `concurrently + wait-on` 组合在 Windows + PowerShell 下不稳。

## 修复

### `frontend-operator/scripts/dev.js`（新）
- Node child_process.spawn 起 `next dev -p 3100`
- 轮询 `http://localhost:3100/login` 直到 HTTP 200
- 起 `electron .` 弹窗
- 任一进程退出收尾另一个；Ctrl+C 用 `taskkill /t` 杀整棵进程树

### `package.json`
- `"dev": "node scripts/dev.js"`，移除 `concurrently` + `wait-on`
- `build:next` 用 `cross-env NEXT_EXPORT=1` 兼容 Windows

### 新 skill `.claude/skills/dev-stack-self-serve/`
CEO 不应该被要求"按步骤跑命令""贴终端输出""开第二个 terminal"。本 skill 把前后端/桌面端启动、停止、诊断、修复全部归到 PM 自己端到端处理。CEO 只需要"创建客服 / 扫码 / 标可出库"这种业务操作。

## 本次现场验证

PM 已经自己把 4 个服务全跑起来了，CEO 直接看 Electron 窗口（已 SetForegroundWindow 拉到前）：

| 服务 | 端口 | PID |
|---|---|---|
| 后端 uvicorn | 8000 | 2940 |
| CEO web | 3000 | 8624 |
| 客服 web | 3100 | 14364 |
| Electron 主窗口 | - | 5400 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)