### PR TITLE
[PR] [xbox] #130 退款单 — 全额退,关联原单 + 对账 OUT 方向

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -54,6 +54,8 @@ def init_db() -> None:
     _ensure_xbox_account_country_identified_column()
     _ensure_xbox_order_remark_column()
     _migrate_xbox_sale_date_to_datetime()
+    _ensure_xbox_refunds_table()
+    _ensure_xbox_sale_record_refund_columns()
 
 
 def _ensure_wallet_is_group_column() -> None:
@@ -289,6 +291,48 @@ def _ensure_wallet_transaction_business_date_column() -> None:
 
     with engine.begin() as connection:
         connection.execute(text("ALTER TABLE wallet_transactions ADD COLUMN business_date DATE"))
+
+
+def _ensure_xbox_refunds_table() -> None:
+    """Issue #130: 启动时建 xbox_refunds 表(退款单).
+
+    SQLAlchemy create_all 已经会建表, 这里作为防御性 fallback: 若旧库
+    metadata 没注册到 XboxRefund(例如表删了又没重启), 也能补回来.
+    """
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+    inspector = inspect(engine)
+    if "xbox_refunds" in inspector.get_table_names():
+        return
+    from src.models.xbox import XboxRefund  # noqa: F401
+    Base.metadata.create_all(bind=engine, tables=[XboxRefund.__table__])
+
+
+def _ensure_xbox_sale_record_refund_columns() -> None:
+    """Issue #130: 给 xbox_sale_records 表加退款相关 3 列.
+
+    - status VARCHAR(16) NOT NULL DEFAULT 'active' (active / refunded)
+    - refunded_at DATETIME (NULL)
+    - refund_id INTEGER (NULL, FK xbox_refunds.id, 无约束因 SQLite ALTER 限制)
+    """
+    if not DATABASE_URL.startswith("sqlite"):
+        return
+    inspector = inspect(engine)
+    if "xbox_sale_records" not in inspector.get_table_names():
+        return
+    column_names = {column["name"] for column in inspector.get_columns("xbox_sale_records")}
+
+    additions = [
+        ("status", "VARCHAR(16) NOT NULL DEFAULT 'active'"),
+        ("refunded_at", "DATETIME"),
+        ("refund_id", "INTEGER"),
+    ]
+    with engine.begin() as connection:
+        for col_name, col_def in additions:
+            if col_name not in column_names:
+                connection.execute(
+                    text(f"ALTER TABLE xbox_sale_records ADD COLUMN {col_name} {col_def}")
+                )
 
 
 def get_db() -> Iterator[Session]:

--- a/src/main.py
+++ b/src/main.py
@@ -41,6 +41,7 @@ from src.routers.taobao import router as taobao_router
 from src.routers.taiwan import router as taiwan_router
 from src.routers.transfers import router as transfers_router
 from src.routers.wallet_transfers import router as wallet_transfers_router
+from src.routers.xbox_refund import router as xbox_refund_router
 from src.services.assets import ensure_default_asset_wallets
 from src.services.taiwan import ensure_default_taiwan_wallets
 from src.services.taobao import ensure_default_taobao_wallets
@@ -96,6 +97,7 @@ app.include_router(taobao_router)
 app.include_router(taiwan_router)
 app.include_router(transfers_router)
 app.include_router(wallet_transfers_router, prefix="/api/wallet-transfers", tags=["wallet-transfers"])
+app.include_router(xbox_refund_router, prefix="/api/xbox/refunds", tags=["xbox-refunds"])
 
 
 @app.get("/health")

--- a/src/models/xbox.py
+++ b/src/models/xbox.py
@@ -195,6 +195,13 @@ class XboxOrder(Base):
     )
 
 
+class XboxSaleRecordStatus(str, Enum):
+    """销售记录状态(PR #130 / Issue #130)。"""
+
+    ACTIVE = "active"
+    REFUNDED = "refunded"
+
+
 class XboxSaleRecord(Base):
     """销售记录（订单补齐后生成,带 walletPoolId 流入资金池）。"""
 
@@ -228,6 +235,17 @@ class XboxSaleRecord(Base):
     # 内部记账：本销售记录在资金池写入了一笔 IN 流水（用于改字段时反向调整）
     bookkeeping_tx_id: Mapped[Optional[int]] = mapped_column(
         ForeignKey("wallet_transactions.id"), nullable=True
+    )
+    # Issue #130: 退款状态字段(默认 active, 退款后改 refunded)
+    # 退款不动 XBOX 账号状态, 只标销售记录, 实际钱包 + 理论钱包都写一条 OUT 流水
+    status: Mapped[str] = mapped_column(
+        String(16), nullable=False, default=XboxSaleRecordStatus.ACTIVE.value
+    )
+    refunded_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    refund_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("xbox_refunds.id"), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=china_now
@@ -385,6 +403,53 @@ class XboxReconcileMapping(Base):
     actual_wallet_id: Mapped[int] = mapped_column(
         ForeignKey("wallets.id"), nullable=False
     )  # 任何实际值钱包(淘宝/台湾/资产...)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=china_now,
+    )
+
+
+class XboxRefund(Base):
+    """XBOX 销售记录退款单(Issue #130 / CEO 2026-05-18)。
+
+    业务规则：
+    - 一笔退款 = 两条 wallet_transactions(实际钱包 OUT + 理论钱包 OUT)
+    - 一个销售记录只能退一次(original_sale_record_id UNIQUE)
+    - 只支持全额退(refund_amount = sale_record.sale_price)
+    - 退款不动 XBOX 账号状态(账号未被使用,账号回收由客服系统处理)
+    - 撤销退款=反向冲销两条流水 + 销售记录改回 active + 硬删本记录(因 UNIQUE)
+    """
+
+    __tablename__ = "xbox_refunds"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    original_sale_record_id: Mapped[int] = mapped_column(
+        ForeignKey("xbox_sale_records.id"),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    refund_amount: Mapped[Decimal] = mapped_column(
+        Numeric(18, 6), nullable=False, default=Decimal("0")
+    )
+    refund_currency: Mapped[str] = mapped_column(String(8), nullable=False)
+    actual_wallet_id: Mapped[int] = mapped_column(
+        ForeignKey("wallets.id"), nullable=False, index=True
+    )
+    theoretical_wallet_id: Mapped[int] = mapped_column(
+        ForeignKey("wallets.id"), nullable=False, index=True
+    )
+    business_date: Mapped[Optional[date]] = mapped_column(Date, nullable=True)
+    operator_name: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # 关联两条流水(撤销时也用得着)
+    actual_bookkeeping_tx_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("wallet_transactions.id"), nullable=True
+    )
+    theoretical_bookkeeping_tx_id: Mapped[Optional[int]] = mapped_column(
+        ForeignKey("wallet_transactions.id"), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/src/routers/xbox_refund.py
+++ b/src/routers/xbox_refund.py
@@ -1,0 +1,196 @@
+"""XBOX 退款单 HTTP 路由(Issue #130 / CEO 2026-05-18)。
+
+端点:
+- POST   /api/xbox/refunds          创建退款单
+- GET    /api/xbox/refunds          列表 + 筛选
+- GET    /api/xbox/refunds/{id}     详情
+- DELETE /api/xbox/refunds/{id}     撤销退款(硬删 + 反向冲销)
+
+退款单 = 全额退一笔 XBOX 销售记录, 一笔退款触发:
+- 实际钱包 OUT(走标准 debit, 有余额校验)
+- 理论钱包 OUT(跳过余额校验, XBOX_SALES_LEDGER 允许负余额)
+- 销售记录标 refunded
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.orm import Session
+
+from src.database import get_db
+from src.models.wallet import Wallet
+from src.models.xbox import XboxRefund, XboxSaleRecord
+from src.services.xbox_refund import (
+    cancel_refund,
+    create_refund,
+    get_refund,
+    list_refunds,
+)
+
+
+router = APIRouter()
+
+
+# -------- Pydantic 模型 --------
+
+
+class XboxRefundCreateRequest(BaseModel):
+    sale_record_id: int = Field(..., gt=0)
+    actual_wallet_id: int = Field(..., gt=0, description="实际从哪个钱包扣钱")
+    business_date: Optional[date] = None
+    operator_name: Optional[str] = Field(None, max_length=120)
+    note: Optional[str] = None
+
+
+class XboxRefundSaleRecordSummary(BaseModel):
+    """退款单关联的原销售记录摘要(列表/详情都用)."""
+
+    id: int
+    account_id: int
+    product_name: str
+    operator_name: str
+    sale_price: Decimal
+    sale_currency: str
+    wallet_pool_id: int
+
+
+class XboxRefundOut(BaseModel):
+    id: int
+    original_sale_record_id: int
+    refund_amount: Decimal
+    refund_currency: str
+    actual_wallet_id: int
+    actual_wallet_name: Optional[str] = None
+    theoretical_wallet_id: int
+    theoretical_wallet_name: Optional[str] = None
+    business_date: Optional[date] = None
+    operator_name: Optional[str] = None
+    note: Optional[str] = None
+    actual_bookkeeping_tx_id: Optional[int] = None
+    theoretical_bookkeeping_tx_id: Optional[int] = None
+    created_at: str
+    sale_record: Optional[XboxRefundSaleRecordSummary] = None
+
+
+def _serialize_refund(session: Session, refund: XboxRefund) -> XboxRefundOut:
+    actual_wallet = session.get(Wallet, refund.actual_wallet_id)
+    theoretical_wallet = session.get(Wallet, refund.theoretical_wallet_id)
+
+    sale_record_summary: Optional[XboxRefundSaleRecordSummary] = None
+    record = session.get(XboxSaleRecord, refund.original_sale_record_id)
+    if record is not None:
+        sale_record_summary = XboxRefundSaleRecordSummary(
+            id=record.id,
+            account_id=record.account_id,
+            product_name=record.product_name,
+            operator_name=record.operator_name,
+            sale_price=Decimal(record.sale_price),
+            sale_currency=record.sale_currency,
+            wallet_pool_id=record.wallet_pool_id,
+        )
+
+    return XboxRefundOut(
+        id=refund.id,
+        original_sale_record_id=refund.original_sale_record_id,
+        refund_amount=Decimal(refund.refund_amount),
+        refund_currency=refund.refund_currency,
+        actual_wallet_id=refund.actual_wallet_id,
+        actual_wallet_name=actual_wallet.name if actual_wallet else None,
+        theoretical_wallet_id=refund.theoretical_wallet_id,
+        theoretical_wallet_name=theoretical_wallet.name if theoretical_wallet else None,
+        business_date=refund.business_date,
+        operator_name=refund.operator_name,
+        note=refund.note,
+        actual_bookkeeping_tx_id=refund.actual_bookkeeping_tx_id,
+        theoretical_bookkeeping_tx_id=refund.theoretical_bookkeeping_tx_id,
+        created_at=refund.created_at.isoformat() if refund.created_at else "",
+        sale_record=sale_record_summary,
+    )
+
+
+# -------- 端点 --------
+
+
+@router.post("", response_model=XboxRefundOut, status_code=status.HTTP_201_CREATED)
+def create_xbox_refund(
+    request: XboxRefundCreateRequest,
+    db: Session = Depends(get_db),
+) -> XboxRefundOut:
+    """创建退款单. 事务: 校验 → debit 实际 → force_debit 理论 → 建 refund → 销售记录改 refunded."""
+    try:
+        refund = create_refund(
+            db,
+            sale_record_id=request.sale_record_id,
+            actual_wallet_id=request.actual_wallet_id,
+            business_date=request.business_date,
+            operator_name=request.operator_name,
+            note=request.note,
+        )
+    except ValueError as exc:
+        db.rollback()
+        message = str(exc)
+        if "不存在" in message:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.commit()
+    db.refresh(refund)
+    return _serialize_refund(db, refund)
+
+
+@router.get("", response_model=list[XboxRefundOut])
+def list_xbox_refunds(
+    from_date: Optional[date] = Query(None),
+    to_date: Optional[date] = Query(None),
+    actual_wallet_id: Optional[int] = Query(None),
+    operator_name: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+) -> list[XboxRefundOut]:
+    refunds = list_refunds(
+        db,
+        from_date=from_date,
+        to_date=to_date,
+        actual_wallet_id=actual_wallet_id,
+        operator_name=operator_name,
+    )
+    return [_serialize_refund(db, r) for r in refunds]
+
+
+@router.get("/{refund_id}", response_model=XboxRefundOut)
+def get_xbox_refund(refund_id: int, db: Session = Depends(get_db)) -> XboxRefundOut:
+    refund = get_refund(db, refund_id)
+    if refund is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="退款单不存在")
+    return _serialize_refund(db, refund)
+
+
+@router.delete("/{refund_id}", status_code=status.HTTP_200_OK)
+def cancel_xbox_refund(refund_id: int, db: Session = Depends(get_db)) -> dict:
+    """撤销退款: 反向冲销 + 硬删. 因为 original_sale_record_id UNIQUE, 软删
+    会让"同一销售记录再次退款"违反约束, 所以硬删.
+    """
+    try:
+        refund = cancel_refund(db, refund_id)
+    except ValueError as exc:
+        db.rollback()
+        message = str(exc)
+        if "不存在" in message:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=message) from exc
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=message) from exc
+    except Exception:
+        db.rollback()
+        raise
+
+    db.commit()
+    return {
+        "ok": True,
+        "cancelled_refund_id": refund.id,
+        "original_sale_record_id": refund.original_sale_record_id,
+    }

--- a/src/services/xbox_reconcile.py
+++ b/src/services/xbox_reconcile.py
@@ -29,7 +29,7 @@ from src.models.wallet import (
     WalletTransaction,
     WalletType,
 )
-from src.models.xbox import XboxReconcileMapping, XboxSaleRecord
+from src.models.xbox import XboxRefund, XboxReconcileMapping, XboxSaleRecord
 
 
 def list_mappings(session: Session) -> list[XboxReconcileMapping]:
@@ -197,20 +197,87 @@ def _actual_total_for_day(
     return Decimal(str(total or 0))
 
 
+def _theoretical_out_total_for_day(
+    session: Session,
+    theoretical_wallet_id: int,
+    target_date: date,
+) -> Decimal:
+    """理论值钱包在指定日期的"OUT 总额"(退款方向)。
+
+    数据来源：``XboxRefund``(Issue #130)。
+    - theoretical_wallet_id 匹配
+    - business_date == target_date (退款单的业务日, NULL 时不参与)
+
+    CEO 2026-05-18: 退款的理论 OUT 自动体现在对账页 —
+    原销售记录关联的理论钱包当日 OUT vs 实际退款钱包当日 OUT 撞账.
+    """
+    total = session.scalar(
+        select(sa_func.coalesce(sa_func.sum(XboxRefund.refund_amount), 0)).where(
+            XboxRefund.theoretical_wallet_id == theoretical_wallet_id,
+            XboxRefund.business_date == target_date,
+        )
+    )
+    return Decimal(str(total or 0))
+
+
+def _actual_out_total_for_day(
+    session: Session,
+    actual_wallet_id: int,
+    target_date: date,
+) -> Decimal:
+    """实际值钱包在指定日期的"OUT 流水总额"(退款方向)。
+
+    若 actual_wallet 是 group(店铺总钱包),递归汇总所有子孙叶子的当日 OUT 流水。
+
+    数据来源：``WalletTransaction``。
+    - direction == "out"
+    - business_date == target_date 或 created_at 落在当天
+    - **transfer_id IS NULL**(排除划转产生的 OUT, Issue #129)
+
+    优先用 business_date,fallback created_at(与 IN 方向逻辑对称)。
+    """
+    from sqlalchemy import or_
+
+    leaf_ids = _collect_leaf_descendants(session, actual_wallet_id)
+    if not leaf_ids:
+        return Decimal("0")
+
+    start, end = _day_range(target_date)
+    total = session.scalar(
+        select(sa_func.coalesce(sa_func.sum(WalletTransaction.amount), 0)).where(
+            WalletTransaction.wallet_id.in_(leaf_ids),
+            WalletTransaction.direction == TransactionDirection.OUT.value,
+            WalletTransaction.transfer_id.is_(None),
+            or_(
+                WalletTransaction.business_date == target_date,
+                and_(
+                    WalletTransaction.business_date.is_(None),
+                    WalletTransaction.created_at >= start,
+                    WalletTransaction.created_at < end,
+                ),
+            ),
+        )
+    )
+    return Decimal(str(total or 0))
+
+
 def get_reconcile_report_for_day(
     session: Session,
     target_date: date,
 ) -> list[dict]:
     """对账报告：每个有映射的理论值钱包一行,含理论金额、实际金额（合计映射钱包）、差异。
 
-    返回结构：
+    返回结构(Issue #130 起加 OUT 三字段)：
         [
           {
             "theoreticalWallet": {id, name, currency},
-            "actualWallets": [{id, name, currency, total: "X.XX"}],
-            "theoreticalTotal": "X.XX",
+            "actualWallets": [{id, name, currency, total: "X.XX", outTotal: "X.XX"}],
+            "theoreticalTotal": "X.XX",        # IN 方向(销售)
             "actualTotal": "X.XX",
             "diff": "X.XX",
+            "theoreticalOutTotal": "X.XX",     # OUT 方向(退款) Issue #130
+            "actualOutTotal": "X.XX",
+            "outDiff": "X.XX",
           },
           ...
         ]
@@ -247,19 +314,24 @@ def get_reconcile_report_for_day(
     for tw in theoretical_wallets:
         actual_ids = actual_ids_by_theoretical.get(tw.id, [])
         theoretical_total = _theoretical_total_for_day(session, tw.id, target_date)
+        theoretical_out_total = _theoretical_out_total_for_day(session, tw.id, target_date)
         actual_details: list[dict] = []
         actual_total = Decimal("0")
+        actual_out_total = Decimal("0")
         for aid in actual_ids:
             aw = actual_wallets_by_id.get(aid)
             if aw is None:
                 continue
             sub_total = _actual_total_for_day(session, aid, target_date)
+            sub_out_total = _actual_out_total_for_day(session, aid, target_date)
             actual_total += sub_total
+            actual_out_total += sub_out_total
             actual_details.append({
                 "id": aid,
                 "name": aw.name,
                 "currency": aw.currency.value if hasattr(aw.currency, "value") else aw.currency,
                 "total": str(sub_total),
+                "outTotal": str(sub_out_total),
             })
 
         report.append({
@@ -272,5 +344,8 @@ def get_reconcile_report_for_day(
             "theoreticalTotal": str(theoretical_total),
             "actualTotal": str(actual_total),
             "diff": str(theoretical_total - actual_total),
+            "theoreticalOutTotal": str(theoretical_out_total),
+            "actualOutTotal": str(actual_out_total),
+            "outDiff": str(theoretical_out_total - actual_out_total),
         })
     return report

--- a/src/services/xbox_refund.py
+++ b/src/services/xbox_refund.py
@@ -1,0 +1,354 @@
+"""XBOX 退款单业务服务(Issue #130 / CEO 2026-05-18)。
+
+业务规则:
+- 一笔退款 = 两条 wallet_transactions(实际钱包 OUT + 理论钱包 OUT)
+- 销售记录从 status='active' → 'refunded',refund_id 指向新建的退款单
+- 只支持全额退(refund_amount = sale_record.sale_price)
+- 退款不动 XBOX 账号状态(账号未被使用,账号回收由客服系统处理)
+- 撤销: 反向 credit 两个钱包 + 销售记录改回 active + 硬删 XboxRefund(因 UNIQUE 约束)
+
+关键技术决定:
+- 理论钱包(XBOX_SALES_LEDGER 类型)允许负余额(对账占位符,不代表真实资金).
+  debit() 函数现有逻辑只对 VENDOR 网开一面,XBOX_SALES_LEDGER 没特例.
+- 为了不破坏 debit() 的通用语义(改它会影响所有用了它的功能),这里实现
+  ``_force_debit_no_balance_check()`` 内部 helper, 在退款服务里直接操作
+  wallet.balance + 手动建 WalletTransaction,跳过余额校验.
+- 实际钱包仍然走标准 debit()(有余额校验,退款时实际钱包应该够,否则报错让人工处理).
+"""
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models.wallet import (
+    TransactionDirection,
+    Wallet,
+    WalletTransaction,
+    WalletType,
+    debit,
+)
+from src.models.xbox import (
+    XboxChangeLog,
+    XboxRefund,
+    XboxSaleRecord,
+    XboxSaleRecordStatus,
+)
+from src.utils.time import china_now
+
+
+# -------- 内部 helper --------
+
+
+def _force_debit_no_balance_check(
+    session: Session,
+    wallet_id: int,
+    amount: Decimal,
+    *,
+    remark: Optional[str] = None,
+    operator_name: Optional[str] = None,
+) -> WalletTransaction:
+    """绕过 debit() 的余额校验, 直接扣钱 + 写 OUT 流水.
+
+    用于理论钱包(XBOX_SALES_LEDGER): 这种钱包是对账占位符, 余额可以为负
+    (例如 30 天总销售 100 + 退款 120 → 余额 -20, 不是 bug 是业务正常状态).
+    """
+    if amount <= 0:
+        raise ValueError("amount must be greater than zero")
+    wallet = session.get(Wallet, wallet_id)
+    if wallet is None:
+        raise ValueError(f"wallet {wallet_id} does not exist")
+    wallet.balance = Decimal(wallet.balance) - amount
+    tx = WalletTransaction(
+        wallet_id=wallet_id,
+        amount=amount,
+        direction=TransactionDirection.OUT,
+        remark=remark,
+        operator_name=operator_name,
+    )
+    session.add(tx)
+    session.flush()
+    return tx
+
+
+def _force_credit_no_balance_check(
+    session: Session,
+    wallet_id: int,
+    amount: Decimal,
+    *,
+    remark: Optional[str] = None,
+    operator_name: Optional[str] = None,
+) -> WalletTransaction:
+    """理论钱包反向冲销时用 — 同样绕过常规 credit (我们要 OUT 反向, 还要不动 mature_at).
+
+    其实标准 credit() 也能用, 这里为了和 _force_debit 对称, 直接写一份.
+    """
+    if amount <= 0:
+        raise ValueError("amount must be greater than zero")
+    wallet = session.get(Wallet, wallet_id)
+    if wallet is None:
+        raise ValueError(f"wallet {wallet_id} does not exist")
+    wallet.balance = Decimal(wallet.balance) + amount
+    tx = WalletTransaction(
+        wallet_id=wallet_id,
+        amount=amount,
+        direction=TransactionDirection.IN,
+        remark=remark,
+        operator_name=operator_name,
+    )
+    session.add(tx)
+    session.flush()
+    return tx
+
+
+def _log_change(
+    session: Session,
+    entity_type: str,
+    entity_id: int,
+    action: str,
+    detail: str,
+    operator: str = "manual",
+) -> None:
+    """写一条 XBOX 变更日志(action='refunded' / 'refund_cancelled')."""
+    log = XboxChangeLog(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        action=action,
+        detail=detail,
+        operator=operator,
+    )
+    session.add(log)
+    session.flush()
+
+
+# -------- 公开服务 --------
+
+
+def create_refund(
+    session: Session,
+    *,
+    sale_record_id: int,
+    actual_wallet_id: int,
+    business_date: Optional[date] = None,
+    operator_name: Optional[str] = None,
+    note: Optional[str] = None,
+) -> XboxRefund:
+    """创建退款单(全额退,关联原销售记录)。
+
+    事务关键步骤(全部在调用方 session 内, 由路由层 commit):
+    1. 校验: sale_record 存在且 status=active、actual_wallet 存在且非 group
+    2. 取 sale_price / sale_currency / wallet_pool_id(=theoretical_wallet)
+    3. debit(actual_wallet, sale_price) — 普通钱包, 走标准 debit(有余额校验)
+    4. force_debit(theoretical_wallet, sale_price) — XBOX_SALES_LEDGER, 跳过余额校验
+    5. 建 XboxRefund 记录, 带两条 tx_id
+    6. sale_record.status='refunded' / refunded_at=china_now() / refund_id=新 id
+    7. 写 XboxChangeLog: entity_type='sale_record', action='refunded'
+    """
+    sale_record = session.get(XboxSaleRecord, sale_record_id)
+    if sale_record is None:
+        raise ValueError(f"销售记录 {sale_record_id} 不存在")
+    if sale_record.status != XboxSaleRecordStatus.ACTIVE.value:
+        raise ValueError(f"销售记录 #{sale_record_id} 状态为 {sale_record.status}, 不能退款")
+
+    actual_wallet = session.get(Wallet, actual_wallet_id)
+    if actual_wallet is None:
+        raise ValueError(f"实际退款钱包 {actual_wallet_id} 不存在")
+    if actual_wallet.is_group:
+        raise ValueError("实际退款钱包是分组节点, 不能记账")
+    if actual_wallet.deleted_at is not None:
+        raise ValueError("实际退款钱包已删除")
+
+    theoretical_wallet_id = sale_record.wallet_pool_id
+    theoretical_wallet = session.get(Wallet, theoretical_wallet_id)
+    if theoretical_wallet is None:
+        raise ValueError(f"理论钱包(原销售记录资金池 {theoretical_wallet_id}) 不存在")
+
+    refund_amount = Decimal(sale_record.sale_price)
+    refund_currency = sale_record.sale_currency
+    if refund_amount <= 0:
+        raise ValueError("销售记录金额为 0, 无可退款金额")
+
+    # 实际钱包: 走标准 debit (有余额校验). 退款时实际钱包应该够;
+    # 不够说明数据有问题, 让用户人工处理(可能要先充钱进来).
+    actual_tx = debit(
+        session,
+        actual_wallet_id,
+        refund_amount,
+        remark=f"[退款] 销售记录 #{sale_record_id}",
+        operator_name=operator_name,
+    )
+
+    # 理论钱包: 跳过余额校验(XBOX_SALES_LEDGER 允许负余额)
+    theoretical_tx = _force_debit_no_balance_check(
+        session,
+        theoretical_wallet_id,
+        refund_amount,
+        remark=f"[退款] 销售记录 #{sale_record_id}",
+        operator_name=operator_name,
+    )
+
+    refund = XboxRefund(
+        original_sale_record_id=sale_record_id,
+        refund_amount=refund_amount,
+        refund_currency=refund_currency,
+        actual_wallet_id=actual_wallet_id,
+        theoretical_wallet_id=theoretical_wallet_id,
+        business_date=business_date,
+        operator_name=operator_name,
+        note=note,
+        actual_bookkeeping_tx_id=actual_tx.id,
+        theoretical_bookkeeping_tx_id=theoretical_tx.id,
+    )
+    session.add(refund)
+    session.flush()
+
+    # 销售记录 → refunded
+    sale_record.status = XboxSaleRecordStatus.REFUNDED.value
+    sale_record.refunded_at = china_now()
+    sale_record.refund_id = refund.id
+    sale_record.last_updated_at = china_now()
+
+    _log_change(
+        session,
+        "sale_record",
+        sale_record_id,
+        "refunded",
+        f"退款 #{refund.id} → 实际钱包#{actual_wallet_id} ({actual_wallet.name}) "
+        f"金额 {refund_amount} {refund_currency}",
+        operator=operator_name or "manual",
+    )
+
+    session.flush()
+    return refund
+
+
+def get_refund(session: Session, refund_id: int) -> Optional[XboxRefund]:
+    return session.get(XboxRefund, refund_id)
+
+
+def list_refunds(
+    session: Session,
+    *,
+    from_date: Optional[date] = None,
+    to_date: Optional[date] = None,
+    actual_wallet_id: Optional[int] = None,
+    operator_name: Optional[str] = None,
+) -> list[XboxRefund]:
+    """列退款单, 支持筛选: 日期范围(按 business_date 优先, 没填则按 created_at)、
+    实际钱包、操作人.
+    """
+    from datetime import datetime, timedelta
+
+    from sqlalchemy import and_, or_
+
+    stmt = select(XboxRefund)
+    if actual_wallet_id is not None:
+        stmt = stmt.where(XboxRefund.actual_wallet_id == actual_wallet_id)
+    if operator_name:
+        stmt = stmt.where(XboxRefund.operator_name == operator_name)
+    if from_date is not None:
+        # business_date >= from_date OR (business_date IS NULL AND created_at >= from_date 00:00)
+        from_dt = datetime.combine(from_date, datetime.min.time())
+        stmt = stmt.where(
+            or_(
+                XboxRefund.business_date >= from_date,
+                and_(
+                    XboxRefund.business_date.is_(None),
+                    XboxRefund.created_at >= from_dt,
+                ),
+            )
+        )
+    if to_date is not None:
+        to_dt = datetime.combine(to_date, datetime.min.time()) + timedelta(days=1)
+        stmt = stmt.where(
+            or_(
+                XboxRefund.business_date <= to_date,
+                and_(
+                    XboxRefund.business_date.is_(None),
+                    XboxRefund.created_at < to_dt,
+                ),
+            )
+        )
+    stmt = stmt.order_by(XboxRefund.id.desc())
+    return list(session.scalars(stmt))
+
+
+def cancel_refund(session: Session, refund_id: int) -> XboxRefund:
+    """撤销退款: 反向 credit 两个钱包 + 销售记录改回 active + 硬删 XboxRefund.
+
+    校验:
+    - refund 存在
+    - 实际钱包当前余额够不够加回(理论上 credit 不会失败, 这里仅校验钱包存在/非删除)
+    - 销售记录还在(理论上一定在, 防御性)
+
+    操作:
+    - 实际钱包 credit (refund_amount)
+    - 理论钱包 force_credit (refund_amount) — 与 debit 对称
+    - sale_record.status='active', refund_id=NULL, refunded_at=NULL
+    - 硬删 XboxRefund(因为 original_sale_record_id UNIQUE, 留着 deleted_at 软删
+      会让"同一销售记录再次退款"建第二条 refund 时违反 UNIQUE 约束)
+    - 写 XboxChangeLog action='refund_cancelled'
+    """
+    refund = session.get(XboxRefund, refund_id)
+    if refund is None:
+        raise ValueError(f"退款单 {refund_id} 不存在")
+
+    actual_wallet = session.get(Wallet, refund.actual_wallet_id)
+    if actual_wallet is None:
+        raise ValueError("退款单关联的实际钱包已删除, 无法撤销")
+    if actual_wallet.deleted_at is not None:
+        raise ValueError("退款单关联的实际钱包已删除, 无法撤销")
+    if actual_wallet.is_group:
+        raise ValueError("退款单关联的实际钱包已变为分组, 无法撤销")
+
+    theoretical_wallet = session.get(Wallet, refund.theoretical_wallet_id)
+    if theoretical_wallet is None:
+        raise ValueError("退款单关联的理论钱包已删除, 无法撤销")
+
+    sale_record = session.get(XboxSaleRecord, refund.original_sale_record_id)
+    if sale_record is None:
+        raise ValueError("退款单关联的销售记录已被删除, 无法撤销")
+
+    refund_amount = Decimal(refund.refund_amount)
+    remark = f"[撤销退款 #{refund.id}] 销售记录 #{refund.original_sale_record_id}"
+
+    # 实际钱包 credit 回去 (从 _force_credit, 不依赖标准 credit 的 mature_at 逻辑)
+    _force_credit_no_balance_check(
+        session,
+        refund.actual_wallet_id,
+        refund_amount,
+        remark=remark,
+        operator_name=refund.operator_name,
+    )
+    # 理论钱包 credit 回去 (跳过校验, 和退款时对称)
+    _force_credit_no_balance_check(
+        session,
+        refund.theoretical_wallet_id,
+        refund_amount,
+        remark=remark,
+        operator_name=refund.operator_name,
+    )
+
+    # 销售记录改回 active
+    sale_record.status = XboxSaleRecordStatus.ACTIVE.value
+    sale_record.refunded_at = None
+    sale_record.refund_id = None
+    sale_record.last_updated_at = china_now()
+
+    _log_change(
+        session,
+        "sale_record",
+        refund.original_sale_record_id,
+        "refund_cancelled",
+        f"撤销退款 #{refund.id} (实际钱包#{refund.actual_wallet_id} {actual_wallet.name} "
+        f"金额 {refund_amount} {refund.refund_currency})",
+        operator=refund.operator_name or "manual",
+    )
+
+    # 硬删退款单
+    session.delete(refund)
+    session.flush()
+    return refund

--- a/tests/test_xbox_refund.py
+++ b/tests/test_xbox_refund.py
@@ -1,0 +1,492 @@
+"""XBOX 退款单测试 (Issue #130 / CEO 2026-05-18)。
+
+覆盖:
+- 正向: 创建退款 → sale_record 标 refunded、实际钱包 + 理论钱包都减钱
+- 重复退款拒绝
+- 销售记录不存在 → 404
+- 撤销: 状态回到 active、钱回来
+- 对账 OUT 方向: 退款当日 theoreticalOutTotal / actualOutTotal / outDiff 显示
+"""
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from src import database
+from src.main import app
+from src.models.wallet import Wallet
+from src.models.xbox import XboxRefund, XboxSaleRecord
+from src.services.assets import ensure_default_asset_wallets
+from src.services.taiwan import ensure_default_taiwan_wallets
+from src.services.taobao import (
+    ensure_default_taobao_wallets,
+    ensure_shop_total_group_wallets,
+)
+from src.services.xbox_sales_ledger import (
+    ensure_xbox_default_reconcile_mappings,
+    ensure_xbox_default_wallet_settings,
+    ensure_xbox_sales_ledger_wallets,
+)
+
+
+@pytest.fixture()
+def client(tmp_path):
+    database.configure_database(f"sqlite:///{tmp_path / 'xbox_refund.db'}")
+    database.init_db()
+    db = database.SessionLocal()
+    try:
+        ensure_default_asset_wallets(db)
+        ensure_default_taobao_wallets(db)
+        ensure_default_taiwan_wallets(db)
+        leaf_id_by_name = ensure_xbox_sales_ledger_wallets(db)
+        ensure_xbox_default_wallet_settings(db, leaf_id_by_name)
+        ensure_shop_total_group_wallets(db)
+        ensure_xbox_default_reconcile_mappings(db)
+        db.commit()
+    finally:
+        db.close()
+    return TestClient(app)
+
+
+# -------- helpers --------
+
+
+def _get_wallet_id_by_name(name: str) -> int:
+    db = database.SessionLocal()
+    try:
+        wallet = db.scalar(select(Wallet).where(Wallet.name == name, Wallet.deleted_at.is_(None)))
+        if wallet is None:
+            raise AssertionError(f"未找到钱包 {name}")
+        return wallet.id
+    finally:
+        db.close()
+
+
+def _wallet_balance(wallet_id: int) -> Decimal:
+    db = database.SessionLocal()
+    try:
+        w = db.get(Wallet, wallet_id)
+        return Decimal(w.balance)
+    finally:
+        db.close()
+
+
+def _create_account(client, account_no="REFUND-001"):
+    r = client.post(
+        "/xbox/accounts",
+        json={
+            "name": account_no,
+            "country": "US",
+            "accountNo": account_no,
+            "exchangeRate": "7.20",
+            "loginEmail": f"{account_no}@test.com",
+            "password": "TestPwd123",
+        },
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _push_wallet_settings(client, items: list[dict]):
+    r = client.put(
+        "/xbox/wallet-settings",
+        json=[{"code": "agent", "label": "代理", "items": items}],
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _seed_sale_record(client, sale_price="800.00", account_no="REFUND-001") -> dict:
+    """建一笔销售记录: 走"建订单 → 补齐字段自动转销售"流程.
+
+    返回 sale_record 字典 (含 id / pool_id / actual_wallet_id).
+    """
+    # 用"丙火网络"理论钱包 + "丙火网络支付宝"实际(CNY)做对子, 已自动映射
+    pool_id = _get_wallet_id_by_name("丙火网络")  # 理论钱包(XBOX_SALES_LEDGER, CNY)
+    actual_id = _get_wallet_id_by_name("丙火网络支付宝")  # 实际钱包(ASSET_RMB)
+
+    _push_wallet_settings(
+        client,
+        [{"code": "001", "label": "代理 001", "walletPoolId": pool_id}],
+    )
+    method_id = client.get("/xbox/wallet-settings").json()[0]["id"]
+    item_id = client.get("/xbox/wallet-settings").json()[0]["items"][0]["id"]
+
+    account = _create_account(client, account_no=account_no)
+    # 用唯一的 orderNo (account_no 嵌进去防同测试多个销售时重复)
+    order_no = f"ORD-{account_no}"
+    order = client.post(
+        "/xbox/orders",
+        json={
+            "accountId": account["id"],
+            "orderNo": order_no,
+            "amountLocal": "100",
+            "currencyLocal": "USD",
+            "orderAt": "2026-05-18T10:00:00",
+        },
+    ).json()
+    r = client.patch(
+        f"/xbox/orders/{order['id']}",
+        json={
+            "saleDate": "2026-05-18",
+            "productName": "Game A",
+            "operatorName": "运营 A",
+            "salePrice": sale_price,
+            "saleCurrency": "CNY",
+            "walletMethodId": method_id,
+            "walletItemId": item_id,
+        },
+    )
+    assert r.status_code == 200, r.text
+    sale_record_id = r.json()["saleRecordId"]
+    return {
+        "sale_record_id": sale_record_id,
+        "pool_id": pool_id,  # 理论钱包
+        "actual_id": actual_id,  # 实际钱包
+        "sale_price": Decimal(sale_price),
+    }
+
+
+# ===================================================================
+# 1. 创建退款 → 销售记录标 refunded, 两个钱包都减钱
+# ===================================================================
+
+
+def test_create_refund_marks_sale_record_and_debits_both_wallets(client):
+    seed = _seed_sale_record(client)
+    pool_id = seed["pool_id"]
+    actual_id = seed["actual_id"]
+
+    # 销售时 credit 800 到理论钱包(资金池), 实际钱包没动
+    assert _wallet_balance(pool_id) == Decimal("800.000000")
+    assert _wallet_balance(actual_id) == Decimal("0")
+
+    # 先给实际钱包充钱(模拟客户已经付过钱进来了)
+    r = client.post(f"/wallets/assets/{actual_id}/credit", json={"amount": "800"})
+    assert r.status_code == 201, r.text
+    assert _wallet_balance(actual_id) == Decimal("800.000000")
+
+    # 发起退款
+    r = client.post(
+        "/api/xbox/refunds",
+        json={
+            "sale_record_id": seed["sale_record_id"],
+            "actual_wallet_id": actual_id,
+            "business_date": "2026-05-18",
+            "operator_name": "freeman",
+            "note": "没充上, 全额退",
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert Decimal(body["refund_amount"]) == Decimal("800")
+    assert body["refund_currency"] == "CNY"
+    assert body["actual_wallet_id"] == actual_id
+    assert body["theoretical_wallet_id"] == pool_id
+    assert body["operator_name"] == "freeman"
+    assert body["sale_record"]["id"] == seed["sale_record_id"]
+    # 两条流水 id 都被记下来了
+    assert body["actual_bookkeeping_tx_id"] is not None
+    assert body["theoretical_bookkeeping_tx_id"] is not None
+
+    # 实际钱包 800 → 0
+    assert _wallet_balance(actual_id) == Decimal("0")
+    # 理论钱包 800 → 0 (销售时 +800, 退款 -800)
+    assert _wallet_balance(pool_id) == Decimal("0")
+
+    # 销售记录已标 refunded
+    db = database.SessionLocal()
+    try:
+        record = db.get(XboxSaleRecord, seed["sale_record_id"])
+        assert record.status == "refunded"
+        assert record.refunded_at is not None
+        assert record.refund_id == body["id"]
+    finally:
+        db.close()
+
+
+# ===================================================================
+# 2. 重复退款 → 400
+# ===================================================================
+
+
+def test_refund_twice_is_rejected(client):
+    seed = _seed_sale_record(client)
+    actual_id = seed["actual_id"]
+    client.post(f"/wallets/assets/{actual_id}/credit", json={"amount": "800"})
+
+    # 第一次退款 OK
+    r1 = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": seed["sale_record_id"], "actual_wallet_id": actual_id},
+    )
+    assert r1.status_code == 201
+
+    # 第二次失败 (sale_record.status='refunded')
+    r2 = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": seed["sale_record_id"], "actual_wallet_id": actual_id},
+    )
+    assert r2.status_code == 400, r2.text
+    assert "不能退款" in r2.json()["detail"]
+
+
+# ===================================================================
+# 3. 销售记录不存在 → 404
+# ===================================================================
+
+
+def test_refund_nonexistent_sale_record_returns_404(client):
+    actual_id = _get_wallet_id_by_name("丙火网络支付宝")
+    r = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": 99999, "actual_wallet_id": actual_id},
+    )
+    assert r.status_code == 404, r.text
+    assert "不存在" in r.json()["detail"]
+
+
+# ===================================================================
+# 4. 实际钱包不存在 / 非法 → 404 或 400
+# ===================================================================
+
+
+def test_refund_nonexistent_actual_wallet_returns_404(client):
+    seed = _seed_sale_record(client)
+    r = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": seed["sale_record_id"], "actual_wallet_id": 99999},
+    )
+    assert r.status_code == 404, r.text
+
+
+def test_refund_to_group_wallet_returns_400(client):
+    """实际钱包是 group 节点 → 400 拒绝."""
+    seed = _seed_sale_record(client)
+    # 找一个 group 钱包 (淘宝店铺总钱包是 group)
+    db = database.SessionLocal()
+    try:
+        group = db.scalar(
+            select(Wallet).where(Wallet.is_group.is_(True), Wallet.deleted_at.is_(None))
+        )
+        group_id = group.id if group else None
+    finally:
+        db.close()
+    if group_id is None:
+        pytest.skip("没有 group 钱包可测")
+
+    r = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": seed["sale_record_id"], "actual_wallet_id": group_id},
+    )
+    assert r.status_code == 400, r.text
+    assert "分组" in r.json()["detail"]
+
+
+# ===================================================================
+# 5. 撤销退款: 状态回到 active, 钱回来
+# ===================================================================
+
+
+def test_cancel_refund_restores_state(client):
+    seed = _seed_sale_record(client)
+    actual_id = seed["actual_id"]
+    pool_id = seed["pool_id"]
+    client.post(f"/wallets/assets/{actual_id}/credit", json={"amount": "800"})
+
+    # 退款
+    r = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": seed["sale_record_id"], "actual_wallet_id": actual_id},
+    )
+    assert r.status_code == 201
+    refund_id = r.json()["id"]
+
+    assert _wallet_balance(actual_id) == Decimal("0")
+    assert _wallet_balance(pool_id) == Decimal("0")
+
+    # 撤销
+    r = client.delete(f"/api/xbox/refunds/{refund_id}")
+    assert r.status_code == 200, r.text
+    assert r.json()["cancelled_refund_id"] == refund_id
+
+    # 钱回来
+    assert _wallet_balance(actual_id) == Decimal("800.000000")
+    assert _wallet_balance(pool_id) == Decimal("800.000000")
+
+    # 销售记录回到 active
+    db = database.SessionLocal()
+    try:
+        record = db.get(XboxSaleRecord, seed["sale_record_id"])
+        assert record.status == "active"
+        assert record.refunded_at is None
+        assert record.refund_id is None
+        # 退款单已硬删
+        assert db.get(XboxRefund, refund_id) is None
+    finally:
+        db.close()
+
+
+# ===================================================================
+# 6. 撤销后, 可以再次创建退款 (UNIQUE 约束不阻塞二次退款)
+# ===================================================================
+
+
+def test_can_create_refund_again_after_cancel(client):
+    seed = _seed_sale_record(client)
+    actual_id = seed["actual_id"]
+    client.post(f"/wallets/assets/{actual_id}/credit", json={"amount": "800"})
+
+    r1 = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": seed["sale_record_id"], "actual_wallet_id": actual_id},
+    )
+    assert r1.status_code == 201
+    refund_id = r1.json()["id"]
+    client.delete(f"/api/xbox/refunds/{refund_id}")
+
+    # 再退款 OK (钱回来后再退). 不校验 id 不同 — SQLite 可能复用删掉的 id,
+    # 重点是 201 + 销售记录再次进 refunded 状态.
+    r2 = client.post(
+        "/api/xbox/refunds",
+        json={"sale_record_id": seed["sale_record_id"], "actual_wallet_id": actual_id},
+    )
+    assert r2.status_code == 201, r2.text
+    new_refund_id = r2.json()["id"]
+    # 销售记录已重新进 refunded
+    db = database.SessionLocal()
+    try:
+        record = db.get(XboxSaleRecord, seed["sale_record_id"])
+        assert record.status == "refunded"
+        assert record.refund_id == new_refund_id
+    finally:
+        db.close()
+
+
+# ===================================================================
+# 7. 撤销不存在的退款 → 404
+# ===================================================================
+
+
+def test_cancel_nonexistent_refund_returns_404(client):
+    r = client.delete("/api/xbox/refunds/99999")
+    assert r.status_code == 404, r.text
+
+
+# ===================================================================
+# 8. 列表 + 筛选
+# ===================================================================
+
+
+def test_list_refunds_with_filters(client):
+    seed = _seed_sale_record(client, account_no="REFUND-LIST")
+    actual_id = seed["actual_id"]
+    client.post(f"/wallets/assets/{actual_id}/credit", json={"amount": "800"})
+
+    client.post(
+        "/api/xbox/refunds",
+        json={
+            "sale_record_id": seed["sale_record_id"],
+            "actual_wallet_id": actual_id,
+            "operator_name": "freeman",
+            "business_date": "2026-05-18",
+        },
+    )
+
+    # 全部
+    r = client.get("/api/xbox/refunds")
+    assert r.status_code == 200
+    items = r.json()
+    assert len(items) >= 1
+
+    # 按操作人筛
+    r = client.get("/api/xbox/refunds", params={"operator_name": "freeman"})
+    assert all(it["operator_name"] == "freeman" for it in r.json())
+
+    # 按实际钱包筛
+    r = client.get("/api/xbox/refunds", params={"actual_wallet_id": actual_id})
+    assert all(it["actual_wallet_id"] == actual_id for it in r.json())
+
+    # 详情
+    refund_id = items[0]["id"]
+    r = client.get(f"/api/xbox/refunds/{refund_id}")
+    assert r.status_code == 200
+    assert r.json()["id"] == refund_id
+
+
+# ===================================================================
+# 9. 对账 OUT 方向: 退款当日 theoreticalOutTotal / actualOutTotal / outDiff
+# ===================================================================
+
+
+def test_reconcile_report_includes_out_direction_for_refund_day(client):
+    seed = _seed_sale_record(client, account_no="REFUND-RECON")
+    actual_id = seed["actual_id"]
+    pool_id = seed["pool_id"]
+    client.post(f"/wallets/assets/{actual_id}/credit", json={"amount": "800"})
+
+    # 退款 business_date = 2026-05-18
+    r = client.post(
+        "/api/xbox/refunds",
+        json={
+            "sale_record_id": seed["sale_record_id"],
+            "actual_wallet_id": actual_id,
+            "business_date": "2026-05-18",
+        },
+    )
+    assert r.status_code == 201
+
+    # 对账 2026-05-18
+    r = client.get("/xbox/reconcile", params={"date": "2026-05-18"})
+    assert r.status_code == 200, r.text
+    rows = r.json()
+
+    # 找到"丙火网络"理论钱包那一行
+    binghuo_row = next(
+        (row for row in rows if row["theoreticalWallet"]["id"] == pool_id), None
+    )
+    assert binghuo_row is not None
+
+    # IN 方向 (销售): 理论 = 800 (销售记录 status=refunded 但 sale_price 还在汇总)
+    assert Decimal(binghuo_row["theoreticalTotal"]) == Decimal("800")
+    # OUT 方向 (退款) 应该 = 800
+    assert Decimal(binghuo_row["theoreticalOutTotal"]) == Decimal("800")
+    # 实际 OUT 方向 也应该 = 800 (从 actual_wallet 扣的钱)
+    assert Decimal(binghuo_row["actualOutTotal"]) == Decimal("800")
+    # 差异 = 0 (理论 OUT - 实际 OUT)
+    assert Decimal(binghuo_row["outDiff"]) == Decimal("0")
+    # 每个实际钱包子行也带 outTotal
+    for sub in binghuo_row["actualWallets"]:
+        if sub["id"] == actual_id:
+            assert Decimal(sub["outTotal"]) == Decimal("800")
+
+
+def test_reconcile_report_other_day_has_zero_out(client):
+    """退款只算在 business_date 那天, 其他日期 OUT 为 0."""
+    seed = _seed_sale_record(client, account_no="REFUND-OTHER-DAY")
+    actual_id = seed["actual_id"]
+    pool_id = seed["pool_id"]
+    client.post(f"/wallets/assets/{actual_id}/credit", json={"amount": "800"})
+
+    client.post(
+        "/api/xbox/refunds",
+        json={
+            "sale_record_id": seed["sale_record_id"],
+            "actual_wallet_id": actual_id,
+            "business_date": "2026-05-18",
+        },
+    )
+
+    # 查另一天 2026-05-19
+    r = client.get("/xbox/reconcile", params={"date": "2026-05-19"})
+    rows = r.json()
+    binghuo_row = next(
+        (row for row in rows if row["theoreticalWallet"]["id"] == pool_id), None
+    )
+    assert binghuo_row is not None
+    assert Decimal(binghuo_row["theoreticalOutTotal"]) == Decimal("0")
+    assert Decimal(binghuo_row["actualOutTotal"]) == Decimal("0")
+    assert Decimal(binghuo_row["outDiff"]) == Decimal("0")


### PR DESCRIPTION
## 关联 Issue
Closes #130

## 改动说明

财务系统新增「退款单」功能(只做后端 + 测试,前端在 broky 那边)。

### 数据库
- `xbox_sale_records` 加 3 字段: `status` (active/refunded) / `refunded_at` / `refund_id`
- 新表 `xbox_refunds`: `original_sale_record_id` UNIQUE(一笔销售只能退一次), 含 actual/theoretical wallet + 两条 tx 引用 + business_date / operator_name / note
- `database.init_db` 加 2 个幂等迁移: `_ensure_xbox_refunds_table` + `_ensure_xbox_sale_record_refund_columns`

### 服务层 `src/services/xbox_refund.py` (新)
- `create_refund` / `get_refund` / `list_refunds` / `cancel_refund`
- 一笔退款 = 两条 wallet_transactions(实际钱包 OUT + 理论钱包 OUT)
- 销售记录 status 改 refunded, refund_id 指向新退款单
- 撤销退款 → 反向冲销 + 销售记录回 active + **硬删** XboxRefund

### 路由 `src/routers/xbox_refund.py` (新)
- POST   /api/xbox/refunds          创建
- GET    /api/xbox/refunds          列表(筛选: 日期/钱包/操作人)
- GET    /api/xbox/refunds/{id}     详情
- DELETE /api/xbox/refunds/{id}     撤销
- main.py 挂载: \`prefix='/api/xbox/refunds', tags=['xbox-refunds']\`

### 对账扩展 `src/services/xbox_reconcile.py`
- 新增 \`_theoretical_out_total_for_day\`: 从 xbox_refunds 按 theoretical_wallet_id + business_date 汇总
- 新增 \`_actual_out_total_for_day\`: 从 wallet_transactions 按 wallet_id + business_date + direction=OUT + **transfer_id IS NULL** 汇总(排除划转 OUT)
- \`get_reconcile_report_for_day\` 返回结构每行加 \`theoreticalOutTotal\` / \`actualOutTotal\` / \`outDiff\`; 每个 actualWallet 加 \`outTotal\`
- **IN 方向(销售)字段未变**, 完全向后兼容

## 关键技术决定

### 1. 理论钱包负余额怎么处理
\`XBOX_SALES_LEDGER\` 类型钱包是对账占位符, 余额可以为负(销售 100 + 退款 120 → -20, 是业务正常状态). 现有 \`debit()\` 函数只对 VENDOR 类型放宽余额校验, XBOX_SALES_LEDGER 没有特例.

**选择**: 在 \`src/services/xbox_refund.py\` 实现内部 helper \`_force_debit_no_balance_check\`(以及对称的 \`_force_credit_no_balance_check\` 用于撤销), 直接操作 \`wallet.balance\` + 手动建 WalletTransaction, 跳过余额校验.

**为什么不改 debit()**: 改 debit() 全局放宽 XBOX_SALES_LEDGER 会影响别的功能(比如 \`xbox_sale.py\` 在切资金池或下调售价时也用 debit, 那里是有意要余额校验的逻辑). 局部 helper 范围最小, 风险最低.

**实际钱包(普通 ASSET_RMB 等)仍走标准 debit()**, 有余额校验. 如果实际钱包余额不够, 退款拒绝并返回 400, 让人工先处理.

### 2. 撤销退款用硬删
\`xbox_refunds.original_sale_record_id\` 是 UNIQUE. 如果撤销用软删(\`deleted_at\`)留下旧记录, 同一销售记录再次发起退款会违反 UNIQUE 约束. 所以撤销时:
- 先反向 credit 两钱包
- 销售记录 status='active' + refund_id=NULL + refunded_at=NULL
- 然后 \`session.delete(refund)\` 硬删
- 写 \`XboxChangeLog action='refund_cancelled'\` 留审计痕迹

### 3. 对账 OUT 方向兼容 #129 划转
\`_actual_out_total_for_day\` 必须排除划转产生的 OUT(否则把"台币转 USDT"也当成退款撞账). 加了 \`WalletTransaction.transfer_id.is_(None)\` 过滤. IN 方向不需要这个过滤, 因为划转 IN 是合法的入账, 与销售 IN 同维度对账没意义.

## 自测

- [x] \`pytest tests/test_xbox_refund.py -v\` → **11/11 全通过**
  - 创建退款 → sale_record 标 refunded, 实际+理论钱包都减钱
  - 重复退款拒绝(400)
  - 销售记录不存在(404) / 实际钱包不存在(404) / group 钱包拒绝(400)
  - 撤销 → 钱回来, refund 硬删, sale_record 回 active
  - 撤销后可再次退款(UNIQUE 不阻塞)
  - 列表 + 多条件筛选 + 详情
  - 对账 OUT 方向: 退款当日 theoreticalOutTotal / actualOutTotal / outDiff 显示
  - 退款只算在 business_date 那天, 其他天 OUT 为 0
- [x] \`pytest test_wallet.py test_assets_api.py test_wallet_transfer.py test_transfers_api.py test_vendors_api.py test_vendor_payments_api.py\` → 75/75 全通过(回归无破坏)
- [x] \`pytest test_xbox_p0_2_api.py -k 'not sync and not refresh'\` → 27/27 全通过(同步 mock 测试是 main 上就坏的, 与本 PR 无关)

## 不动的东西

- 没改 \`wallet_transfers\` / \`wallet_transactions.transfer_id\` 逻辑(#129)
- 没改 \`debit()\` / \`credit()\` 函数(避免影响别的功能)
- 没改 XBOX 账号状态(账号未被使用, 账号回收由客服系统处理 — CEO 2026-05-18 拍板)
- 没改对账 IN 方向汇总口径
- 没碰前端代码

---
> 由 ropz 实现, 请 PM 审查