### PR TITLE
feat(operator-exe): 工作台主流程重排 + 历史订单 9 列表 + 订单备注

### DIFF
--- a/frontend-operator/app/page.tsx
+++ b/frontend-operator/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { OperatorDashboard } from "@/components/dashboard";
+import { OperatorWorkbench } from "@/components/workbench";
 import { useRequireAuth } from "@/lib/auth";
 
 export default function Home() {
@@ -14,5 +14,5 @@ export default function Home() {
     );
   }
 
-  return <OperatorDashboard operator={operator} />;
+  return <OperatorWorkbench operator={operator} />;
 }

--- a/frontend-operator/components/complete-order-modal.tsx
+++ b/frontend-operator/components/complete-order-modal.tsx
@@ -35,6 +35,7 @@ export function CompleteOrderModal({
   const [walletItemId, setWalletItemId] = useState<number | "">(
     order.walletItemId ?? ""
   );
+  const [remark, setRemark] = useState(order.remark ?? "");
   const [error, setError] = useState<string | null>(null);
 
   const methodsQuery = useQuery({
@@ -67,11 +68,12 @@ export function CompleteOrderModal({
         salePrice: salePrice.trim(),
         saleCurrency,
         walletMethodId,
-        walletItemId
+        walletItemId,
+        remark: remark.trim() || undefined
       });
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["operator-orders", order.accountId] });
+      await queryClient.invalidateQueries({ queryKey: ["operator-orders"] });
       onClose();
     },
     onError: (err) => setError(err instanceof Error ? err.message : "提交失败")
@@ -200,6 +202,18 @@ export function CompleteOrderModal({
                   </option>
                 ))}
             </select>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-xs font-medium">
+              备注（可自由填写）
+            </label>
+            <textarea
+              className="min-h-[60px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={remark}
+              onChange={(e) => setRemark(e.target.value)}
+              placeholder="如: 客户加急 / 续费 / 特殊情况备忘"
+            />
           </div>
 
           {error ? (

--- a/frontend-operator/components/workbench.tsx
+++ b/frontend-operator/components/workbench.tsx
@@ -1,0 +1,701 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Copy,
+  ExternalLink,
+  Eye,
+  EyeOff,
+  Gamepad2,
+  Globe2,
+  KeyRound,
+  LogOut,
+  PackageOpen,
+  PencilLine,
+  RefreshCcw,
+  Undo2,
+  Wallet,
+  Zap
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { CompleteOrderModal } from "@/components/complete-order-modal";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table";
+import {
+  claimAccount,
+  getAccountDetail,
+  getAccountOrders,
+  getAvailableAccounts,
+  getMyClaims,
+  returnClaim,
+  syncOrders
+} from "@/lib/api";
+import { clearSession, type StoredOperator } from "@/lib/auth";
+import { formatDateTimeSeconds } from "@/lib/utils";
+import type { OperatorOrder } from "@/types";
+
+const MAX_CLAIMS = 3;
+const SYNC_COUNTS = [10, 20, 30, 50] as const;
+const MICROSOFT_LOGIN_URL = "https://login.live.com/";
+
+// ===================================================================
+// 主工作台 (CEO 2026-05-12 重排: 选账号 → 同步 → 历史订单 → 补销售)
+// ===================================================================
+
+export function OperatorWorkbench({ operator }: { operator: StoredOperator }) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  const [selectedAccountId, setSelectedAccountId] = useState<number | null>(null);
+  const [syncCount, setSyncCount] = useState<10 | 20 | 30 | 50>(20);
+  const [error, setError] = useState<string | null>(null);
+  const [syncSummary, setSyncSummary] = useState<string | null>(null);
+  const [completeTarget, setCompleteTarget] = useState<OperatorOrder | null>(null);
+  const [claimPanelOpen, setClaimPanelOpen] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+
+  // 我领的账号 — 用于账号选择器
+  const claimsQuery = useQuery({
+    queryKey: ["operator-my-claims", operator.id],
+    queryFn: () => getMyClaims(operator.id)
+  });
+  const activeClaims = (claimsQuery.data ?? []).filter((c) => c.isActive);
+
+  // 选中账号详情
+  const detailQuery = useQuery({
+    queryKey: ["account-detail", selectedAccountId, operator.id],
+    queryFn: () => getAccountDetail(selectedAccountId!, operator.id),
+    enabled: selectedAccountId !== null
+  });
+
+  // 历史订单(全部, pending + converted)
+  const ordersQuery = useQuery({
+    queryKey: ["operator-orders", selectedAccountId, operator.id],
+    queryFn: () => getAccountOrders(selectedAccountId!, operator.id, false),
+    enabled: selectedAccountId !== null
+  });
+  const orders = ordersQuery.data ?? [];
+
+  // 自动选中第一个领取的账号
+  useEffect(() => {
+    if (selectedAccountId === null && activeClaims.length > 0) {
+      setSelectedAccountId(activeClaims[0].accountId);
+    }
+    // 如果当前选中的账号已被归还,自动切换或清空
+    if (
+      selectedAccountId !== null &&
+      activeClaims.length > 0 &&
+      !activeClaims.some((c) => c.accountId === selectedAccountId)
+    ) {
+      setSelectedAccountId(activeClaims[0].accountId);
+    }
+    if (activeClaims.length === 0 && selectedAccountId !== null) {
+      setSelectedAccountId(null);
+    }
+  }, [activeClaims, selectedAccountId]);
+
+  const syncMut = useMutation({
+    mutationFn: () => syncOrders(selectedAccountId!, operator.id, syncCount),
+    onSuccess: async (data) => {
+      setError(null);
+      const balanceText = data.balance
+        ? `, 余额 ${data.balance.balance} ${data.balance.currency}`
+        : "";
+      const failText = data.failure ? ` | 失败: ${data.failure.message}` : "";
+      setSyncSummary(
+        `同步完成: +${data.ordersAdded} 单 / 跳过 ${data.ordersSkipped}${balanceText}${failText}`
+      );
+      await queryClient.invalidateQueries({ queryKey: ["operator-orders"] });
+      await queryClient.invalidateQueries({ queryKey: ["account-detail"] });
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "同步失败")
+  });
+
+  // 客服信息
+  const claimedAccount = detailQuery.data;
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-10 flex items-center justify-between border-b border-border bg-background/95 px-6 py-3 backdrop-blur">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary text-primary-foreground">
+            <Gamepad2 className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="text-sm font-semibold">XBOX 客服销售系统</div>
+            <div className="text-xs text-muted-foreground">
+              {operator.displayName} · 持有 {activeClaims.length}/{MAX_CLAIMS} 个账号
+            </div>
+          </div>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            if (activeClaims.length > 0) {
+              if (
+                !confirm(`你还持有 ${activeClaims.length} 个账号未归还，确定退出登录？`)
+              ) {
+                return;
+              }
+            }
+            clearSession();
+            router.replace("/login");
+          }}
+        >
+          <LogOut className="h-3.5 w-3.5" />
+          退出
+        </Button>
+      </header>
+
+      <main className="mx-auto w-full max-w-7xl space-y-4 px-6 py-4">
+        {error ? (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+            {error}
+          </div>
+        ) : null}
+
+        {/* ----- 主操作区: 账号选择 + 同步 ----- */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="flex items-center gap-2 text-base">
+              <Zap className="h-4 w-4" />
+              选择账号 → 同步 Microsoft 订单
+            </CardTitle>
+            <div className="text-xs text-muted-foreground">
+              主流程: 选你领的账号 → 点同步 → 下方加载历史订单 → 待补的点「补销售」
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {activeClaims.length === 0 ? (
+              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-3 text-sm text-amber-800">
+                <div className="font-medium">还没领取账号</div>
+                <div className="mt-1 text-xs">
+                  打开下方「账号领取」面板,从「可领账号池」选一个领取后再来同步。
+                </div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_auto_auto] md:items-end">
+                {/* 账号选择 */}
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    账号 (你领取的 {activeClaims.length} 个)
+                  </label>
+                  <select
+                    className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+                    value={selectedAccountId ?? ""}
+                    onChange={(e) =>
+                      setSelectedAccountId(e.target.value ? Number(e.target.value) : null)
+                    }
+                  >
+                    {activeClaims.map((claim) => (
+                      <option key={claim.id} value={claim.accountId}>
+                        账号 #{claim.accountId}
+                        {claimedAccount && claimedAccount.id === claim.accountId
+                          ? ` (${claimedAccount.accountNo ?? claimedAccount.name})`
+                          : ""}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                {/* 同步条数 */}
+                <div className="space-y-1">
+                  <label className="text-xs font-medium text-muted-foreground">
+                    同步条数
+                  </label>
+                  <div className="flex gap-1">
+                    {SYNC_COUNTS.map((n) => (
+                      <Button
+                        key={n}
+                        size="sm"
+                        variant={syncCount === n ? "default" : "outline"}
+                        onClick={() => setSyncCount(n)}
+                        className="h-10 px-3"
+                      >
+                        {n}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* 同步按钮 */}
+                <div className="space-y-1">
+                  <label className="invisible text-xs">.</label>
+                  <Button
+                    className="h-10"
+                    onClick={() => {
+                      setError(null);
+                      setSyncSummary(null);
+                      syncMut.mutate();
+                    }}
+                    disabled={syncMut.isPending || selectedAccountId === null}
+                  >
+                    <Zap className="h-3.5 w-3.5" />
+                    {syncMut.isPending ? "同步中…" : "同步订单"}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {syncSummary ? (
+              <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800">
+                <CheckCircle2 className="mr-1 inline h-3 w-3" />
+                {syncSummary}
+              </div>
+            ) : null}
+
+            {/* 当前账号信息(密码 / 邮箱 / 余额 / Microsoft 登录入口) */}
+            {claimedAccount ? (
+              <div className="grid grid-cols-1 gap-3 rounded-md border border-border bg-muted/30 p-3 md:grid-cols-4">
+                <FieldMini label="登录邮箱" value={claimedAccount.loginEmail ?? "-"} copyable />
+                <div className="space-y-1">
+                  <div className="text-[10px] font-medium text-muted-foreground">密码</div>
+                  <div className="flex items-center gap-1">
+                    <span className="flex-1 truncate font-mono text-sm">
+                      {claimedAccount.passwordPlain
+                        ? showPassword
+                          ? claimedAccount.passwordPlain
+                          : "•".repeat(Math.min(10, claimedAccount.passwordPlain.length))
+                        : "(未设置)"}
+                    </span>
+                    {claimedAccount.passwordPlain ? (
+                      <>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => setShowPassword((s) => !s)}
+                          className="h-6 w-6 p-0"
+                          title={showPassword ? "隐藏" : "显示"}
+                        >
+                          {showPassword ? (
+                            <EyeOff className="h-3 w-3" />
+                          ) : (
+                            <Eye className="h-3 w-3" />
+                          )}
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() =>
+                            claimedAccount.passwordPlain &&
+                            navigator.clipboard?.writeText(claimedAccount.passwordPlain)
+                          }
+                          className="h-6 w-6 p-0"
+                          title="复制"
+                        >
+                          <Copy className="h-3 w-3" />
+                        </Button>
+                      </>
+                    ) : null}
+                  </div>
+                </div>
+                <FieldMini
+                  label={`本币余额 (${claimedAccount.currency})`}
+                  value={`${claimedAccount.localBalance} ${claimedAccount.currency}`}
+                  mono
+                />
+                <div className="space-y-1">
+                  <div className="text-[10px] font-medium text-muted-foreground">
+                    上次同步
+                  </div>
+                  <div className="text-xs tabular-nums">
+                    {formatDateTimeSeconds(claimedAccount.lastSyncedAt)}
+                  </div>
+                  <a
+                    href={MICROSOFT_LOGIN_URL}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex items-center gap-1 text-xs text-blue-700 hover:underline"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                    打开 Microsoft 登录页
+                  </a>
+                </div>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        {/* ----- 历史订单表 ----- */}
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between pb-3">
+            <div>
+              <CardTitle className="text-base">历史订单</CardTitle>
+              <div className="mt-1 text-xs text-muted-foreground">
+                同步后所有订单(待补 + 已转销售)都列在这。点「补销售」补齐订单。
+              </div>
+            </div>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => ordersQuery.refetch()}
+              disabled={ordersQuery.isFetching || selectedAccountId === null}
+            >
+              <RefreshCcw className="h-3.5 w-3.5" />
+              刷新
+            </Button>
+          </CardHeader>
+          <CardContent className="p-0">
+            <HistoryOrdersTable
+              orders={orders}
+              loading={selectedAccountId !== null && ordersQuery.isLoading}
+              empty={
+                selectedAccountId === null
+                  ? "先选账号 + 点同步"
+                  : "暂无订单, 点上方「同步订单」拉取"
+              }
+              onCompleteOrder={(o) => setCompleteTarget(o)}
+            />
+          </CardContent>
+        </Card>
+
+        {/* ----- 附加: 账号领取/归还面板(默认折叠) ----- */}
+        <Card>
+          <CardHeader
+            className="cursor-pointer pb-3"
+            onClick={() => setClaimPanelOpen((v) => !v)}
+          >
+            <CardTitle className="flex items-center justify-between text-sm">
+              <span className="flex items-center gap-2">
+                <PackageOpen className="h-4 w-4" />
+                账号领取 / 归还（附加功能）
+              </span>
+              {claimPanelOpen ? (
+                <ChevronUp className="h-4 w-4" />
+              ) : (
+                <ChevronDown className="h-4 w-4" />
+              )}
+            </CardTitle>
+          </CardHeader>
+          {claimPanelOpen ? (
+            <CardContent>
+              <ClaimPanel operator={operator} activeClaims={activeClaims} />
+            </CardContent>
+          ) : null}
+        </Card>
+      </main>
+
+      {completeTarget ? (
+        <CompleteOrderModal
+          order={completeTarget}
+          operatorId={operator.id}
+          operatorDisplayName={operator.displayName}
+          onClose={() => setCompleteTarget(null)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ===================================================================
+// 历史订单表 (CEO 2026-05-12 Q2: 9 列)
+// ===================================================================
+
+function HistoryOrdersTable({
+  orders,
+  loading,
+  empty,
+  onCompleteOrder
+}: {
+  orders: OperatorOrder[];
+  loading: boolean;
+  empty: string;
+  onCompleteOrder: (order: OperatorOrder) => void;
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>账号编号</TableHead>
+          <TableHead>订单编号</TableHead>
+          <TableHead>类型</TableHead>
+          <TableHead>日期(秒)</TableHead>
+          <TableHead>商品名称</TableHead>
+          <TableHead>经办人</TableHead>
+          <TableHead>收款方式</TableHead>
+          <TableHead className="text-right">收款金额</TableHead>
+          <TableHead>备注</TableHead>
+          <TableHead className="text-right">操作</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {orders.map((order) => {
+          const isPending = order.status === "pending_complete";
+          return (
+            <TableRow key={order.id}>
+              <TableCell className="font-mono text-xs">
+                {order.accountNo ?? `#${order.accountId}`}
+              </TableCell>
+              <TableCell className="font-mono text-xs">{order.orderNo}</TableCell>
+              <TableCell>
+                {isPending ? (
+                  <Badge tone="warning">待补</Badge>
+                ) : (
+                  <Badge tone="success">已转销售</Badge>
+                )}
+              </TableCell>
+              <TableCell className="text-xs tabular-nums">
+                {formatDateTimeSeconds(order.orderAt)}
+              </TableCell>
+              <TableCell className="text-sm">
+                {order.productName ?? <span className="text-muted-foreground">-</span>}
+              </TableCell>
+              <TableCell className="text-xs">
+                {order.operatorName ?? <span className="text-muted-foreground">-</span>}
+              </TableCell>
+              <TableCell className="text-xs">
+                {order.walletMethodLabel ? (
+                  <div className="flex flex-col">
+                    <span>{order.walletMethodLabel}</span>
+                    {order.walletItemLabel ? (
+                      <span className="text-[10px] text-muted-foreground">
+                        {order.walletItemLabel}
+                      </span>
+                    ) : null}
+                  </div>
+                ) : (
+                  <span className="text-muted-foreground">-</span>
+                )}
+              </TableCell>
+              <TableCell className="text-right tabular-nums font-semibold">
+                {order.salePrice ? (
+                  <>
+                    {order.salePrice}
+                    <span className="ml-1 text-[10px] font-normal text-muted-foreground">
+                      {order.saleCurrency}
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    {order.amountLocal} {order.currencyLocal}
+                  </span>
+                )}
+              </TableCell>
+              <TableCell className="max-w-[160px] truncate text-xs text-muted-foreground">
+                {order.remark ?? "-"}
+              </TableCell>
+              <TableCell className="text-right">
+                <Button
+                  size="sm"
+                  variant={isPending ? "default" : "ghost"}
+                  onClick={() => onCompleteOrder(order)}
+                  title={isPending ? "补销售信息" : "修改销售信息(拆单)"}
+                >
+                  <PencilLine className="h-3.5 w-3.5" />
+                  {isPending ? "补销售" : "改"}
+                </Button>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+        {orders.length === 0 ? (
+          <TableRow>
+            <TableCell colSpan={10} className="py-8 text-center text-xs text-muted-foreground">
+              {loading ? "加载中…" : empty}
+            </TableCell>
+          </TableRow>
+        ) : null}
+      </TableBody>
+    </Table>
+  );
+}
+
+// ===================================================================
+// 附加: 账号领取/归还 (折叠面板)
+// ===================================================================
+
+function ClaimPanel({
+  operator,
+  activeClaims
+}: {
+  operator: StoredOperator;
+  activeClaims: { id: number; accountId: number; claimedAt: string }[];
+}) {
+  const queryClient = useQueryClient();
+  const [panelError, setPanelError] = useState<string | null>(null);
+
+  const availableQuery = useQuery({
+    queryKey: ["operator-available-accounts"],
+    queryFn: getAvailableAccounts
+  });
+
+  const claimMut = useMutation({
+    mutationFn: (accountId: number) => claimAccount(accountId, operator.id),
+    onSuccess: async () => {
+      setPanelError(null);
+      await queryClient.invalidateQueries({
+        queryKey: ["operator-available-accounts"]
+      });
+      await queryClient.invalidateQueries({ queryKey: ["operator-my-claims"] });
+    },
+    onError: (err) => setPanelError(err instanceof Error ? err.message : "领取失败")
+  });
+
+  const returnMut = useMutation({
+    mutationFn: (claimId: number) => returnClaim(claimId, operator.id),
+    onSuccess: async () => {
+      setPanelError(null);
+      await queryClient.invalidateQueries({
+        queryKey: ["operator-available-accounts"]
+      });
+      await queryClient.invalidateQueries({ queryKey: ["operator-my-claims"] });
+    },
+    onError: (err) => setPanelError(err instanceof Error ? err.message : "归还失败")
+  });
+
+  const available = availableQuery.data ?? [];
+  const slotsLeft = Math.max(0, MAX_CLAIMS - activeClaims.length);
+
+  return (
+    <div className="space-y-3">
+      <div className="text-xs text-muted-foreground">
+        业务规则: 1 个账号同一时刻只能 1 人持有；每人最多 3 个。下班前请手动归还。
+      </div>
+
+      {panelError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+          {panelError}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        {/* 我领的 */}
+        <div className="space-y-2">
+          <div className="text-xs font-medium">
+            我的领取 ({activeClaims.length}/{MAX_CLAIMS})
+          </div>
+          <div className="space-y-1">
+            {activeClaims.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border px-3 py-3 text-center text-xs text-muted-foreground">
+                还没领账号
+              </div>
+            ) : (
+              activeClaims.map((claim) => (
+                <div
+                  key={claim.id}
+                  className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2"
+                >
+                  <div>
+                    <div className="text-sm font-medium">账号 #{claim.accountId}</div>
+                    <div className="text-[10px] text-muted-foreground tabular-nums">
+                      {formatDateTimeSeconds(claim.claimedAt)}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      if (confirm(`归还账号 #${claim.accountId}？`)) {
+                        returnMut.mutate(claim.id);
+                      }
+                    }}
+                    disabled={returnMut.isPending}
+                  >
+                    <Undo2 className="h-3.5 w-3.5" />
+                    归还
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* 可领账号池 */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="text-xs font-medium">可领账号池 ({available.length})</div>
+            <span className="text-[10px] text-muted-foreground">
+              还能再领 {slotsLeft} 个
+            </span>
+          </div>
+          <div className="space-y-1 max-h-[300px] overflow-y-auto">
+            {available.length === 0 ? (
+              <div className="rounded-md border border-dashed border-border px-3 py-3 text-center text-xs text-muted-foreground">
+                暂无可领账号 (CEO 后台未标"可出库")
+              </div>
+            ) : (
+              available.map((account) => (
+                <div
+                  key={account.id}
+                  className="flex items-center justify-between rounded-md border border-border bg-card px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-1 text-sm font-medium">
+                      <Badge tone={account.country === "UK" ? "danger" : "transfer"}>
+                        <Globe2 className="mr-1 h-3 w-3" />
+                        {account.country}
+                      </Badge>
+                      <span className="font-mono">{account.accountNo ?? account.name}</span>
+                    </div>
+                    <div className="truncate text-[10px] text-muted-foreground">
+                      {account.loginEmail ?? "-"}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={() => claimMut.mutate(account.id)}
+                    disabled={claimMut.isPending || slotsLeft <= 0}
+                  >
+                    领取
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ===================================================================
+// 小组件
+// ===================================================================
+
+function FieldMini({
+  label,
+  value,
+  copyable = false,
+  mono = false
+}: {
+  label: string;
+  value: string;
+  copyable?: boolean;
+  mono?: boolean;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="text-[10px] font-medium text-muted-foreground">{label}</div>
+      <div className="flex items-center gap-1">
+        <span className={`${mono ? "font-mono" : ""} flex-1 truncate text-sm`}>
+          {value}
+        </span>
+        {copyable && value !== "-" ? (
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => navigator.clipboard?.writeText(value)}
+            className="h-6 w-6 p-0"
+            title="复制"
+          >
+            <Copy className="h-3 w-3" />
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend-operator/lib/api.ts
+++ b/frontend-operator/lib/api.ts
@@ -128,7 +128,7 @@ export function syncOrders(
 export function getAccountOrders(
   accountId: number,
   operatorId: number,
-  onlyPending = true
+  onlyPending = false // CEO 2026-05-12: 默认返回全部历史订单
 ): Promise<OperatorOrder[]> {
   return request<OperatorOrder[]>(
     `/api/operator/accounts/${accountId}/orders?operatorId=${operatorId}&onlyPending=${onlyPending}`
@@ -144,6 +144,7 @@ export function completeOrder(
     saleCurrency: SaleCurrency;
     walletMethodId: number;
     walletItemId: number;
+    remark?: string;
   }
 ): Promise<OperatorOrder> {
   return request<OperatorOrder>(

--- a/frontend-operator/types.ts
+++ b/frontend-operator/types.ts
@@ -65,20 +65,27 @@ export type SyncOrdersResult = {
 };
 
 // 客服 exe 看的订单
+// CEO 2026-05-12: 历史订单表 9 列 (账号编号 / 订单编号 / 类型 / 日期 / 商品名 /
+//   经办人 / 收款方式 / 收款金额 / 备注) — 字段全部映射在这。
 export type OperatorOrder = {
   id: number;
   accountId: number;
-  orderNo: string;
-  amountLocal: string;
-  currencyLocal: string;
-  orderAt: string;
-  saleDate: string | null;
-  status: string;
-  productName: string | null;
-  salePrice: string | null;
+  accountNo: string | null;        // 账号编号
+  orderNo: string;                  // 订单编号
+  amountLocal: string;              // 本币金额(微软订单原始金额)
+  currencyLocal: string;            // 本币币种 USD/GBP
+  orderAt: string;                  // 订单时间(=日期, 精确到秒)
+  saleDate: string | null;          // 销售日期(自动=orderAt)
+  status: string;                   // 类型: pending_complete / converted
+  productName: string | null;       // 商品名
+  operatorName: string | null;      // 经办人
+  salePrice: string | null;         // 收款金额
   saleCurrency: string | null;
   walletMethodId: number | null;
+  walletMethodLabel: string | null; // 收款方式 label
   walletItemId: number | null;
+  walletItemLabel: string | null;   // 备注模板 label
+  remark: string | null;            // CEO 2026-05-12: 可自由填写
 };
 
 // 钱包设置 (复用 /xbox/wallet-settings)

--- a/src/database.py
+++ b/src/database.py
@@ -49,6 +49,7 @@ def init_db() -> None:
     _ensure_xbox_account_extended_columns()
     _ensure_xbox_account_is_available_for_claim_column()
     _ensure_xbox_account_country_identified_column()
+    _ensure_xbox_order_remark_column()
     _migrate_xbox_sale_date_to_datetime()
 
 
@@ -157,6 +158,20 @@ def _ensure_xbox_account_country_identified_column() -> None:
                 "BOOLEAN NOT NULL DEFAULT 0"
             )
         )
+
+
+def _ensure_xbox_order_remark_column() -> None:
+    """加 XBOX 订单"备注"字段(CEO 2026-05-12: 客服补销售可自由填写)。"""
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+    inspector = inspect(engine)
+    if "xbox_orders" not in inspector.get_table_names():
+        return
+    column_names = {column["name"] for column in inspector.get_columns("xbox_orders")}
+    if "remark" in column_names:
+        return
+    with engine.begin() as connection:
+        connection.execute(text("ALTER TABLE xbox_orders ADD COLUMN remark TEXT"))
 
 
 def _migrate_xbox_sale_date_to_datetime() -> None:

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -199,6 +199,8 @@ class XboxOrder(Base):
     wallet_item_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("xbox_wallet_items.id"), nullable=True
     )
+    # CEO 2026-05-12: 客服补销售时可自由填写的备注
+    remark: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     # 关联（方案 3 双向）
     sale_record_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("xbox_sale_records.id"), nullable=True, index=True

--- a/src/routers/operator.py
+++ b/src/routers/operator.py
@@ -529,12 +529,16 @@ def operator_sync_orders_endpoint(
 
 
 class OperatorOrderOut(BaseModel):
-    """客服 exe 看的订单(简化版,只暴露客服需要的字段)。"""
+    """客服 exe 看的订单(简化版,只暴露客服需要的字段)。
+
+    CEO 2026-05-12: 历史订单表展示 9 列 — 字段都映射到这里。
+    """
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
 
     id: int
     account_id: int
+    account_no: Optional[str]  # 账号编号(给历史订单表用,免去前端再查)
     order_no: str
     amount_local: str
     currency_local: str
@@ -542,16 +546,28 @@ class OperatorOrderOut(BaseModel):
     sale_date: Optional[str]
     status: str
     product_name: Optional[str]
+    operator_name: Optional[str]  # 经办人(=补销售时填的客服名)
     sale_price: Optional[str]
     sale_currency: Optional[str]
     wallet_method_id: Optional[int]
+    wallet_method_label: Optional[str]  # 收款方式 label(展示用)
     wallet_item_id: Optional[int]
+    wallet_item_label: Optional[str]  # 备注模板 label(展示用)
+    remark: Optional[str]  # CEO 2026-05-12: 客服自由填写的备注
 
 
-def _serialize_op_order(order: XboxOrder) -> OperatorOrderOut:
+def _serialize_op_order(
+    order: XboxOrder,
+    *,
+    account_no_map: Optional[dict[int, Optional[str]]] = None,
+    method_label_map: Optional[dict[int, str]] = None,
+    item_label_map: Optional[dict[int, str]] = None,
+) -> OperatorOrderOut:
+    """序列化客服 exe 端订单。可传 label 映射避免每行单独 query。"""
     return OperatorOrderOut(
         id=order.id,
         account_id=order.account_id,
+        account_no=(account_no_map or {}).get(order.account_id),
         order_no=order.order_no,
         amount_local=str(order.amount_local),
         currency_local=order.currency_local,
@@ -559,10 +575,22 @@ def _serialize_op_order(order: XboxOrder) -> OperatorOrderOut:
         sale_date=order.sale_date.isoformat() if order.sale_date else None,
         status=order.status,
         product_name=order.product_name,
+        operator_name=order.operator_name,
         sale_price=str(order.sale_price) if order.sale_price is not None else None,
         sale_currency=order.sale_currency,
         wallet_method_id=order.wallet_method_id,
+        wallet_method_label=(
+            (method_label_map or {}).get(order.wallet_method_id)
+            if order.wallet_method_id is not None
+            else None
+        ),
         wallet_item_id=order.wallet_item_id,
+        wallet_item_label=(
+            (item_label_map or {}).get(order.wallet_item_id)
+            if order.wallet_item_id is not None
+            else None
+        ),
+        remark=order.remark,
     )
 
 
@@ -574,20 +602,51 @@ def _serialize_op_order(order: XboxOrder) -> OperatorOrderOut:
 def operator_list_orders_endpoint(
     account_id: int,
     operator_id: int = Query(..., alias="operatorId"),
-    only_pending: bool = Query(True, alias="onlyPending"),
+    only_pending: bool = Query(False, alias="onlyPending"),
     db: Session = Depends(get_db),
 ) -> list[OperatorOrderOut]:
-    """客服看该账号的订单列表(默认只看待补销售的)。"""
-    _require_holding(db, account_id, operator_id)
+    """客服看该账号的订单列表。
+
+    CEO 2026-05-12: 默认返回**所有历史订单**(pending + converted),展示在工作台
+    主表里;只看待补可传 onlyPending=true。
+    """
+    account, _ = _require_holding(db, account_id, operator_id)
     stmt = select(XboxOrder).where(XboxOrder.account_id == account_id)
     if only_pending:
         stmt = stmt.where(XboxOrder.status == XboxOrderStatus.PENDING_COMPLETE.value)
     stmt = stmt.order_by(XboxOrder.order_at.desc())
-    return [_serialize_op_order(o) for o in db.scalars(stmt)]
+    orders = list(db.scalars(stmt))
+
+    # 一次性查 method/item labels(避免每行 query)
+    from src.models.xbox import XboxWalletItem, XboxWalletMethod
+
+    method_ids = {o.wallet_method_id for o in orders if o.wallet_method_id is not None}
+    item_ids = {o.wallet_item_id for o in orders if o.wallet_item_id is not None}
+    method_label_map: dict[int, str] = {}
+    item_label_map: dict[int, str] = {}
+    if method_ids:
+        for m in db.scalars(select(XboxWalletMethod).where(XboxWalletMethod.id.in_(method_ids))):
+            method_label_map[m.id] = m.label
+    if item_ids:
+        for it in db.scalars(select(XboxWalletItem).where(XboxWalletItem.id.in_(item_ids))):
+            item_label_map[it.id] = it.label
+
+    account_no_map = {account.id: account.account_no}
+    return [
+        _serialize_op_order(
+            o,
+            account_no_map=account_no_map,
+            method_label_map=method_label_map,
+            item_label_map=item_label_map,
+        )
+        for o in orders
+    ]
 
 
 class OperatorOrderCompletion(BaseModel):
-    """客服补销售信息。销售日期 + 经办人系统自动填,客服只填商品/售价/币种/收款方式/备注模板。"""
+    """客服补销售信息。销售日期 + 经办人系统自动填,
+    客服填: 商品 / 售价 / 币种 / 收款方式 / 备注模板 / 备注(可自由填写)。
+    """
 
     model_config = ConfigDict(populate_by_name=True, alias_generator=_to_camel)
 
@@ -597,6 +656,7 @@ class OperatorOrderCompletion(BaseModel):
     sale_currency: str
     wallet_method_id: int
     wallet_item_id: int
+    remark: Optional[str] = None  # CEO 2026-05-12: 客服自由填写
 
 
 @router.patch(
@@ -617,7 +677,7 @@ def operator_complete_order_endpoint(
     order = db.get(XboxOrder, order_id)
     if order is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="订单不存在")
-    _account, operator = _require_holding(db, order.account_id, request.operator_id)
+    account, operator = _require_holding(db, order.account_id, request.operator_id)
 
     try:
         update_order_completion(
@@ -632,9 +692,31 @@ def operator_complete_order_endpoint(
             wallet_method_id=request.wallet_method_id,
             wallet_item_id=request.wallet_item_id,
         )
+        # CEO 2026-05-12: 备注独立字段, 不走 update_order_completion (它不管 remark)
+        if request.remark is not None:
+            order.remark = request.remark.strip() or None
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     db.commit()
     db.refresh(order)
-    return _serialize_op_order(order)
+
+    # 序列化时填 labels 给前端
+    from src.models.xbox import XboxWalletItem, XboxWalletMethod
+
+    method_label_map = {}
+    item_label_map = {}
+    if order.wallet_method_id is not None:
+        m = db.get(XboxWalletMethod, order.wallet_method_id)
+        if m:
+            method_label_map[m.id] = m.label
+    if order.wallet_item_id is not None:
+        it = db.get(XboxWalletItem, order.wallet_item_id)
+        if it:
+            item_label_map[it.id] = it.label
+    return _serialize_op_order(
+        order,
+        account_no_map={account.id: account.account_no},
+        method_label_map=method_label_map,
+        item_label_map=item_label_map,
+    )

--- a/tests/test_operator_account_api.py
+++ b/tests/test_operator_account_api.py
@@ -202,7 +202,8 @@ def test_sync_orders_invalid_count_400(client):
 # ---------------- 订单列表 ----------------
 
 
-def test_list_pending_orders_returns_synced_orders(client):
+def test_list_orders_returns_synced_orders_with_labels(client):
+    """CEO 2026-05-12: 默认返回所有订单(pending + converted),并带 labels。"""
     op = _create_operator(client, "lister")
     acc = _create_xbox_account(client, "LIST-1")
     _mark_available(client, acc["id"])
@@ -219,11 +220,37 @@ def test_list_pending_orders_returns_synced_orders(client):
     assert r.status_code == 200
     orders = r.json()
     assert len(orders) >= 1
-    # 默认只看待补的
+    # 默认返回全部 (CEO 2026-05-12 改了默认值 onlyPending=False)
+    # 这时还没补销售,所以全部 pending
     assert all(o["status"] == "pending_complete" for o in orders)
     # sale_date 已经自动 = order_at (CEO 2026-05-12 PR-A)
+    # 同时新字段都在 response 里
     for o in orders:
         assert o["saleDate"] == o["orderAt"]
+        assert "accountNo" in o
+        assert o["accountNo"] == "LIST-1"
+        assert "remark" in o  # 新字段
+        assert "operatorName" in o
+        assert "walletMethodLabel" in o
+        assert "walletItemLabel" in o
+
+
+def test_list_orders_only_pending_query_works(client):
+    """传 onlyPending=true 时只返回 pending_complete 订单。"""
+    op = _create_operator(client, "only_pending_test")
+    acc = _create_xbox_account(client, "OP-1")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op["operatorId"])
+    client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op["operatorId"], "count": 10},
+    )
+    r = client.get(
+        f"/operator/accounts/{acc['id']}/orders"
+        f"?operatorId={op['operatorId']}&onlyPending=true"
+    )
+    assert r.status_code == 200
+    assert all(o["status"] == "pending_complete" for o in r.json())
 
 
 def test_list_orders_forbidden_if_not_holder(client):
@@ -240,6 +267,50 @@ def test_list_orders_forbidden_if_not_holder(client):
 
 
 # ---------------- 补销售信息 ----------------
+
+
+def test_complete_order_with_remark_persists(client):
+    """CEO 2026-05-12: 客服补销售时填 remark, 后续读出来还在。"""
+    op = _create_operator(client, "remarker", display_name="备注客服")
+    acc = _create_xbox_account(client, "REMARK-1")
+    _mark_available(client, acc["id"])
+    _claim(client, acc["id"], op["operatorId"])
+
+    client.post(
+        f"/operator/accounts/{acc['id']}/sync-orders",
+        json={"operatorId": op["operatorId"], "count": 10},
+    )
+    orders = client.get(
+        f"/operator/accounts/{acc['id']}/orders?operatorId={op['operatorId']}"
+    ).json()
+    order_id = orders[0]["id"]
+    _pool, method_id, item_id = _ensure_wallet_setting(client)
+
+    r = client.patch(
+        f"/operator/orders/{order_id}/completion",
+        json={
+            "operatorId": op["operatorId"],
+            "productName": "5350 档",
+            "salePrice": "5350",
+            "saleCurrency": "CNY",
+            "walletMethodId": method_id,
+            "walletItemId": item_id,
+            "remark": "客户加急 / 老板娘要的",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["remark"] == "客户加急 / 老板娘要的"
+    assert body["operatorName"] == "备注客服"
+    assert body["walletMethodLabel"]  # 新字段, 不该为空
+    assert body["walletItemLabel"]
+
+    # 再 GET 一次, 备注还在
+    all_orders = client.get(
+        f"/operator/accounts/{acc['id']}/orders?operatorId={op['operatorId']}"
+    ).json()
+    matching = next(o for o in all_orders if o["id"] == order_id)
+    assert matching["remark"] == "客户加急 / 老板娘要的"
 
 
 def test_complete_order_auto_fills_operator_name(client):


### PR DESCRIPTION
## CEO 2026-05-12 反馈

> "领取账号只是销售系统的附加项, 主要项是为销售自动爬订单, 然后客服补齐"
> "以选择账号的方式选择, 选好点同步, 下方自动加载所有历史订单"
> "备注可自由填写"
> Q2: 9 列 (账号编号 / 订单编号 / 类型 / 日期(秒) / 商品名 / 经办人 / 收款方式 / 收款金额 / 备注)

同时修复了之前的 bug:客服 exe 点账号详情显示"加载失败"(根因:旧的 3100 Next.js 还在用过时的 `BACKEND_PORT=8001`, 现在统一走 8002)。

## Summary

### 后端
- 新字段 `XboxOrder.remark`(TEXT, nullable)+ SQLite migration
- `/operator/orders/{id}/completion` 接受 `remark`
- `/operator/accounts/{id}/orders`:
  - 默认 `onlyPending=false`(返回全部历史)
  - 响应加 `walletMethodLabel` / `walletItemLabel` / `operatorName` / `accountNo` / `remark`
  - 一次性查 label 字典,避免 N+1
- 测试 234/234 ✓

### frontend-operator(主流程重排)
新建 `components/workbench.tsx` 取代旧 dashboard:
- **顶部主操作**:账号下拉(我领的) → 同步条数 → 同步按钮
- **账号信息条**(同步卡里):邮箱 / 密码(眼睛切换+复制) / 余额 / 上次同步 / Microsoft 登录入口
- **中央历史订单表 9 列**:
  | 账号编号 | 订单编号 | **类型**(待补/已转销售徽章) | **日期(秒)** | 商品名 | 经办人 | 收款方式 | **收款金额** | **备注** | 操作 |
- **底部折叠面板**:「账号领取 / 归还」(降级为附加功能)
- `complete-order-modal` 加 remark textarea

## Test plan

- [x] `pytest tests/` → **234 passed**(原 232 + 新 2)
- [x] `tsc --noEmit` 0 错
- [x] `next build` 4 路由 OK
- [ ] PM 已重启后端 + 客服 web + Electron 等 CEO 手测:
  1. 客服 exe 登录 → 工作台
  2. 顶部下拉选账号 → 看到密码/余额/邮箱条
  3. 点「同步订单」→ 下方历史订单表自动出 9 列
  4. 待补订单点「补销售」→ 弹窗有商品/售价/币种/方式/模板/**备注**字段
  5. 提交后订单类型变"已转销售"
  6. 底部折叠点开 → 领取/归还附加功能仍可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)