### PR TITLE
fix(frontend): next.config.js 后端端口走 BACKEND_PORT env

### DIFF
--- a/frontend-operator/next.config.js
+++ b/frontend-operator/next.config.js
@@ -1,14 +1,15 @@
 /** @type {import('next').NextConfig} */
+const BACKEND_PORT = process.env.BACKEND_PORT || "8000";
 const nextConfig = {
   // Electron 打包用静态导出
   output: process.env.NEXT_EXPORT === "1" ? "export" : undefined,
-  // 开发时把 /api/* 转给后端 (本机 8000)
+  // 开发时把 /api/* 转给后端 (BACKEND_PORT env 默认 8000)
   async rewrites() {
     if (process.env.NEXT_EXPORT === "1") return [];
     return [
       {
         source: "/api/:path*",
-        destination: "http://localhost:8000/:path*"
+        destination: `http://localhost:${BACKEND_PORT}/:path*`
       }
     ];
   },

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,10 +1,11 @@
 /** @type {import('next').NextConfig} */
+const BACKEND_PORT = process.env.BACKEND_PORT || "8000";
 const nextConfig = {
   async rewrites() {
     return [
       {
         source: "/api/:path*",
-        destination: "http://localhost:8000/:path*"
+        destination: `http://localhost:${BACKEND_PORT}/:path*`
       }
     ];
   }


### PR DESCRIPTION
Windows TCP 偶发 phantom socket(进程退出后 listener 不清理),导致后端不得不换端口启动。前端 proxy 现在读 BACKEND_PORT env(默认 8000),遇到 phantom 时切个端口就行。