### PR TITLE
[PR] [wallet] #129 划转单(钱包间转账) — 台币→USDT 等跨货币归集

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -47,6 +47,8 @@ def init_db() -> None:
     _ensure_wallet_is_group_column()
     _ensure_wallet_transaction_business_date_column()
     _ensure_wallet_transaction_operator_name_column()
+    _ensure_wallet_transfers_table()
+    _ensure_wallet_transaction_transfer_id_column()
     _ensure_xbox_account_extended_columns()
     _ensure_xbox_account_is_available_for_claim_column()
     _ensure_xbox_account_country_identified_column()
@@ -224,6 +226,48 @@ def _ensure_wallet_transaction_operator_name_column() -> None:
         return
     with engine.begin() as connection:
         connection.execute(text("ALTER TABLE wallet_transactions ADD COLUMN operator_name VARCHAR(120)"))
+
+
+def _ensure_wallet_transfers_table() -> None:
+    """Issue #129: 启动时建 wallet_transfers 表(划转单).
+
+    SQLAlchemy create_all 已经会建表, 这里仅作为防御性 fallback: 若旧库
+    metadata 没注册到 WalletTransfer (例如表删了又没重启), 也能补回来.
+    """
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+    inspector = inspect(engine)
+    if "wallet_transfers" in inspector.get_table_names():
+        return
+    # 通过 create_all 走 SQLAlchemy 的 DDL 比手写 SQL 更安全; 这里 import 一下确保
+    # WalletTransfer 注册进 metadata
+    from src.models.wallet import WalletTransfer  # noqa: F401
+    Base.metadata.create_all(bind=engine, tables=[WalletTransfer.__table__])
+
+
+def _ensure_wallet_transaction_transfer_id_column() -> None:
+    """Issue #129: 给 wallet_transactions 表加 transfer_id 列(FK + 索引).
+
+    用于把同一笔划转的 OUT/IN 两条流水绑死. 普通 credit/debit 流水留 NULL.
+    """
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+    inspector = inspect(engine)
+    if "wallet_transactions" not in inspector.get_table_names():
+        return
+    column_names = {column["name"] for column in inspector.get_columns("wallet_transactions")}
+    if "transfer_id" in column_names:
+        return
+    with engine.begin() as connection:
+        # SQLite 加 FK 列只能不带 REFERENCES 约束(SQLite 不支持 ALTER 加 FK).
+        # SQLAlchemy ORM 层仍会按 FK 解析; 数据完整性靠业务层保证.
+        connection.execute(text("ALTER TABLE wallet_transactions ADD COLUMN transfer_id INTEGER"))
+        connection.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS idx_wallet_transactions_transfer_id "
+                "ON wallet_transactions(transfer_id)"
+            )
+        )
 
 
 def _ensure_wallet_transaction_business_date_column() -> None:

--- a/src/main.py
+++ b/src/main.py
@@ -40,6 +40,7 @@ from src.routers.xbox import router as xbox_router
 from src.routers.taobao import router as taobao_router
 from src.routers.taiwan import router as taiwan_router
 from src.routers.transfers import router as transfers_router
+from src.routers.wallet_transfers import router as wallet_transfers_router
 from src.services.assets import ensure_default_asset_wallets
 from src.services.taiwan import ensure_default_taiwan_wallets
 from src.services.taobao import ensure_default_taobao_wallets
@@ -94,6 +95,7 @@ app.include_router(xbox_router)
 app.include_router(taobao_router)
 app.include_router(taiwan_router)
 app.include_router(transfers_router)
+app.include_router(wallet_transfers_router, prefix="/api/wallet-transfers", tags=["wallet-transfers"])
 
 
 @app.get("/health")

--- a/src/models/wallet.py
+++ b/src/models/wallet.py
@@ -100,8 +100,53 @@ class WalletTransaction(Base):
         Date,
         nullable=True,
     )
+    # Issue #129: 关联划转单(钱包间转账). 一笔划转 = 两条 wallet_transactions
+    # (一 OUT 一 IN), 用 transfer_id 绑死. 普通的 credit/debit 流水留 NULL.
+    transfer_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("wallet_transfers.id"),
+        nullable=True,
+        index=True,
+    )
 
     wallet: Mapped[Wallet] = relationship(back_populates="transactions")
+
+
+class WalletTransfer(Base):
+    """划转单 — 一笔钱从 A 钱包搬到 B 钱包, 记录两边金额和汇率快照.
+
+    Issue #129 (CEO 2026-05-18):
+    - 典型场景: 台湾同事把 TWD 兑成 USDT 打到资产钱包, 一条 transfer = 两条 tx
+    - 用户填两个金额 (出账/入账), 系统自动算 rate = to_amount / from_amount
+    - from_currency / to_currency 必须**快照**, 防钱包后续改名/改币种导致历史汇率失真
+    - 软删除 (deleted_at) 用于"撤销划转": 反向冲销两条流水 + 标记 deleted_at
+    """
+
+    __tablename__ = "wallet_transfers"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    from_wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id"), nullable=False, index=True)
+    to_wallet_id: Mapped[int] = mapped_column(ForeignKey("wallets.id"), nullable=False, index=True)
+    from_amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    to_amount: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    # 汇率精度比金额高 2 位, 保留 8 位小数足够覆盖 USDT/CNY/TWD 间小数级别波动
+    rate: Mapped[Decimal] = mapped_column(Numeric(18, 8), nullable=False)
+    from_currency: Mapped[str] = mapped_column(String(8), nullable=False)
+    to_currency: Mapped[str] = mapped_column(String(8), nullable=False)
+    business_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    operator_name: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=china_now,
+    )
+    deleted_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+
+    from_wallet: Mapped[Wallet] = relationship(foreign_keys=[from_wallet_id])
+    to_wallet: Mapped[Wallet] = relationship(foreign_keys=[to_wallet_id])
 
 
 def _to_decimal(amount: Decimal | int | float | str) -> Decimal:

--- a/src/routers/wallet_transfers.py
+++ b/src/routers/wallet_transfers.py
@@ -1,0 +1,203 @@
+"""划转单 (钱包间转账) HTTP 路由.
+
+Issue #129: 一笔划转 = 两条 wallet_transactions(OUT + IN), 用 transfer_id 绑死,
+锁汇率快照. 典型场景: 台湾 TWD → 资产 USDT 归集.
+
+端点:
+- POST   /api/wallet-transfers       创建划转
+- GET    /api/wallet-transfers       列表 + 筛选
+- GET    /api/wallet-transfers/{id}  详情(含两条流水引用)
+- DELETE /api/wallet-transfers/{id}  撤销(反向冲销 + 软删)
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.wallet import Wallet, WalletTransfer
+from src.services.wallet_transfer import (
+    cancel_transfer,
+    create_transfer,
+    find_transfer_transactions,
+    get_transfer,
+    list_transfers,
+)
+
+
+router = APIRouter()
+
+
+# -------- Pydantic 模型 --------
+
+
+class WalletTransferCreateRequest(BaseModel):
+    from_wallet_id: int = Field(..., gt=0)
+    to_wallet_id: int = Field(..., gt=0)
+    from_amount: Decimal = Field(..., gt=0, description="出账金额, 正数")
+    to_amount: Decimal = Field(..., gt=0, description="入账金额, 正数")
+    business_date: Optional[date] = None
+    operator_name: Optional[str] = Field(None, max_length=120)
+    note: Optional[str] = None
+
+
+class TransferTransactionRef(BaseModel):
+    """划转关联的流水简要引用(详情接口里返回 2 条)."""
+
+    id: int
+    wallet_id: int
+    direction: str
+    amount: Decimal
+    remark: Optional[str] = None
+
+
+class WalletTransferOut(BaseModel):
+    id: int
+    from_wallet_id: int
+    to_wallet_id: int
+    from_wallet_name: Optional[str] = None
+    to_wallet_name: Optional[str] = None
+    from_amount: Decimal
+    to_amount: Decimal
+    rate: Decimal
+    from_currency: str
+    to_currency: str
+    business_date: Optional[date] = None
+    operator_name: Optional[str] = None
+    note: Optional[str] = None
+    created_at: str
+    deleted_at: Optional[str] = None
+    transactions: list[TransferTransactionRef] = []
+
+
+def _serialize_transfer(
+    session: Session, transfer: WalletTransfer, include_tx: bool = True
+) -> WalletTransferOut:
+    """序列化划转单. include_tx=True 时附带关联流水(详情接口用)."""
+    from_wallet = session.get(Wallet, transfer.from_wallet_id)
+    to_wallet = session.get(Wallet, transfer.to_wallet_id)
+
+    tx_refs: list[TransferTransactionRef] = []
+    if include_tx:
+        for tx in find_transfer_transactions(session, transfer.id):
+            direction = tx.direction.value if hasattr(tx.direction, "value") else tx.direction
+            tx_refs.append(
+                TransferTransactionRef(
+                    id=tx.id,
+                    wallet_id=tx.wallet_id,
+                    direction=direction,
+                    amount=Decimal(tx.amount),
+                    remark=tx.remark,
+                )
+            )
+
+    return WalletTransferOut(
+        id=transfer.id,
+        from_wallet_id=transfer.from_wallet_id,
+        to_wallet_id=transfer.to_wallet_id,
+        from_wallet_name=from_wallet.name if from_wallet else None,
+        to_wallet_name=to_wallet.name if to_wallet else None,
+        from_amount=Decimal(transfer.from_amount),
+        to_amount=Decimal(transfer.to_amount),
+        rate=Decimal(transfer.rate),
+        from_currency=transfer.from_currency,
+        to_currency=transfer.to_currency,
+        business_date=transfer.business_date,
+        operator_name=transfer.operator_name,
+        note=transfer.note,
+        created_at=transfer.created_at.isoformat() if transfer.created_at else "",
+        deleted_at=transfer.deleted_at.isoformat() if transfer.deleted_at else None,
+        transactions=tx_refs,
+    )
+
+
+# -------- 端点 --------
+
+
+@router.post("", response_model=WalletTransferOut, status_code=status.HTTP_201_CREATED)
+def create_wallet_transfer(
+    request: WalletTransferCreateRequest,
+    db: Session = Depends(get_db),
+) -> WalletTransferOut:
+    """创建划转单. 事务: 校验 → debit from → credit to → 建 transfer → 绑 tx."""
+    try:
+        transfer = create_transfer(
+            db,
+            from_wallet_id=request.from_wallet_id,
+            to_wallet_id=request.to_wallet_id,
+            from_amount=request.from_amount,
+            to_amount=request.to_amount,
+            business_date=request.business_date,
+            operator_name=request.operator_name,
+            note=request.note,
+        )
+    except ValueError as exc:
+        db.rollback()
+        message = str(exc)
+        # 找不到钱包用 404, 其他业务校验失败用 400
+        if "不存在" in message:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.commit()
+    db.refresh(transfer)
+    return _serialize_transfer(db, transfer, include_tx=True)
+
+
+@router.get("", response_model=list[WalletTransferOut])
+def list_wallet_transfers(
+    from_wallet_id: Optional[int] = Query(None),
+    to_wallet_id: Optional[int] = Query(None),
+    from_date: Optional[date] = Query(None),
+    to_date: Optional[date] = Query(None),
+    operator_name: Optional[str] = Query(None),
+    include_deleted: bool = Query(False, description="是否含已撤销的"),
+    db: Session = Depends(get_db),
+) -> list[WalletTransferOut]:
+    transfers = list_transfers(
+        db,
+        from_wallet_id=from_wallet_id,
+        to_wallet_id=to_wallet_id,
+        from_date=from_date,
+        to_date=to_date,
+        operator_name=operator_name,
+        include_deleted=include_deleted,
+    )
+    # 列表为了性能不带流水明细, 想看 2 条流水去详情接口
+    return [_serialize_transfer(db, t, include_tx=False) for t in transfers]
+
+
+@router.get("/{transfer_id}", response_model=WalletTransferOut)
+def get_wallet_transfer(transfer_id: int, db: Session = Depends(get_db)) -> WalletTransferOut:
+    transfer = get_transfer(db, transfer_id)
+    if transfer is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="划转单不存在")
+    return _serialize_transfer(db, transfer, include_tx=True)
+
+
+@router.delete("/{transfer_id}", response_model=WalletTransferOut)
+def cancel_wallet_transfer(transfer_id: int, db: Session = Depends(get_db)) -> WalletTransferOut:
+    """撤销划转: 反向冲销 + 软删. 撤销后 to_wallet 余额需要够扣回."""
+    try:
+        transfer = cancel_transfer(db, transfer_id)
+    except ValueError as exc:
+        db.rollback()
+        message = str(exc)
+        if "不存在" in message:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.commit()
+    db.refresh(transfer)
+    return _serialize_transfer(db, transfer, include_tx=True)

--- a/src/services/wallet_transfer.py
+++ b/src/services/wallet_transfer.py
@@ -1,0 +1,236 @@
+"""划转单(钱包间转账) 业务服务.
+
+Issue #129 (CEO 2026-05-18):
+- 一笔划转 = 两条 wallet_transactions(一 OUT 一 IN), 通过 transfer_id 绑死
+- 用户填两个金额, 系统自动算 rate = to_amount / from_amount
+- from_currency / to_currency 是钱包当前币种的快照, 防钱包改名/改币种导致历史汇率失真
+- 撤销: 反向冲销两条流水 + transfer.deleted_at 软删
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import (
+    Currency,
+    Wallet,
+    WalletTransaction,
+    WalletTransfer,
+    credit,
+    debit,
+)
+from src.utils.time import china_now
+
+
+def _currency_value(wallet: Wallet) -> str:
+    return wallet.currency.value if isinstance(wallet.currency, Currency) else wallet.currency
+
+
+def _to_positive_decimal(amount: Decimal | int | float | str, field: str) -> Decimal:
+    value = Decimal(str(amount))
+    if value <= 0:
+        raise ValueError(f"{field} 必须大于 0")
+    return value
+
+
+def create_transfer(
+    session: Session,
+    *,
+    from_wallet_id: int,
+    to_wallet_id: int,
+    from_amount: Decimal | int | float | str,
+    to_amount: Decimal | int | float | str,
+    business_date: Optional[date] = None,
+    operator_name: Optional[str] = None,
+    note: Optional[str] = None,
+) -> WalletTransfer:
+    """创建划转单 + 两条关联流水.
+
+    事务关键步骤(全部在调用方 session 内, 由路由层 commit):
+    1. 校验: 两钱包都存在、非 group、非同钱包、from/to amount > 0
+    2. debit from_wallet
+    3. credit to_wallet
+    4. 创建 WalletTransfer(rate = to / from, from/to currency 快照)
+    5. 把两条 tx 的 transfer_id 更新为 transfer.id
+    6. flush + 返回
+    """
+    if from_wallet_id == to_wallet_id:
+        raise ValueError("不能划转到同一个钱包")
+
+    from_amount_dec = _to_positive_decimal(from_amount, "出账金额")
+    to_amount_dec = _to_positive_decimal(to_amount, "入账金额")
+
+    from_wallet = session.get(Wallet, from_wallet_id)
+    if from_wallet is None:
+        raise ValueError("出账钱包不存在")
+    to_wallet = session.get(Wallet, to_wallet_id)
+    if to_wallet is None:
+        raise ValueError("入账钱包不存在")
+
+    if from_wallet.is_group:
+        raise ValueError("出账钱包是分组节点, 不能记账")
+    if to_wallet.is_group:
+        raise ValueError("入账钱包是分组节点, 不能记账")
+    if from_wallet.deleted_at is not None:
+        raise ValueError("出账钱包已删除")
+    if to_wallet.deleted_at is not None:
+        raise ValueError("入账钱包已删除")
+
+    from_currency = _currency_value(from_wallet)
+    to_currency = _currency_value(to_wallet)
+    # 汇率精度 8 位, quantize 防止 to_amount/from_amount 出现长尾小数
+    rate = (to_amount_dec / from_amount_dec).quantize(Decimal("0.00000001"))
+
+    remark = f"[划转] {from_wallet.name}→{to_wallet.name} @ {rate}"
+
+    # debit 会抛 ValueError("insufficient wallet balance"), 由调用方 catch
+    out_tx = debit(
+        session,
+        from_wallet_id,
+        from_amount_dec,
+        remark=remark,
+        operator_name=operator_name,
+    )
+    in_tx = credit(
+        session,
+        to_wallet_id,
+        to_amount_dec,
+        remark=remark,
+        business_date=business_date,
+        operator_name=operator_name,
+    )
+
+    transfer = WalletTransfer(
+        from_wallet_id=from_wallet_id,
+        to_wallet_id=to_wallet_id,
+        from_amount=from_amount_dec,
+        to_amount=to_amount_dec,
+        rate=rate,
+        from_currency=from_currency,
+        to_currency=to_currency,
+        business_date=business_date,
+        operator_name=operator_name,
+        note=note,
+    )
+    session.add(transfer)
+    session.flush()
+
+    # 把两条 tx 的 transfer_id 绑定到新建的 transfer
+    out_tx.transfer_id = transfer.id
+    in_tx.transfer_id = transfer.id
+    session.flush()
+
+    return transfer
+
+
+def get_transfer(session: Session, transfer_id: int) -> Optional[WalletTransfer]:
+    return session.get(WalletTransfer, transfer_id)
+
+
+def list_transfers(
+    session: Session,
+    *,
+    from_wallet_id: Optional[int] = None,
+    to_wallet_id: Optional[int] = None,
+    from_date: Optional[date] = None,
+    to_date: Optional[date] = None,
+    operator_name: Optional[str] = None,
+    include_deleted: bool = False,
+) -> list[WalletTransfer]:
+    """列表 + 多条件筛选.
+
+    日期筛选用 business_date(没填则不参与该条件; 调用方可改为 created_at 但
+    业务上 CEO 关心的是"这笔划转算哪天的钱", 应该是 business_date).
+    """
+    stmt = select(WalletTransfer)
+    if not include_deleted:
+        stmt = stmt.where(WalletTransfer.deleted_at.is_(None))
+    if from_wallet_id is not None:
+        stmt = stmt.where(WalletTransfer.from_wallet_id == from_wallet_id)
+    if to_wallet_id is not None:
+        stmt = stmt.where(WalletTransfer.to_wallet_id == to_wallet_id)
+    if from_date is not None:
+        stmt = stmt.where(WalletTransfer.business_date >= from_date)
+    if to_date is not None:
+        stmt = stmt.where(WalletTransfer.business_date <= to_date)
+    if operator_name:
+        stmt = stmt.where(WalletTransfer.operator_name == operator_name)
+    stmt = stmt.order_by(WalletTransfer.id.desc())
+    return list(session.scalars(stmt))
+
+
+def find_transfer_transactions(
+    session: Session, transfer_id: int
+) -> list[WalletTransaction]:
+    """查这笔划转关联的所有 wallet_transactions(应该是 2 条: OUT + IN).
+
+    撤销时也包含为了撤销而新建的反向冲销流水, 这是有意的: 让"流水
+    透明"——撤销也是历史的一部分.
+    """
+    return list(
+        session.scalars(
+            select(WalletTransaction)
+            .where(WalletTransaction.transfer_id == transfer_id)
+            .order_by(WalletTransaction.id)
+        )
+    )
+
+
+def cancel_transfer(session: Session, transfer_id: int) -> WalletTransfer:
+    """撤销划转: 反向冲销 + 软删 transfer.
+
+    校验:
+    - transfer 存在且未被撤销
+    - to_wallet 当前余额够不够 to_amount(否则会变负余额, 拒绝)
+    - to_wallet / from_wallet 不能是 group / 已删除
+
+    操作:
+    - to_wallet debit (to_amount)
+    - from_wallet credit (from_amount)
+    - 两条新流水也挂同一个 transfer_id, remark 标 [撤销划转 #N]
+    - transfer.deleted_at = china_now()
+    """
+    transfer = session.get(WalletTransfer, transfer_id)
+    if transfer is None:
+        raise ValueError("划转单不存在")
+    if transfer.deleted_at is not None:
+        raise ValueError("划转单已撤销")
+
+    from_wallet = session.get(Wallet, transfer.from_wallet_id)
+    to_wallet = session.get(Wallet, transfer.to_wallet_id)
+    if from_wallet is None or to_wallet is None:
+        raise ValueError("关联钱包已删除, 无法撤销")
+    if from_wallet.deleted_at is not None or to_wallet.deleted_at is not None:
+        raise ValueError("关联钱包已删除, 无法撤销")
+    if from_wallet.is_group or to_wallet.is_group:
+        raise ValueError("关联钱包已变为分组, 无法撤销")
+
+    # 反向冲销: 先把入账的钱扣回去, 再把出账的钱补回来
+    # debit 会做余额校验, 不够时抛 ValueError("insufficient wallet balance")
+    remark = f"[撤销划转 #{transfer.id}] {from_wallet.name}←{to_wallet.name}"
+    reverse_out = debit(
+        session,
+        to_wallet.id,
+        Decimal(transfer.to_amount),
+        remark=remark,
+        operator_name=transfer.operator_name,
+    )
+    reverse_in = credit(
+        session,
+        from_wallet.id,
+        Decimal(transfer.from_amount),
+        remark=remark,
+        operator_name=transfer.operator_name,
+    )
+    # 撤销冲销的两条流水也挂同一个 transfer_id, 这样查流水时能完整看到一笔
+    # 划转的全过程(原始 OUT + 原始 IN + 撤销 OUT + 撤销 IN)
+    reverse_out.transfer_id = transfer.id
+    reverse_in.transfer_id = transfer.id
+
+    transfer.deleted_at = china_now()
+    session.flush()
+    return transfer

--- a/tests/test_wallet_transfer.py
+++ b/tests/test_wallet_transfer.py
@@ -1,0 +1,441 @@
+"""Issue #129 - 划转单 (钱包间转账) 测试."""
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src import database
+from src.main import app
+from src.models.wallet import Wallet
+from src.services.assets import ensure_default_asset_wallets
+from src.services.taiwan import ensure_default_taiwan_wallets
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'wallet_transfer.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        ensure_default_taiwan_wallets(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+def _find_wallet_id(wallets, name):
+    for wallet in wallets:
+        if wallet["name"] == name:
+            return wallet["id"]
+        found = _find_wallet_id(wallet.get("children", []), name)
+        if found:
+            return found
+    return None
+
+
+def _get_asset_leaf_id(client, name):
+    return _find_wallet_id(client.get("/wallets/assets").json(), name)
+
+
+def _get_taiwan_wallet_id(client, name):
+    for wallet in client.get("/taiwan/wallets").json():
+        if wallet["name"] == name:
+            return wallet["id"]
+    return None
+
+
+def _credit_asset(client, wallet_id, amount):
+    resp = client.post(f"/wallets/assets/{wallet_id}/credit", json={"amount": str(amount)})
+    assert resp.status_code == 201, resp.text
+
+
+def _credit_taiwan(client, wallet_id, amount):
+    resp = client.post(
+        f"/taiwan/wallets/{wallet_id}/credit",
+        json={"amount": str(amount), "remark": "test seed"},
+    )
+    assert resp.status_code == 201, resp.text
+
+
+def _wallet_balance(wallet_id):
+    db = database.SessionLocal()
+    try:
+        wallet = db.get(Wallet, wallet_id)
+        return Decimal(wallet.balance)
+    finally:
+        db.close()
+
+
+# ---- 1. 正向: 创建划转 → 两边余额变化, 汇率正确 ----
+
+
+def test_create_transfer_changes_balances_and_records_rate(client):
+    from_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    to_id = _get_asset_leaf_id(client, "TOM支付宝")
+    _credit_asset(client, from_id, "1000")
+
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "300",
+            "to_amount": "300",
+            "operator_name": "freeman",
+            "note": "test transfer",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert Decimal(body["from_amount"]) == Decimal("300")
+    assert Decimal(body["to_amount"]) == Decimal("300")
+    assert Decimal(body["rate"]) == Decimal("1")
+    assert body["from_currency"] == "CNY"
+    assert body["to_currency"] == "CNY"
+    assert body["operator_name"] == "freeman"
+    assert body["note"] == "test transfer"
+
+    # 余额变化
+    assert _wallet_balance(from_id) == Decimal("700")
+    assert _wallet_balance(to_id) == Decimal("300")
+
+    # 关联了 2 条流水, 一 OUT 一 IN
+    assert len(body["transactions"]) == 2
+    directions = {tx["direction"] for tx in body["transactions"]}
+    assert directions == {"in", "out"}
+    # 两条流水的 remark 都有"[划转]"前缀
+    for tx in body["transactions"]:
+        assert tx["remark"].startswith("[划转]")
+
+
+# ---- 2. 同币种划转 (rate=1, 内部资金调拨) ----
+
+
+def test_same_currency_transfer_rate_is_one(client):
+    from_id = _get_taiwan_wallet_id(client, "全支付")
+    to_id = _get_taiwan_wallet_id(client, "悠游付")
+    _credit_taiwan(client, from_id, "5000")
+
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "1000",
+            "to_amount": "1000",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert Decimal(body["rate"]) == Decimal("1")
+    assert body["from_currency"] == "TWD"
+    assert body["to_currency"] == "TWD"
+    assert _wallet_balance(from_id) == Decimal("4000")
+    assert _wallet_balance(to_id) == Decimal("1000")
+
+
+# ---- 3. 异币种划转 (TWD → USDT, 典型场景) ----
+
+
+def test_cross_currency_transfer_twd_to_usdt(client):
+    from_id = _get_taiwan_wallet_id(client, "全支付")  # TWD
+    to_id = _get_asset_leaf_id(client, "FREEMAN币安")  # USDT
+    _credit_taiwan(client, from_id, "30000")
+
+    # 30000 TWD → 1000 USDT, rate = 1000 / 30000 = 0.03333333
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "30000",
+            "to_amount": "1000",
+            "operator_name": "李睿旭",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["from_currency"] == "TWD"
+    assert body["to_currency"] == "USDT"
+    # rate = 1000 / 30000 = 0.03333333 (quantize 到 8 位小数)
+    assert Decimal(body["rate"]) == Decimal("0.03333333")
+    assert _wallet_balance(from_id) == Decimal("0")
+    assert _wallet_balance(to_id) == Decimal("1000")
+
+
+# ---- 4. 余额不足: from_wallet 余额不够 → 拒绝 ----
+
+
+def test_insufficient_balance_rejected(client):
+    from_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    to_id = _get_asset_leaf_id(client, "TOM支付宝")
+    _credit_asset(client, from_id, "100")  # 只有 100
+
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "500",
+            "to_amount": "500",
+        },
+    )
+    assert resp.status_code == 400, resp.text
+    assert "insufficient" in resp.json()["detail"].lower()
+
+    # 原子性: from 没扣, to 没增
+    assert _wallet_balance(from_id) == Decimal("100")
+    assert _wallet_balance(to_id) == Decimal("0")
+
+    # 列表里也不能出现这笔(已 rollback)
+    listing = client.get("/api/wallet-transfers").json()
+    assert listing == []
+
+
+# ---- 5. 同钱包: from == to → 拒绝 ----
+
+
+def test_same_wallet_rejected(client):
+    wallet_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    _credit_asset(client, wallet_id, "100")
+
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": wallet_id,
+            "to_wallet_id": wallet_id,
+            "from_amount": "10",
+            "to_amount": "10",
+        },
+    )
+    assert resp.status_code == 400
+    assert "同一个钱包" in resp.json()["detail"]
+
+
+# ---- 6. 撤销: 余额回到原状 ----
+
+
+def test_cancel_transfer_restores_balances(client):
+    from_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    to_id = _get_asset_leaf_id(client, "TOM支付宝")
+    _credit_asset(client, from_id, "1000")
+
+    # 先创建划转
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "300",
+            "to_amount": "300",
+        },
+    )
+    assert resp.status_code == 201
+    transfer_id = resp.json()["id"]
+    assert _wallet_balance(from_id) == Decimal("700")
+    assert _wallet_balance(to_id) == Decimal("300")
+
+    # 撤销
+    cancel_resp = client.delete(f"/api/wallet-transfers/{transfer_id}")
+    assert cancel_resp.status_code == 200, cancel_resp.text
+    body = cancel_resp.json()
+    assert body["deleted_at"] is not None
+    # 撤销后流水应该有 4 条 (原 OUT + 原 IN + 反向 OUT + 反向 IN)
+    assert len(body["transactions"]) == 4
+
+    # 余额回到原状
+    assert _wallet_balance(from_id) == Decimal("1000")
+    assert _wallet_balance(to_id) == Decimal("0")
+
+    # 默认列表不含已撤销
+    default_list = client.get("/api/wallet-transfers").json()
+    assert all(t["id"] != transfer_id for t in default_list)
+    # include_deleted=true 能看到
+    full_list = client.get("/api/wallet-transfers?include_deleted=true").json()
+    assert any(t["id"] == transfer_id for t in full_list)
+
+
+# ---- 7. 撤销时 to 余额不足 → 拒绝 ----
+
+
+def test_cancel_rejected_when_to_balance_insufficient(client):
+    from_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    to_id = _get_asset_leaf_id(client, "TOM支付宝")
+    _credit_asset(client, from_id, "1000")
+
+    # 划转 300 过去
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "300",
+            "to_amount": "300",
+        },
+    )
+    transfer_id = resp.json()["id"]
+    assert _wallet_balance(to_id) == Decimal("300")
+
+    # to_wallet 把钱花掉到只剩 50
+    debit_resp = client.post(
+        f"/wallets/assets/{to_id}/debit", json={"amount": "250"}
+    )
+    assert debit_resp.status_code == 201
+    assert _wallet_balance(to_id) == Decimal("50")
+
+    # 撤销应该被拒绝(to 只有 50, 但要扣回 300)
+    cancel_resp = client.delete(f"/api/wallet-transfers/{transfer_id}")
+    assert cancel_resp.status_code == 400, cancel_resp.text
+    assert "insufficient" in cancel_resp.json()["detail"].lower()
+
+    # 余额没变, transfer 也没被软删
+    assert _wallet_balance(from_id) == Decimal("700")
+    assert _wallet_balance(to_id) == Decimal("50")
+    get_resp = client.get(f"/api/wallet-transfers/{transfer_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["deleted_at"] is None
+
+
+# ---- 额外: 创建时金额非正 / group 钱包 / 钱包不存在 ----
+
+
+def test_create_transfer_rejects_non_positive_amount(client):
+    from_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    to_id = _get_asset_leaf_id(client, "TOM支付宝")
+    _credit_asset(client, from_id, "100")
+
+    # from_amount = 0 (被 pydantic gt=0 拦, 返回 422)
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "0",
+            "to_amount": "10",
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_create_transfer_rejects_group_wallet(client):
+    # RMB钱包 是顶级 group
+    wallets = client.get("/wallets/assets").json()
+    rmb_root_id = next(w["id"] for w in wallets if w["name"] == "RMB钱包")
+    leaf_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    _credit_asset(client, leaf_id, "100")
+
+    # group 作为 from
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": rmb_root_id,
+            "to_wallet_id": leaf_id,
+            "from_amount": "10",
+            "to_amount": "10",
+        },
+    )
+    assert resp.status_code == 400
+    assert "分组" in resp.json()["detail"]
+
+    # group 作为 to
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": leaf_id,
+            "to_wallet_id": rmb_root_id,
+            "from_amount": "10",
+            "to_amount": "10",
+        },
+    )
+    assert resp.status_code == 400
+    assert "分组" in resp.json()["detail"]
+
+
+def test_create_transfer_404_when_wallet_missing(client):
+    leaf_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    _credit_asset(client, leaf_id, "100")
+
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": leaf_id,
+            "to_wallet_id": 99999,
+            "from_amount": "10",
+            "to_amount": "10",
+        },
+    )
+    assert resp.status_code == 404
+
+
+# ---- 列表筛选 ----
+
+
+def test_list_filters_by_wallet_and_operator(client):
+    from_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    to_id_1 = _get_asset_leaf_id(client, "TOM支付宝")
+    to_id_2 = _get_asset_leaf_id(client, "BOSS支付宝")
+    _credit_asset(client, from_id, "1000")
+
+    client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id_1,
+            "from_amount": "100",
+            "to_amount": "100",
+            "operator_name": "freeman",
+        },
+    )
+    client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id_2,
+            "from_amount": "200",
+            "to_amount": "200",
+            "operator_name": "李睿旭",
+        },
+    )
+
+    # 按 to_wallet_id 筛
+    resp = client.get(f"/api/wallet-transfers?to_wallet_id={to_id_1}")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["to_wallet_id"] == to_id_1
+
+    # 按 operator 筛
+    resp = client.get("/api/wallet-transfers?operator_name=freeman")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+    assert items[0]["operator_name"] == "freeman"
+
+
+# ---- 双重撤销 ----
+
+
+def test_double_cancel_rejected(client):
+    from_id = _get_asset_leaf_id(client, "丙火网络支付宝")
+    to_id = _get_asset_leaf_id(client, "TOM支付宝")
+    _credit_asset(client, from_id, "1000")
+
+    resp = client.post(
+        "/api/wallet-transfers",
+        json={
+            "from_wallet_id": from_id,
+            "to_wallet_id": to_id,
+            "from_amount": "300",
+            "to_amount": "300",
+        },
+    )
+    transfer_id = resp.json()["id"]
+
+    # 第一次撤销 ok
+    assert client.delete(f"/api/wallet-transfers/{transfer_id}").status_code == 200
+    # 第二次撤销拒绝
+    second = client.delete(f"/api/wallet-transfers/{transfer_id}")
+    assert second.status_code == 400
+    assert "已撤销" in second.json()["detail"]


### PR DESCRIPTION
## 关联 Issue

Closes #129

## 改动说明

新增「划转单」机制 — 一笔 transfer = 两条 wallet_transactions(OUT + IN),用 transfer_id 绑死、汇率快照。

**模型 + 迁移** (`src/models/wallet.py` + `src/database.py`)
- 新表 `wallet_transfers`:from/to wallet+amount+currency, rate(自动算), business_date, operator_name, note, deleted_at(软删)
- `wallet_transactions` 加 `transfer_id` FK,索引
- 启动时自动建表 + ALTER 加列(SQLite 风格)

**服务层** (`src/services/wallet_transfer.py` 新文件)
- `create_transfer`:校验 → debit from → credit to → 建 transfer → 把两条 tx 绑 transfer_id
- `cancel_transfer`:反向冲销(同 transfer_id) + 软删
- `list_transfers`:按钱包/日期/操作人筛选
- `find_transfer_transactions`:查 transfer 关联的所有流水(含撤销冲销)

**路由** (`src/routers/wallet_transfers.py` 新文件)
- `POST /api/wallet-transfers` 创建
- `GET /api/wallet-transfers` 列表 + 筛选
- `GET /api/wallet-transfers/{id}` 详情(含两条流水)
- `DELETE /api/wallet-transfers/{id}` 撤销

## 关键技术决定

- **汇率精度 Numeric(18,8)**:金额是 Numeric(18,6),汇率高 2 位足够覆盖 USDT/CNY/TWD 间小数级波动。用 `quantize(Decimal("0.00000001"))` 防止 to/from 长尾
- **币种快照**:transfer 表存 from_currency / to_currency 副本,避免钱包改名/改币种后历史汇率失真
- **撤销策略**:反向流水也挂同一 transfer_id,流水视图能看到一笔划转完整生命周期(原 OUT/IN + 撤销 OUT/IN)
- **同币种允许**:rate=1 用于内部资金调拨
- **余额校验**:debit 自身已抛 `insufficient wallet balance`,路由层捕获返 400
- **不影响淘宝聚合释放等其他流水**(transfer_id 设默认 NULL)

## 自测

- [x] `pytest tests/test_wallet_transfer.py -v` 12/12 通过
  - 正向创建、同币种(rate=1)、跨币种(TWD→USDT)
  - 余额不足拒绝、同钱包拒绝、非正金额拒绝、group 钱包拒绝、404
  - 撤销恢复、撤销时 to 余额不足拒绝、重复撤销拒绝
  - 列表筛选(钱包/操作人)
- [x] `pytest tests/test_wallet.py tests/test_assets_api.py` 全部通过(没破坏现有钱包功能)
- [x] 模型/路由/服务跟现有风格一致(参考 taiwan / assets router)

## 遗留

- `tests/test_taiwan_api.py` 2 个 case fail —— 与本 PR **无关**,是 commit 438749d "feat(taiwan): 钱包分组架构" 引入的老测试遗留(钱包名变更后没更新断言)。建议另起 Issue 修。
- `tests/test_xbox_playwright_parsing.py` import 错 —— 也是无关历史遗留(xbox_playwright.py 重写后 `_DATE_RE` 已删)。

---
> 由 ropz 实现,PM 审查后合并