### PR TITLE
feat(operator-exe): 账号详情页 + Microsoft 同步 + 补销售信息

### DIFF
--- a/frontend-operator/app/accounts/[id]/page.tsx
+++ b/frontend-operator/app/accounts/[id]/page.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { AccountDetail } from "@/components/account-detail";
+import { useRequireAuth } from "@/lib/auth";
+import { useParams } from "next/navigation";
+
+export default function AccountDetailPage() {
+  const { operator, loading } = useRequireAuth();
+  const params = useParams<{ id: string }>();
+  const accountId = Number(params.id);
+
+  if (loading || !operator) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+        加载中…
+      </div>
+    );
+  }
+
+  if (!Number.isInteger(accountId) || accountId <= 0) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-red-700">
+        无效的账号 ID
+      </div>
+    );
+  }
+
+  return <AccountDetail accountId={accountId} operator={operator} />;
+}

--- a/frontend-operator/components/account-detail.tsx
+++ b/frontend-operator/components/account-detail.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  Copy,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Globe2,
+  KeyRound,
+  RefreshCcw,
+  Wallet,
+  Zap
+} from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { CompleteOrderModal } from "@/components/complete-order-modal";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table";
+import {
+  getAccountDetail,
+  getAccountOrders,
+  syncOrders
+} from "@/lib/api";
+import type { StoredOperator } from "@/lib/auth";
+import { formatDateTimeSeconds } from "@/lib/utils";
+import type { OperatorOrder } from "@/types";
+
+const SYNC_COUNTS = [10, 20, 30, 50] as const;
+
+const MICROSOFT_LOGIN_URL = "https://login.live.com/";
+
+export function AccountDetail({
+  accountId,
+  operator
+}: {
+  accountId: number;
+  operator: StoredOperator;
+}) {
+  const queryClient = useQueryClient();
+  const [showPassword, setShowPassword] = useState(false);
+  const [syncCount, setSyncCount] = useState<10 | 20 | 30 | 50>(20);
+  const [completeTarget, setCompleteTarget] = useState<OperatorOrder | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [syncResult, setSyncResult] = useState<{
+    ordersAdded: number;
+    ordersSkipped: number;
+    balance: string | null;
+    failure: string | null;
+  } | null>(null);
+
+  const detailQuery = useQuery({
+    queryKey: ["account-detail", accountId, operator.id],
+    queryFn: () => getAccountDetail(accountId, operator.id)
+  });
+  const ordersQuery = useQuery({
+    queryKey: ["operator-orders", accountId, operator.id],
+    queryFn: () => getAccountOrders(accountId, operator.id, true)
+  });
+
+  const syncMut = useMutation({
+    mutationFn: () => syncOrders(accountId, operator.id, syncCount),
+    onSuccess: async (data) => {
+      setError(null);
+      setSyncResult({
+        ordersAdded: data.ordersAdded,
+        ordersSkipped: data.ordersSkipped,
+        balance: data.balance?.balance ?? null,
+        failure: data.failure?.message ?? null
+      });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["account-detail", accountId] }),
+        queryClient.invalidateQueries({ queryKey: ["operator-orders", accountId] })
+      ]);
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "同步失败")
+  });
+
+  const copyToClipboard = async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setError(null);
+      // 简单反馈: 临时改 syncResult.failure (复用 banner)
+      const old = syncResult;
+      setSyncResult({
+        ordersAdded: 0,
+        ordersSkipped: 0,
+        balance: null,
+        failure: `已复制${label}到剪贴板`
+      });
+      setTimeout(() => setSyncResult(old), 2000);
+    } catch {
+      setError(`复制${label}失败，请手动选中`);
+    }
+  };
+
+  if (detailQuery.isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center text-sm text-muted-foreground">
+        加载账号详情…
+      </div>
+    );
+  }
+
+  if (detailQuery.error || !detailQuery.data) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4 p-6">
+        <BackButton />
+        <Card>
+          <CardContent className="pt-5">
+            <div className="text-sm text-red-700">
+              加载失败:{" "}
+              {detailQuery.error instanceof Error
+                ? detailQuery.error.message
+                : "未知错误"}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const detail = detailQuery.data;
+  const orders = ordersQuery.data ?? [];
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/95 px-6 py-3 backdrop-blur">
+        <BackButton />
+        <div className="text-xs text-muted-foreground">
+          客服: {operator.displayName} ({operator.loginName})
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-5xl space-y-5 px-6 py-5">
+        {error ? (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+            {error}
+          </div>
+        ) : null}
+        {syncResult ? (
+          <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+            {syncResult.failure ?? (
+              <>
+                <CheckCircle2 className="mr-1 inline h-3 w-3" />
+                同步完成: 新增 {syncResult.ordersAdded} 单, 跳过{" "}
+                {syncResult.ordersSkipped} 单
+                {syncResult.balance
+                  ? `, 当前余额 ${syncResult.balance} ${detail.currency}`
+                  : ""}
+              </>
+            )}
+          </div>
+        ) : null}
+
+        {/* ----- 账号信息卡 ----- */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4" />
+              {detail.accountNo ?? detail.name}
+              <Badge tone={detail.country === "UK" ? "danger" : "transfer"}>
+                <Globe2 className="mr-1 h-3 w-3" />
+                {detail.country}
+              </Badge>
+              {detail.status !== "active" ? (
+                <Badge tone="warning">{detail.status}</Badge>
+              ) : null}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+              <FieldRow
+                label="登录邮箱"
+                value={detail.loginEmail ?? "-"}
+                copyable={detail.loginEmail ?? undefined}
+                onCopy={() =>
+                  detail.loginEmail && copyToClipboard(detail.loginEmail, "邮箱")
+                }
+              />
+              <FieldRow
+                label="密码"
+                value={
+                  detail.passwordPlain
+                    ? showPassword
+                      ? detail.passwordPlain
+                      : "•".repeat(Math.min(12, detail.passwordPlain.length))
+                    : "(未设置)"
+                }
+                rightSlot={
+                  detail.passwordPlain ? (
+                    <div className="flex gap-1">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setShowPassword((s) => !s)}
+                        title={showPassword ? "隐藏" : "显示"}
+                      >
+                        {showPassword ? (
+                          <EyeOff className="h-3.5 w-3.5" />
+                        ) : (
+                          <Eye className="h-3.5 w-3.5" />
+                        )}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() =>
+                          detail.passwordPlain &&
+                          copyToClipboard(detail.passwordPlain, "密码")
+                        }
+                        title="复制"
+                      >
+                        <Copy className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ) : null
+                }
+                mono
+              />
+              <FieldRow
+                label="账号汇率"
+                value={detail.exchangeRate ? `1 ${detail.currency} = ${detail.exchangeRate} CNY` : "-"}
+              />
+              <FieldRow
+                label="状态备注"
+                value={detail.statusMessage ?? "-"}
+              />
+            </div>
+
+            <div className="flex flex-wrap gap-2 pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  typeof window !== "undefined" &&
+                  window.open(MICROSOFT_LOGIN_URL, "_blank")
+                }
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                打开 Microsoft 登录页
+              </Button>
+              <span className="text-xs text-muted-foreground self-center">
+                登录后再回来点「同步订单」
+              </span>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* ----- 余额 + 同步 ----- */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Wallet className="h-4 w-4" />
+                微软账号余额
+              </CardTitle>
+              <div className="mt-1 text-xs text-muted-foreground">
+                上次同步: {formatDateTimeSeconds(detail.lastSyncedAt)}
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="text-3xl font-semibold tabular-nums text-blue-700">
+                {detail.localBalance} {detail.currency}
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-xs text-muted-foreground">同步条数:</span>
+              {SYNC_COUNTS.map((n) => (
+                <Button
+                  key={n}
+                  size="sm"
+                  variant={syncCount === n ? "default" : "outline"}
+                  onClick={() => setSyncCount(n)}
+                >
+                  {n}
+                </Button>
+              ))}
+              <div className="flex-1" />
+              <Button
+                onClick={() => {
+                  setError(null);
+                  setSyncResult(null);
+                  syncMut.mutate();
+                }}
+                disabled={syncMut.isPending}
+              >
+                <Zap className="h-3.5 w-3.5" />
+                {syncMut.isPending ? "同步中…" : "同步 Microsoft 订单"}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* ----- 待补销售订单 ----- */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <div>
+              <CardTitle>待补销售信息的订单</CardTitle>
+              <div className="mt-1 text-xs text-muted-foreground">
+                点订单的「补销售」补齐 → 自动转销售记录
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => ordersQuery.refetch()}
+              disabled={ordersQuery.isFetching}
+            >
+              <RefreshCcw className="h-3.5 w-3.5" />
+              刷新
+            </Button>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>订单号</TableHead>
+                  <TableHead className="text-right">本币金额</TableHead>
+                  <TableHead>订单时间</TableHead>
+                  <TableHead className="text-right">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {orders.map((order) => (
+                  <TableRow key={order.id}>
+                    <TableCell className="font-mono text-xs">
+                      {order.orderNo}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {order.amountLocal} {order.currencyLocal}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground tabular-nums">
+                      {formatDateTimeSeconds(order.orderAt)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        onClick={() => setCompleteTarget(order)}
+                      >
+                        补销售
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {orders.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={4}
+                      className="py-8 text-center text-xs text-muted-foreground"
+                    >
+                      暂无待补订单。点上方「同步 Microsoft 订单」拉新订单
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </main>
+
+      {completeTarget ? (
+        <CompleteOrderModal
+          order={completeTarget}
+          operatorId={operator.id}
+          operatorDisplayName={operator.displayName}
+          onClose={() => setCompleteTarget(null)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function BackButton() {
+  return (
+    <Link
+      href="/"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+    >
+      <ArrowLeft className="h-4 w-4" />
+      返回工作台
+    </Link>
+  );
+}
+
+function FieldRow({
+  label,
+  value,
+  rightSlot,
+  copyable,
+  onCopy,
+  mono
+}: {
+  label: string;
+  value: string;
+  rightSlot?: React.ReactNode;
+  copyable?: string;
+  onCopy?: () => void;
+  mono?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div className="flex items-center gap-2 rounded-md border border-border bg-muted px-3 py-2">
+        <span className={mono ? "font-mono text-sm flex-1 break-all" : "text-sm flex-1"}>
+          {value}
+        </span>
+        {rightSlot ??
+          (copyable ? (
+            <Button size="sm" variant="ghost" onClick={onCopy} title="复制">
+              <Copy className="h-3.5 w-3.5" />
+            </Button>
+          ) : null)}
+      </div>
+    </div>
+  );
+}

--- a/frontend-operator/components/complete-order-modal.tsx
+++ b/frontend-operator/components/complete-order-modal.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { CheckCircle2, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { completeOrder, getWalletMethods } from "@/lib/api";
+import { formatDateTimeSeconds } from "@/lib/utils";
+import type { OperatorOrder, SaleCurrency } from "@/types";
+
+const SALE_CURRENCIES: SaleCurrency[] = ["CNY", "USD", "USDT", "TWD"];
+
+export function CompleteOrderModal({
+  order,
+  operatorId,
+  operatorDisplayName,
+  onClose
+}: {
+  order: OperatorOrder;
+  operatorId: number;
+  operatorDisplayName: string;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [productName, setProductName] = useState(order.productName ?? "");
+  const [salePrice, setSalePrice] = useState(order.salePrice ?? "");
+  const [saleCurrency, setSaleCurrency] = useState<SaleCurrency>(
+    (order.saleCurrency as SaleCurrency) ?? "CNY"
+  );
+  const [walletMethodId, setWalletMethodId] = useState<number | "">(
+    order.walletMethodId ?? ""
+  );
+  const [walletItemId, setWalletItemId] = useState<number | "">(
+    order.walletItemId ?? ""
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const methodsQuery = useQuery({
+    queryKey: ["wallet-methods"],
+    queryFn: getWalletMethods
+  });
+
+  const methods = methodsQuery.data ?? [];
+  const selectedMethod = methods.find((m) => m.id === walletMethodId);
+  const items = selectedMethod?.items ?? [];
+
+  // 切方式时清空旧的 item
+  useEffect(() => {
+    if (selectedMethod && walletItemId !== "") {
+      const stillValid = items.some((it) => it.id === walletItemId);
+      if (!stillValid) setWalletItemId("");
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [walletMethodId]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!productName.trim()) throw new Error("商品名不能为空");
+      if (!salePrice.trim()) throw new Error("售价不能为空");
+      if (typeof walletMethodId !== "number") throw new Error("请选收款方式");
+      if (typeof walletItemId !== "number") throw new Error("请选备注模板");
+      return completeOrder(order.id, {
+        operatorId,
+        productName: productName.trim(),
+        salePrice: salePrice.trim(),
+        saleCurrency,
+        walletMethodId,
+        walletItemId
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["operator-orders", order.accountId] });
+      onClose();
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "提交失败")
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <CardHeader className="flex flex-row items-center justify-between">
+          <div>
+            <CardTitle>补销售信息 · {order.orderNo}</CardTitle>
+            <div className="mt-1 text-xs text-muted-foreground">
+              本币 {order.amountLocal} {order.currencyLocal} · 订单时间{" "}
+              {formatDateTimeSeconds(order.orderAt)}
+            </div>
+          </div>
+          <Button size="sm" variant="ghost" onClick={onClose}>
+            <X className="h-4 w-4" />
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* 销售日期 + 经办人 — 系统自动,只读 */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">
+                销售日期（系统自动，精确到秒）
+              </label>
+              <div className="flex h-10 items-center rounded-md border border-border bg-muted px-3 text-xs tabular-nums text-muted-foreground">
+                {formatDateTimeSeconds(order.saleDate ?? order.orderAt)}
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium text-muted-foreground">
+                经办人（自动 = 登录客服）
+              </label>
+              <div className="flex h-10 items-center rounded-md border border-border bg-muted px-3 text-sm text-muted-foreground">
+                {operatorDisplayName}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium">
+              商品名 <span className="text-red-600">*</span>
+            </label>
+            <Input
+              value={productName}
+              onChange={(e) => setProductName(e.target.value)}
+              placeholder="例: 5350 档"
+            />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-1 col-span-2">
+              <label className="text-xs font-medium">
+                售价 <span className="text-red-600">*</span>
+              </label>
+              <Input
+                inputMode="decimal"
+                value={salePrice}
+                onChange={(e) => setSalePrice(e.target.value)}
+                placeholder="如 5350.00"
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-xs font-medium">
+                币种 <span className="text-red-600">*</span>
+              </label>
+              <select
+                className="h-10 w-full rounded-md border border-border bg-card px-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+                value={saleCurrency}
+                onChange={(e) => setSaleCurrency(e.target.value as SaleCurrency)}
+              >
+                {SALE_CURRENCIES.map((c) => (
+                  <option key={c} value={c}>
+                    {c}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium">
+              收款方式 <span className="text-red-600">*</span>
+            </label>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={walletMethodId}
+              onChange={(e) =>
+                setWalletMethodId(e.target.value === "" ? "" : Number(e.target.value))
+              }
+              disabled={methodsQuery.isLoading}
+            >
+              <option value="">{methodsQuery.isLoading ? "加载中…" : "请选择"}</option>
+              {methods
+                .filter((m) => m.isActive)
+                .map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.label}
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium">
+              备注模板 <span className="text-red-600">*</span>
+            </label>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={walletItemId}
+              onChange={(e) =>
+                setWalletItemId(e.target.value === "" ? "" : Number(e.target.value))
+              }
+              disabled={!selectedMethod}
+            >
+              <option value="">
+                {selectedMethod ? "请选择" : "先选收款方式"}
+              </option>
+              {items
+                .filter((it) => it.isActive)
+                .map((it) => (
+                  <option key={it.id} value={it.id}>
+                    {it.label}
+                  </option>
+                ))}
+            </select>
+          </div>
+
+          {error ? (
+            <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" size="sm" onClick={onClose}>
+              取消
+            </Button>
+            <Button
+              size="sm"
+              onClick={() => {
+                setError(null);
+                mutation.mutate();
+              }}
+              disabled={mutation.isPending}
+            >
+              <CheckCircle2 className="h-3.5 w-3.5" />
+              {mutation.isPending ? "提交中…" : "提交销售信息"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend-operator/components/dashboard.tsx
+++ b/frontend-operator/components/dashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+  ChevronRight,
   CheckCircle2,
   Gamepad2,
   Globe2,
@@ -167,6 +168,7 @@ export function OperatorDashboard({ operator }: { operator: StoredOperator }) {
           {/* ----- 我的领取 ----- */}
           <MyClaimsPanel
             claims={claims}
+            onOpen={(accountId) => router.push(`/accounts/${accountId}`)}
             onReturn={(claimId) => {
               setError(null);
               if (confirm("归还这个账号？归还后其他客服可以领取。")) {
@@ -202,12 +204,14 @@ export function OperatorDashboard({ operator }: { operator: StoredOperator }) {
 
 function MyClaimsPanel({
   claims,
+  onOpen,
   onReturn,
   returnPending,
   onRefresh,
   refreshing
 }: {
   claims: OperatorClaim[];
+  onOpen: (accountId: number) => void;
   onReturn: (claimId: number) => void;
   returnPending: boolean;
   onRefresh: () => void;
@@ -219,7 +223,7 @@ function MyClaimsPanel({
         <div>
           <CardTitle>我领的账号</CardTitle>
           <div className="mt-1 text-xs text-muted-foreground">
-            点账号进入详情(看密码 / 同步订单 / 补销售信息) — PR C 上线
+            点账号进入详情(看密码 / 同步订单 / 补销售信息)
           </div>
         </div>
         <Button variant="outline" size="sm" onClick={onRefresh} disabled={refreshing}>
@@ -238,9 +242,14 @@ function MyClaimsPanel({
           </TableHeader>
           <TableBody>
             {claims.map((claim) => (
-              <TableRow key={claim.id}>
+              <TableRow
+                key={claim.id}
+                className="cursor-pointer"
+                onClick={() => onOpen(claim.accountId)}
+              >
                 <TableCell className="text-sm">
                   <Badge tone="transfer">#{claim.accountId}</Badge>
+                  <ChevronRight className="ml-1 inline h-3 w-3 text-muted-foreground" />
                 </TableCell>
                 <TableCell className="text-xs text-muted-foreground tabular-nums">
                   {formatDateTimeSeconds(claim.claimedAt)}
@@ -249,7 +258,10 @@ function MyClaimsPanel({
                   <Button
                     size="sm"
                     variant="outline"
-                    onClick={() => onReturn(claim.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onReturn(claim.id);
+                    }}
                     disabled={returnPending}
                   >
                     <Undo2 className="h-3.5 w-3.5" />

--- a/frontend-operator/lib/api.ts
+++ b/frontend-operator/lib/api.ts
@@ -5,6 +5,10 @@ import type {
   AvailableAccount,
   LoginResponse,
   OperatorClaim,
+  OperatorOrder,
+  SaleCurrency,
+  SyncOrdersResult,
+  WalletMethod,
   XboxAccountDetail
 } from "@/types";
 import { clearSession, getToken } from "./auth";
@@ -96,14 +100,64 @@ export function returnClaim(
   });
 }
 
-// ---------- XBOX 账号详情 (PR C 用,先暴露 stub) ----------
+// ---------- XBOX 账号详情 / 同步 / 补销售 (PR C) ----------
 
-export async function getAccountDetail(
-  accountId: number
-): Promise<XboxAccountDetail | null> {
-  // /xbox/accounts 返回完整列表; 后续会做单 GET /xbox/accounts/{id}
-  const list = await request<XboxAccountDetail[]>("/api/xbox/accounts");
-  return list.find((a) => a.id === accountId) ?? null;
+export function getAccountDetail(
+  accountId: number,
+  operatorId: number
+): Promise<XboxAccountDetail> {
+  return request<XboxAccountDetail>(
+    `/api/operator/accounts/${accountId}?operatorId=${operatorId}`
+  );
+}
+
+export function syncOrders(
+  accountId: number,
+  operatorId: number,
+  count: number
+): Promise<SyncOrdersResult> {
+  return request<SyncOrdersResult>(
+    `/api/operator/accounts/${accountId}/sync-orders`,
+    {
+      method: "POST",
+      body: JSON.stringify({ operatorId, count })
+    }
+  );
+}
+
+export function getAccountOrders(
+  accountId: number,
+  operatorId: number,
+  onlyPending = true
+): Promise<OperatorOrder[]> {
+  return request<OperatorOrder[]>(
+    `/api/operator/accounts/${accountId}/orders?operatorId=${operatorId}&onlyPending=${onlyPending}`
+  );
+}
+
+export function completeOrder(
+  orderId: number,
+  payload: {
+    operatorId: number;
+    productName: string;
+    salePrice: string;
+    saleCurrency: SaleCurrency;
+    walletMethodId: number;
+    walletItemId: number;
+  }
+): Promise<OperatorOrder> {
+  return request<OperatorOrder>(
+    `/api/operator/orders/${orderId}/completion`,
+    {
+      method: "PATCH",
+      body: JSON.stringify(payload)
+    }
+  );
+}
+
+// 钱包设置(收款方式 / 备注模板) — 复用 CEO 后台的端点
+export function getWalletMethods(): Promise<WalletMethod[]> {
+  return request<WalletMethod[]>("/api/xbox/wallet-settings?onlyActive=true");
 }
 
 export { ApiError };

--- a/frontend-operator/types.ts
+++ b/frontend-operator/types.ts
@@ -38,7 +38,7 @@ export type OperatorClaim = {
   returnReason: string | null;
 };
 
-// 账号详情 (PR C 用,先占位)
+// 账号详情 (PR C: 客服在 exe 内查的字段)
 export type XboxAccountDetail = {
   id: number;
   accountNo: string | null;
@@ -46,9 +46,54 @@ export type XboxAccountDetail = {
   country: string;
   currency: string;
   loginEmail: string | null;
-  hasPassword: boolean;
-  localBalance: string; // 微软账号本币余额 (USD/GBP)
+  passwordPlain: string | null; // 解密后明文(客服用来登录 Microsoft)
+  exchangeRate: string | null;
+  localBalance: string; // 微软账号当前本币余额 (USD/GBP)
   status: string;
   statusMessage: string | null;
   lastSyncedAt: string | null;
 };
+
+// Microsoft 订单同步结果
+export type SyncOrdersResult = {
+  batchId: number;
+  success: boolean;
+  ordersAdded: number;
+  ordersSkipped: number;
+  balance: { currency: string; balance: string } | null;
+  failure: { category: string; message: string } | null;
+};
+
+// 客服 exe 看的订单
+export type OperatorOrder = {
+  id: number;
+  accountId: number;
+  orderNo: string;
+  amountLocal: string;
+  currencyLocal: string;
+  orderAt: string;
+  saleDate: string | null;
+  status: string;
+  productName: string | null;
+  salePrice: string | null;
+  saleCurrency: string | null;
+  walletMethodId: number | null;
+  walletItemId: number | null;
+};
+
+// 钱包设置 (复用 /xbox/wallet-settings)
+export type WalletMethod = {
+  id: number;
+  code: string;
+  label: string;
+  isActive: boolean;
+  items: {
+    id: number;
+    code: string;
+    label: string;
+    walletPoolId: number;
+    isActive: boolean;
+  }[];
+};
+
+export type SaleCurrency = "CNY" | "USD" | "USDT" | "TWD";

--- a/src/routers/operator.py
+++ b/src/routers/operator.py
@@ -2,14 +2,17 @@
 from __future__ import annotations
 
 from datetime import datetime
+from decimal import Decimal
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from src.database import get_db
 from src.models.operator import Operator, XboxAccountClaim
+from src.models.xbox import XboxAccount, XboxOrder, XboxOrderStatus
 from src.services.operator_auth import (
     AuthError,
     confirm_totp,
@@ -22,15 +25,20 @@ from src.services.operator_auth import (
     totp_qrcode_png_base64,
     totp_provisioning_uri,
 )
+from src.services.xbox_account import reveal_password
 from src.services.xbox_account_claim import (
     ClaimError,
     claim_account,
     count_active_claims_for_operator,
+    get_active_claim_for_account,
     list_active_claims_for_operator,
     list_all_claims_with_active_filter,
     list_available_accounts,
     return_claim,
 )
+from src.services.xbox_order import update_order_completion
+from src.services.xbox_sync import trigger_sync
+from src.utils.crypto import CryptoError
 
 
 router = APIRouter(prefix="/operator", tags=["operator"])
@@ -400,3 +408,233 @@ def list_all_claims_endpoint(
 ) -> list[XboxAccountClaimOut]:
     """CEO 后台: 看所有领取记录(默认仅活跃,可看历史)。"""
     return [_serialize_claim(c) for c in list_all_claims_with_active_filter(db, only_active)]
+
+
+# ===================================================================
+# 客服 exe: 账号详情 + 同步 + 补销售信息 (CEO 2026-05-12 PR-C)
+# ===================================================================
+
+
+def _require_holding(
+    db: Session, account_id: int, operator_id: int
+) -> tuple[XboxAccount, Operator]:
+    """校验 operator 当前持有此账号(active claim)。返回 (account, operator)。
+
+    任意一个不满足都抛 403/404。
+    """
+    account = db.get(XboxAccount, account_id)
+    if account is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="账号不存在")
+    operator = get_operator(db, operator_id)
+    if operator is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="客服不存在")
+    if not operator.is_active:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="客服账号已停用")
+
+    claim = get_active_claim_for_account(db, account_id)
+    if claim is None or claim.operator_id != operator_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="你没有领取这个账号,无权操作",
+        )
+    return account, operator
+
+
+class OperatorAccountDetailOut(BaseModel):
+    """客服看的账号详情(含密码明文 + 当前余额)。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    account_no: Optional[str]
+    name: str
+    country: str
+    currency: str
+    login_email: Optional[str]
+    password_plain: Optional[str]  # 解密后明文(客服需要拿来登录 Microsoft)
+    exchange_rate: Optional[str]
+    local_balance: str  # 微软账号当前本币余额(同步后会更新)
+    status: str
+    status_message: Optional[str]
+    last_synced_at: Optional[str]
+
+
+@router.get(
+    "/accounts/{account_id}",
+    response_model=OperatorAccountDetailOut,
+    response_model_by_alias=True,
+)
+def get_account_detail_endpoint(
+    account_id: int,
+    operator_id: int = Query(..., alias="operatorId"),
+    db: Session = Depends(get_db),
+) -> OperatorAccountDetailOut:
+    """客服 exe 看账号详情(密码明文 + 当前余额)。
+
+    校验: 必须是当前持有此账号的客服。
+    """
+    account, _ = _require_holding(db, account_id, operator_id)
+
+    password_plain: Optional[str] = None
+    if account.password_enc:
+        try:
+            password_plain = reveal_password(account)
+        except (CryptoError, ValueError):
+            password_plain = None  # 密钥配置错或密文损坏,不阻塞详情展示
+
+    return OperatorAccountDetailOut(
+        id=account.id,
+        account_no=account.account_no,
+        name=account.name,
+        country=account.country.value if hasattr(account.country, "value") else account.country,
+        currency=account.currency.value if hasattr(account.currency, "value") else account.currency,
+        login_email=account.login_email,
+        password_plain=password_plain,
+        exchange_rate=str(account.exchange_rate) if account.exchange_rate is not None else None,
+        local_balance=str(account.local_balance or Decimal("0")),
+        status=account.status,
+        status_message=account.status_message,
+        last_synced_at=account.last_synced_at.isoformat() if account.last_synced_at else None,
+    )
+
+
+class OperatorSyncRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    operator_id: int
+    count: int = 20  # 10 / 20 / 30 / 50
+
+
+@router.post(
+    "/accounts/{account_id}/sync-orders",
+    response_model=dict,
+)
+def operator_sync_orders_endpoint(
+    account_id: int,
+    request: OperatorSyncRequest,
+    db: Session = Depends(get_db),
+) -> dict:
+    """客服触发该账号的 Microsoft 订单同步。
+
+    校验: 必须是当前持有此账号的客服。
+    返回: {batchId, success, ordersAdded, ordersSkipped, balance, failure}
+    """
+    account, _ = _require_holding(db, account_id, request.operator_id)
+    try:
+        result = trigger_sync(db, account, count=request.count)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    db.commit()
+    return result
+
+
+class OperatorOrderOut(BaseModel):
+    """客服 exe 看的订单(简化版,只暴露客服需要的字段)。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    id: int
+    account_id: int
+    order_no: str
+    amount_local: str
+    currency_local: str
+    order_at: str
+    sale_date: Optional[str]
+    status: str
+    product_name: Optional[str]
+    sale_price: Optional[str]
+    sale_currency: Optional[str]
+    wallet_method_id: Optional[int]
+    wallet_item_id: Optional[int]
+
+
+def _serialize_op_order(order: XboxOrder) -> OperatorOrderOut:
+    return OperatorOrderOut(
+        id=order.id,
+        account_id=order.account_id,
+        order_no=order.order_no,
+        amount_local=str(order.amount_local),
+        currency_local=order.currency_local,
+        order_at=order.order_at.isoformat() if order.order_at else "",
+        sale_date=order.sale_date.isoformat() if order.sale_date else None,
+        status=order.status,
+        product_name=order.product_name,
+        sale_price=str(order.sale_price) if order.sale_price is not None else None,
+        sale_currency=order.sale_currency,
+        wallet_method_id=order.wallet_method_id,
+        wallet_item_id=order.wallet_item_id,
+    )
+
+
+@router.get(
+    "/accounts/{account_id}/orders",
+    response_model=list[OperatorOrderOut],
+    response_model_by_alias=True,
+)
+def operator_list_orders_endpoint(
+    account_id: int,
+    operator_id: int = Query(..., alias="operatorId"),
+    only_pending: bool = Query(True, alias="onlyPending"),
+    db: Session = Depends(get_db),
+) -> list[OperatorOrderOut]:
+    """客服看该账号的订单列表(默认只看待补销售的)。"""
+    _require_holding(db, account_id, operator_id)
+    stmt = select(XboxOrder).where(XboxOrder.account_id == account_id)
+    if only_pending:
+        stmt = stmt.where(XboxOrder.status == XboxOrderStatus.PENDING_COMPLETE.value)
+    stmt = stmt.order_by(XboxOrder.order_at.desc())
+    return [_serialize_op_order(o) for o in db.scalars(stmt)]
+
+
+class OperatorOrderCompletion(BaseModel):
+    """客服补销售信息。销售日期 + 经办人系统自动填,客服只填商品/售价/币种/收款方式/备注模板。"""
+
+    model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
+
+    operator_id: int
+    product_name: str = Field(..., min_length=1, max_length=255)
+    sale_price: Decimal
+    sale_currency: str
+    wallet_method_id: int
+    wallet_item_id: int
+
+
+@router.patch(
+    "/orders/{order_id}/completion",
+    response_model=OperatorOrderOut,
+    response_model_by_alias=True,
+)
+def operator_complete_order_endpoint(
+    order_id: int,
+    request: OperatorOrderCompletion,
+    db: Session = Depends(get_db),
+) -> OperatorOrderOut:
+    """客服补销售信息(自动经办人 = 客服显示名;销售日期已自动 = order_at)。
+
+    校验: 客服必须持有该订单对应的账号。
+    成功后订单 status 变 converted(若所有字段就位)。
+    """
+    order = db.get(XboxOrder, order_id)
+    if order is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="订单不存在")
+    _account, operator = _require_holding(db, order.account_id, request.operator_id)
+
+    try:
+        update_order_completion(
+            db,
+            order,
+            # sale_date 不传 → 保持自动填的 order_at
+            product_name=request.product_name.strip(),
+            # 经办人系统自动填(CEO 2026-05-11: 自动填客服名字)
+            operator_name=operator.display_name,
+            sale_price=request.sale_price,
+            sale_currency=request.sale_currency,
+            wallet_method_id=request.wallet_method_id,
+            wallet_item_id=request.wallet_item_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    db.commit()
+    db.refresh(order)
+    return _serialize_op_order(order)

--- a/tests/test_operator_account_api.py
+++ b/tests/test_operator_account_api.py
@@ -1,0 +1,317 @@
+"""客服 exe 端: 账号详情 + 同步 + 补销售信息 API (CEO 2026-05-12 PR-C)。"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pyotp
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.models.wallet import Wallet, WalletType, Currency, create_wallet
+from src.models.xbox import XboxWalletItem, XboxWalletMethod
+from src.services.assets import ensure_default_asset_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'operator_c.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+# ---------------- 帮助函数 ----------------
+
+
+def _create_operator(client, login_name, display_name=None, password="Pwd123456"):
+    r = client.post(
+        "/operator/operators",
+        json={
+            "loginName": login_name,
+            "displayName": display_name or login_name,
+            "password": password,
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _create_xbox_account(client, account_no="X-PR-C-001"):
+    r = client.post(
+        "/xbox/accounts",
+        json={
+            "name": account_no,
+            "country": "US",
+            "accountNo": account_no,
+            "loginEmail": "x@test.com",
+            "password": "MicrosoftPwd123",
+            "exchangeRate": "7.2",
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _mark_available(client, account_id, available=True):
+    r = client.patch(
+        f"/xbox/accounts/{account_id}/availability",
+        json={"isAvailableForClaim": available},
+    )
+    assert r.status_code == 200, r.text
+
+
+def _claim(client, account_id, operator_id):
+    r = client.post(
+        "/operator/claims",
+        json={"accountId": account_id, "operatorId": operator_id},
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _ensure_wallet_setting(client) -> tuple[int, int, int]:
+    """创建 1 个钱包池 + 1 个收款方式 + 1 个备注模板。返回 (pool_id, method_id, item_id)。"""
+    db = database.SessionLocal()
+    try:
+        # 找一个 CNY 钱包(默认资产 RMB 主钱包)
+        pool = db.scalars(
+            db.query(Wallet).filter(Wallet.currency == Currency.CNY).order_by(Wallet.id).statement
+        ).first()
+        assert pool is not None
+        method = XboxWalletMethod(code="test_method_pr_c", label="测试方式", is_active=True)
+        db.add(method)
+        db.flush()
+        item = XboxWalletItem(
+            method_id=method.id,
+            code="test_item_pr_c",
+            label="测试备注",
+            wallet_pool_id=pool.id,
+            is_active=True,
+        )
+        db.add(item)
+        db.commit()
+        return pool.id, method.id, item.id
+    finally:
+        db.close()
+
+
+# ---------------- 账号详情 ----------------
+
+
+def test_get_account_detail_includes_plaintext_password_and_balance(client):
+    op = _create_operator(client, "detail_user")
+    acc = _create_xbox_account(client, "DETAIL-1")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op["operatorId"])
+
+    r = client.get(
+        f"/operator/accounts/{acc['id']}?operatorId={op['operatorId']}"
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["accountNo"] == "DETAIL-1"
+    assert body["loginEmail"] == "x@test.com"
+    # 关键: 密码明文必须解密返回(客服需要拿来登录 Microsoft)
+    assert body["passwordPlain"] == "MicrosoftPwd123"
+    assert body["localBalance"] == "0"
+    assert body["status"] == "active"
+
+
+def test_get_account_detail_forbidden_if_not_holder(client):
+    op_a = _create_operator(client, "holder_a")
+    op_b = _create_operator(client, "non_holder_b")
+    acc = _create_xbox_account(client, "DETAIL-FORBID")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op_a["operatorId"])
+
+    # op_b 没领,不能看
+    r = client.get(
+        f"/operator/accounts/{acc['id']}?operatorId={op_b['operatorId']}"
+    )
+    assert r.status_code == 403
+    assert "无权" in r.json()["detail"]
+
+
+def test_get_account_detail_404_if_no_account(client):
+    op = _create_operator(client, "ghost")
+    r = client.get(f"/operator/accounts/999999?operatorId={op['operatorId']}")
+    assert r.status_code == 404
+
+
+# ---------------- 同步订单 ----------------
+
+
+def test_sync_orders_by_operator_updates_balance(client):
+    """客服触发同步: 调 trigger_sync, 更新账号余额, 写订单。"""
+    op = _create_operator(client, "syncer")
+    acc = _create_xbox_account(client, "SYNC-1")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op["operatorId"])
+
+    r = client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op["operatorId"], "count": 10},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["success"] is True
+    assert body["ordersAdded"] >= 1
+    assert body["balance"] is not None
+
+    # 账号余额更新了 (stub balance=123.45)
+    detail = client.get(
+        f"/operator/accounts/{acc['id']}?operatorId={op['operatorId']}"
+    ).json()
+    assert Decimal(detail["localBalance"]) == Decimal("123.45")
+
+
+def test_sync_orders_forbidden_if_not_holder(client):
+    op_a = _create_operator(client, "holder_sync_a")
+    op_b = _create_operator(client, "non_holder_sync")
+    acc = _create_xbox_account(client, "SYNC-FORBID")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op_a["operatorId"])
+
+    r = client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op_b["operatorId"], "count": 10},
+    )
+    assert r.status_code == 403
+
+
+def test_sync_orders_invalid_count_400(client):
+    op = _create_operator(client, "bad_count")
+    acc = _create_xbox_account(client, "SYNC-BAD-COUNT")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op["operatorId"])
+
+    r = client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op["operatorId"], "count": 13},
+    )
+    assert r.status_code == 400
+
+
+# ---------------- 订单列表 ----------------
+
+
+def test_list_pending_orders_returns_synced_orders(client):
+    op = _create_operator(client, "lister")
+    acc = _create_xbox_account(client, "LIST-1")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op["operatorId"])
+
+    # 先同步出订单
+    client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op["operatorId"], "count": 10},
+    )
+    r = client.get(
+        f"/operator/accounts/{acc['id']}/orders?operatorId={op['operatorId']}"
+    )
+    assert r.status_code == 200
+    orders = r.json()
+    assert len(orders) >= 1
+    # 默认只看待补的
+    assert all(o["status"] == "pending_complete" for o in orders)
+    # sale_date 已经自动 = order_at (CEO 2026-05-12 PR-A)
+    for o in orders:
+        assert o["saleDate"] == o["orderAt"]
+
+
+def test_list_orders_forbidden_if_not_holder(client):
+    op_a = _create_operator(client, "list_a")
+    op_b = _create_operator(client, "list_b")
+    acc = _create_xbox_account(client, "LIST-FORBID")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op_a["operatorId"])
+
+    r = client.get(
+        f"/operator/accounts/{acc['id']}/orders?operatorId={op_b['operatorId']}"
+    )
+    assert r.status_code == 403
+
+
+# ---------------- 补销售信息 ----------------
+
+
+def test_complete_order_auto_fills_operator_name(client):
+    """客服补销售: operatorName 自动 = 客服 display_name (CEO 2026-05-11)。"""
+    op = _create_operator(client, "completer", display_name="李客服")
+    acc = _create_xbox_account(client, "COMPLETE-1")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op["operatorId"])
+
+    # 同步出订单
+    client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op["operatorId"], "count": 10},
+    )
+    orders = client.get(
+        f"/operator/accounts/{acc['id']}/orders?operatorId={op['operatorId']}"
+    ).json()
+    order_id = orders[0]["id"]
+
+    pool_id, method_id, item_id = _ensure_wallet_setting(client)
+
+    r = client.patch(
+        f"/operator/orders/{order_id}/completion",
+        json={
+            "operatorId": op["operatorId"],
+            "productName": "5350 档",
+            "salePrice": "5350",
+            "saleCurrency": "CNY",
+            "walletMethodId": method_id,
+            "walletItemId": item_id,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["productName"] == "5350 档"
+    assert Decimal(body["salePrice"]) == Decimal("5350")
+    assert body["status"] == "converted"
+
+    # 验证销售记录里 operator_name 自动是 "李客服"
+    records = client.get("/xbox/sale-records").json()
+    matching = [r for r in records if r["accountId"] == acc["id"]]
+    assert len(matching) == 1
+    assert matching[0]["operatorName"] == "李客服"
+
+
+def test_complete_order_forbidden_if_not_holder(client):
+    op_a = _create_operator(client, "comp_a")
+    op_b = _create_operator(client, "comp_b")
+    acc = _create_xbox_account(client, "COMP-FORBID")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op_a["operatorId"])
+
+    client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op_a["operatorId"], "count": 10},
+    )
+    orders = client.get(
+        f"/operator/accounts/{acc['id']}/orders?operatorId={op_a['operatorId']}"
+    ).json()
+    order_id = orders[0]["id"]
+
+    pool_id, method_id, item_id = _ensure_wallet_setting(client)
+
+    r = client.patch(
+        f"/operator/orders/{order_id}/completion",
+        json={
+            "operatorId": op_b["operatorId"],
+            "productName": "x",
+            "salePrice": "100",
+            "saleCurrency": "CNY",
+            "walletMethodId": method_id,
+            "walletItemId": item_id,
+        },
+    )
+    assert r.status_code == 403


### PR DESCRIPTION
## 业务背景（CEO 2026-05-12）

客服 exe 准备工作 **PR-C**（共 4 个 PR 滚动推进）：
- ✅ PR A (#120 merged): 销售日期自动 + 同步更新余额
- ✅ PR B (#121 merged): Electron 骨架 + 登录页 + 工作台
- ✅ PR-C 修复 (#122 merged): 启动脚本换 Node 版 + 新 skill
- **PR C（本 PR）**：账号详情页 + 同步订单 + 补销售信息
- ⏳ PR D: 历史销售记录页 + Electron 打包 .exe

## Summary

### 后端（src/routers/operator.py，新 5 个端点）
- `GET /operator/accounts/{id}?operatorId=X` — 账号详情**含密码明文**（AES-GCM 解密，仅持有人能拿）+ 当前余额
- `POST /operator/accounts/{id}/sync-orders` — 客服触发 Microsoft 同步，余额自动更新
- `GET /operator/accounts/{id}/orders` — 看该账号的订单（默认 pending）
- `PATCH /operator/orders/{id}/completion` — 客服补销售；销售日期自动 = order_at，经办人自动 = operator.display_name
- 权限：每个端点都校验 `operator` 当前持有该账号（active claim），非持有人 403

### 前端 `frontend-operator/`
- `app/accounts/[id]/page.tsx` + `components/account-detail.tsx`：
  - 账号信息卡：编号 / 邮箱 / 密码（眼睛切换 + 复制按钮）/ 汇率 / 状态
  - 余额卡：本币余额 + 上次同步时间 + 同步条数（10/20/30/50）+ 同步按钮
  - 「打开 Microsoft 登录页」按钮（外部浏览器）
  - 待补订单表 → 「补销售」按钮
- `components/complete-order-modal.tsx`：
  - 销售日期 + 经办人**只读**（系统自动）
  - 商品名 / 售价 / 币种 / 收款方式 / 备注模板 → 提交后订单变 converted
- 工作台「我领的账号」点击行跳详情页

## Test plan

- [x] `pytest tests/` → **226 passed**（含 10 个新增）
- [x] `tsc --noEmit` 无类型错误
- [x] `next build` 4 路由生成成功（/、/login、/accounts/[id]、/_not-found）
- [ ] 手测（PM 重启 Electron 后 CEO 直接试）：
  1. 登录客服
  2. 工作台点「我领的账号」一行 → 进详情
  3. 看到密码明文（眼睛切换）+ 余额 0 + 同步条数选择
  4. 点同步 → 余额变 123.45 + 出现 3 个待补订单
  5. 点「补销售」→ 填商品/售价/币种/收款方式/备注模板 → 提交
  6. 订单从列表消失 → CEO web 销售记录页能看到这条新销售

### 新增测试覆盖
- 账号详情含密码明文 + 余额；非持有人 403；账号不存在 404
- 客服同步 → 余额更新 → 非持有人 403 → count 非法 400
- 订单列表只看 pending；非持有人 403
- 补销售自动填经办人 = 客服显示名；非持有人 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)