### PR TITLE
[PR] [frontend] #129 + #130 划转单 / 退款单 前端实现

### DIFF
--- a/frontend/components/assets-page.tsx
+++ b/frontend/components/assets-page.tsx
@@ -31,6 +31,8 @@ import {
 import { formatMoney, sumMinor } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import type { AssetTransaction, Currency, WalletBalance } from "@/types";
+import { WalletTransferList } from "@/components/wallet-transfer-list";
+import { WalletTransferModal } from "@/components/wallet-transfer-modal";
 
 type AssetTab = "CNY" | "USDT";
 type MovementMode = "credit" | "debit";
@@ -584,7 +586,8 @@ function AssetTree({
   onShowTransactions,
   onEdit,
   onDelete,
-  onTransfer
+  onTransfer,
+  onCrossTransfer
 }: {
   wallets: WalletBalance[];
   expandedIds: Set<string>;
@@ -597,6 +600,7 @@ function AssetTree({
   onEdit: (wallet: WalletBalance) => void;
   onDelete: (wallet: WalletBalance) => void;
   onTransfer: (wallet: WalletBalance) => void;
+  onCrossTransfer: (wallet: WalletBalance) => void;
 }) {
   const renderNode = (wallet: WalletBalance, depth: number) => {
     const hasChildren = Boolean(wallet.children?.length);
@@ -671,6 +675,10 @@ function AssetTree({
                         转账
                       </Button>
                     ) : null}
+                    <Button variant="outline" size="sm" onClick={() => onCrossTransfer(wallet)}>
+                      <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+                      划转
+                    </Button>
                   </>
                 )}
                 <Button variant="outline" size="sm" onClick={() => onEdit(wallet)}>
@@ -768,6 +776,8 @@ export function AssetsPage() {
   const [editTarget, setEditTarget] = useState<WalletBalance | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<WalletBalance | null>(null);
   const [transferTarget, setTransferTarget] = useState<WalletBalance | null>(null);
+  const [crossTransferTarget, setCrossTransferTarget] = useState<WalletBalance | null>(null);
+  const [showTransferList, setShowTransferList] = useState(false);
   const { data: wallets = [], isFetching, refetch } = useQuery({
     queryKey: ["assets"],
     queryFn: getAssetWallets
@@ -816,11 +826,22 @@ export function AssetsPage() {
           <h2 className="text-2xl font-semibold tracking-normal">资产钱包</h2>
           <p className="mt-1 text-sm text-muted-foreground">RMB 和 USDT 三层结构、分组折叠、叶子钱包记账和流水。</p>
         </div>
-        <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
-          <RefreshCcw className="h-4 w-4" />
-          刷新
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant={showTransferList ? "default" : "outline"}
+            onClick={() => setShowTransferList((v) => !v)}
+          >
+            <ArrowLeftRight className="h-4 w-4" aria-hidden="true" />
+            划转记录
+          </Button>
+          <Button variant="outline" onClick={() => refetch()} disabled={isFetching}>
+            <RefreshCcw className="h-4 w-4" />
+            刷新
+          </Button>
+        </div>
       </div>
+
+      {showTransferList ? <WalletTransferList title="资产钱包相关划转记录" /> : null}
 
       <div className="grid gap-2 rounded-lg border border-border bg-card p-2 md:grid-cols-2">
         {tabs.map((tab) => (
@@ -874,6 +895,7 @@ export function AssetsPage() {
         onEdit={setEditTarget}
         onDelete={setDeleteTarget}
         onTransfer={setTransferTarget}
+        onCrossTransfer={setCrossTransferTarget}
       />
       <AssetActions
         leafWallets={leafWallets}
@@ -899,6 +921,11 @@ export function AssetsPage() {
           onClose={() => setTransferTarget(null)}
         />
       ) : null}
+      <WalletTransferModal
+        open={crossTransferTarget !== null}
+        onClose={() => setCrossTransferTarget(null)}
+        defaultFromWalletId={crossTransferTarget?.id}
+      />
     </div>
   );
 }

--- a/frontend/components/taiwan-page.tsx
+++ b/frontend/components/taiwan-page.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ArrowDownLeft,
+  ArrowLeftRight,
   ArrowUpRight,
   ChevronDown,
   ChevronUp,
@@ -31,6 +32,8 @@ import {
 import { formatMoney } from "@/lib/money";
 import { cn } from "@/lib/utils";
 import type { TaiwanWallet } from "@/types";
+import { WalletTransferList } from "@/components/wallet-transfer-list";
+import { WalletTransferModal } from "@/components/wallet-transfer-modal";
 
 // CEO 2026-05-18: 操作人名字存在 localStorage, 跨刷新保持
 const OP_NAME_KEY = "taiwan-operator-name";
@@ -52,12 +55,16 @@ function SummaryHeader({
   total,
   count,
   isFetching,
+  showTransfers,
+  onToggleTransfers,
   onRefresh,
   onCreateClick
 }: {
   total: number;
   count: number;
   isFetching: boolean;
+  showTransfers: boolean;
+  onToggleTransfers: () => void;
   onRefresh: () => void;
   onCreateClick: () => void;
 }) {
@@ -79,6 +86,14 @@ function SummaryHeader({
         <Button variant="outline" size="sm" onClick={onRefresh} disabled={isFetching}>
           <RefreshCcw className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} />
           <span className="ml-1.5">刷新</span>
+        </Button>
+        <Button
+          variant={showTransfers ? "default" : "outline"}
+          size="sm"
+          onClick={onToggleTransfers}
+        >
+          <ArrowLeftRight className="h-3.5 w-3.5" />
+          <span className="ml-1.5">划转记录</span>
         </Button>
         <Button size="sm" onClick={onCreateClick}>
           <Plus className="h-3.5 w-3.5" />
@@ -498,12 +513,14 @@ function ChildWalletCard({
   wallet,
   onUpdate,
   onEdit,
-  onShowTransactions
+  onShowTransactions,
+  onTransfer
 }: {
   wallet: TaiwanWallet;
   onUpdate: () => void;
   onEdit: () => void;
   onShowTransactions: () => void;
+  onTransfer: () => void;
 }) {
   // CEO: 解析 remark 里的"卡号:" 和 "注册人:" 行
   const parseRemark = () => {
@@ -562,6 +579,10 @@ function ChildWalletCard({
             <ArrowUpRight className="h-3 w-3 text-red-100 -ml-1" />
             <span className="ml-1 text-xs">更新余额</span>
           </Button>
+          <Button size="sm" variant="outline" onClick={onTransfer} className="h-7 px-2.5">
+            <ArrowLeftRight className="h-3 w-3" />
+            <span className="ml-1 text-xs">划转</span>
+          </Button>
           <Button size="sm" variant="outline" onClick={onShowTransactions} className="h-7 px-2.5">
             <ListOrdered className="h-3 w-3" />
             <span className="ml-1 text-xs">流水</span>
@@ -578,7 +599,8 @@ function GroupCard({
   defaultOpen,
   onUpdate,
   onEdit,
-  onShowTransactions
+  onShowTransactions,
+  onTransfer
 }: {
   group: TaiwanWallet;
   children: TaiwanWallet[];
@@ -586,6 +608,7 @@ function GroupCard({
   onUpdate: (w: TaiwanWallet) => void;
   onEdit: (w: TaiwanWallet) => void;
   onShowTransactions: (w: TaiwanWallet) => void;
+  onTransfer: (w: TaiwanWallet) => void;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const groupTotal = children.reduce((s, c) => s + c.balanceMinor, 0);
@@ -633,6 +656,7 @@ function GroupCard({
                   onUpdate={() => onUpdate(w)}
                   onEdit={() => onEdit(w)}
                   onShowTransactions={() => onShowTransactions(w)}
+                  onTransfer={() => onTransfer(w)}
                 />
               ))}
             </div>
@@ -648,6 +672,8 @@ export function TaiwanPage() {
   const [updateTarget, setUpdateTarget] = useState<TaiwanWallet | null>(null);
   const [editTarget, setEditTarget] = useState<TaiwanWallet | null>(null);
   const [transactionsTarget, setTransactionsTarget] = useState<TaiwanWallet | null>(null);
+  const [transferTarget, setTransferTarget] = useState<TaiwanWallet | null>(null);
+  const [showTransferList, setShowTransferList] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
 
   const { data: wallets = [], isFetching } = useQuery({
@@ -684,12 +710,16 @@ export function TaiwanPage() {
         total={summary?.totalBalanceMinor ?? 0}
         count={summary?.walletCount ?? 0}
         isFetching={isFetching}
+        showTransfers={showTransferList}
+        onToggleTransfers={() => setShowTransferList((v) => !v)}
         onRefresh={() => {
           queryClient.invalidateQueries({ queryKey: ["taiwan-wallets"] });
           queryClient.invalidateQueries({ queryKey: ["taiwan-summary"] });
         }}
         onCreateClick={() => setShowCreate(true)}
       />
+
+      {showTransferList ? <WalletTransferList title="台湾相关划转记录" /> : null}
 
       <div className="space-y-4">
         {groups.map((group) => (
@@ -701,6 +731,7 @@ export function TaiwanPage() {
             onUpdate={setUpdateTarget}
             onEdit={setEditTarget}
             onShowTransactions={setTransactionsTarget}
+            onTransfer={setTransferTarget}
           />
         ))}
         {groups.length === 0 && !isFetching ? (
@@ -727,6 +758,11 @@ export function TaiwanPage() {
       {showCreate ? (
         <CreateWalletModal groups={groups} onClose={() => setShowCreate(false)} />
       ) : null}
+      <WalletTransferModal
+        open={transferTarget !== null}
+        onClose={() => setTransferTarget(null)}
+        defaultFromWalletId={transferTarget?.id}
+      />
     </div>
   );
 }

--- a/frontend/components/wallet-transfer-list.tsx
+++ b/frontend/components/wallet-transfer-list.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowRight, RefreshCcw, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  cancelWalletTransfer,
+  getDashboardData,
+  listWalletTransfers
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type { WalletBalance, WalletTransfer } from "@/types";
+
+// 与弹窗共用: 把汇率(数字字符串) trim 尾 0 显示
+function formatRate(rate: string | number): string {
+  const n = typeof rate === "number" ? rate : Number(rate);
+  if (!Number.isFinite(n) || n <= 0) return "-";
+  const fixed = n.toFixed(8);
+  return fixed.replace(/\.?0+$/, "") || "0";
+}
+
+// 金额字符串保留 2 位(常见钱包币种), USDT/小数币种保留 6 位
+function formatAmountStr(amount: string, currency: string): string {
+  const n = Number(amount);
+  if (!Number.isFinite(n)) return amount;
+  const digits =
+    currency === "USDT" || currency === "BTC" || currency === "ETH" ? 6 : 2;
+  return n.toFixed(digits);
+}
+
+function formatDateOnly(value: string | null): string {
+  if (!value) return "-";
+  return value.length >= 10 ? value.slice(0, 10) : value;
+}
+
+// 拍平钱包树供下拉用
+function flattenLeaves(wallets: WalletBalance[]): WalletBalance[] {
+  const out: WalletBalance[] = [];
+  const walk = (nodes: WalletBalance[]) => {
+    for (const w of nodes) {
+      if (!w.isGroup) out.push(w);
+      if (w.children && w.children.length > 0) walk(w.children);
+    }
+  };
+  walk(wallets);
+  return out;
+}
+
+export type WalletTransferListProps = {
+  // 传了就只看与该钱包相关的(from 或 to)
+  walletId?: string;
+  // 标题(默认"划转记录")
+  title?: string;
+};
+
+export function WalletTransferList({ walletId, title = "划转记录" }: WalletTransferListProps) {
+  const queryClient = useQueryClient();
+
+  // 筛选状态
+  const [filterWalletId, setFilterWalletId] = useState<string>(walletId ?? "");
+  const [fromDate, setFromDate] = useState<string>("");
+  const [toDate, setToDate] = useState<string>("");
+  const [operator, setOperator] = useState<string>("");
+  const [includeDeleted, setIncludeDeleted] = useState<boolean>(false);
+
+  // 钱包下拉数据
+  const { data: dashboard } = useQuery({
+    queryKey: ["dashboard"],
+    queryFn: getDashboardData
+  });
+  const walletOptions = useMemo(
+    () => flattenLeaves(dashboard?.wallets ?? []),
+    [dashboard?.wallets]
+  );
+
+  // 拉划转列表 - 如果绑定 walletId, 拉 from+to 两次合并; 否则按筛选
+  const effectiveWalletId = walletId ?? filterWalletId;
+  const queryKey = useMemo(
+    () => [
+      "wallet-transfers",
+      {
+        walletId: effectiveWalletId,
+        fromDate,
+        toDate,
+        operator,
+        includeDeleted
+      }
+    ],
+    [effectiveWalletId, fromDate, toDate, operator, includeDeleted]
+  );
+
+  const { data: transfers = [], isFetching, refetch } = useQuery({
+    queryKey,
+    queryFn: async () => {
+      if (effectiveWalletId) {
+        // 既看出账也看入账, 合并去重
+        const [outList, inList] = await Promise.all([
+          listWalletTransfers({
+            fromWalletId: effectiveWalletId,
+            fromDate: fromDate || undefined,
+            toDate: toDate || undefined,
+            operatorName: operator || undefined,
+            includeDeleted
+          }),
+          listWalletTransfers({
+            toWalletId: effectiveWalletId,
+            fromDate: fromDate || undefined,
+            toDate: toDate || undefined,
+            operatorName: operator || undefined,
+            includeDeleted
+          })
+        ]);
+        const map = new Map<string, WalletTransfer>();
+        for (const t of [...outList, ...inList]) {
+          map.set(t.id, t);
+        }
+        return [...map.values()].sort((a, b) =>
+          (a.createdAt < b.createdAt ? 1 : -1)
+        );
+      }
+      return listWalletTransfers({
+        fromDate: fromDate || undefined,
+        toDate: toDate || undefined,
+        operatorName: operator || undefined,
+        includeDeleted
+      });
+    }
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (transferId: string) => cancelWalletTransfer(transferId),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["wallet-transfers"] }),
+        queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
+        queryClient.invalidateQueries({ queryKey: ["assets"] }),
+        queryClient.invalidateQueries({ queryKey: ["asset-transactions"] }),
+        queryClient.invalidateQueries({ queryKey: ["taiwan-wallets"] }),
+        queryClient.invalidateQueries({ queryKey: ["taiwan-summary"] }),
+        queryClient.invalidateQueries({ queryKey: ["taiwan-transactions"] })
+      ]);
+    },
+    onError: (err) => {
+      window.alert(err instanceof Error ? err.message : "撤销失败");
+    }
+  });
+
+  const handleCancel = (t: WalletTransfer) => {
+    const desc = `从 ${t.fromWalletName ?? t.fromWalletId} 划 ${formatAmountStr(t.fromAmount, t.fromCurrency)} ${t.fromCurrency} 到 ${t.toWalletName ?? t.toWalletId}`;
+    if (!confirm(`确定撤销这笔划转?\n\n${desc}\n\n撤销会反向冲销两条流水, 入账钱包余额需够扣回。`)) {
+      return;
+    }
+    cancelMutation.mutate(t.id);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">{title}</CardTitle>
+          <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+            <RefreshCcw className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} aria-hidden="true" />
+            <span className="ml-1.5">刷新</span>
+          </Button>
+        </div>
+
+        {/* 筛选 */}
+        <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-5">
+          {!walletId ? (
+            <div className="space-y-1">
+              <div className="text-[10px] font-medium text-muted-foreground">钱包</div>
+              <select
+                className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary"
+                value={filterWalletId}
+                onChange={(e) => setFilterWalletId(e.target.value)}
+              >
+                <option value="">全部</option>
+                {walletOptions.map((w) => (
+                  <option key={w.id} value={w.id}>
+                    {w.name}({w.currency})
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">起始日期</div>
+            <input
+              type="date"
+              className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">结束日期</div>
+            <input
+              type="date"
+              className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">操作人</div>
+            <input
+              className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary"
+              value={operator}
+              onChange={(e) => setOperator(e.target.value)}
+              placeholder="比如 黄呈煜"
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">含已撤销</div>
+            <label className="flex h-9 items-center gap-2 rounded-md border border-border bg-card px-2 text-xs">
+              <input
+                type="checkbox"
+                checked={includeDeleted}
+                onChange={(e) => setIncludeDeleted(e.target.checked)}
+              />
+              <span>显示已撤销</span>
+            </label>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>日期</TableHead>
+              <TableHead>出账</TableHead>
+              <TableHead>入账</TableHead>
+              <TableHead className="text-right">汇率</TableHead>
+              <TableHead>操作人</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead className="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {transfers.map((t) => {
+              const cancelled = Boolean(t.deletedAt);
+              return (
+                <TableRow
+                  key={t.id}
+                  className={cn(cancelled && "text-muted-foreground line-through opacity-60")}
+                >
+                  <TableCell className="tabular-nums text-xs">
+                    {formatDateOnly(t.businessDate ?? t.createdAt)}
+                    {cancelled ? (
+                      <Badge tone="danger" className="ml-2">
+                        已撤销
+                      </Badge>
+                    ) : null}
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    <div className="font-medium">{t.fromWalletName ?? t.fromWalletId}</div>
+                    <div className="tabular-nums text-red-600 font-semibold no-underline">
+                      -{formatAmountStr(t.fromAmount, t.fromCurrency)} {t.fromCurrency}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-xs">
+                    <div className="font-medium">{t.toWalletName ?? t.toWalletId}</div>
+                    <div className="tabular-nums text-green-600 font-semibold no-underline">
+                      +{formatAmountStr(t.toAmount, t.toCurrency)} {t.toCurrency}
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums text-xs">
+                    <div className="flex items-center justify-end gap-1">
+                      <span>1 {t.fromCurrency}</span>
+                      <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
+                      <span>
+                        {formatRate(t.rate)} {t.toCurrency}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-xs">{t.operatorName ?? "-"}</TableCell>
+                  <TableCell className="text-xs text-muted-foreground">{t.note ?? "-"}</TableCell>
+                  <TableCell className="text-right">
+                    {cancelled ? (
+                      <span className="text-[10px] text-muted-foreground">
+                        {formatDateOnly(t.deletedAt)}
+                      </span>
+                    ) : (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        className="h-7 text-red-600 border-red-300 hover:bg-red-50"
+                        onClick={() => handleCancel(t)}
+                        disabled={cancelMutation.isPending}
+                      >
+                        <Trash2 className="h-3 w-3" aria-hidden="true" />
+                        <span className="ml-1">撤销</span>
+                      </Button>
+                    )}
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+            {transfers.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="py-8 text-center text-muted-foreground">
+                  {isFetching ? "加载中..." : "暂无划转记录"}
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/wallet-transfer-modal.tsx
+++ b/frontend/components/wallet-transfer-modal.tsx
@@ -1,0 +1,311 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowRight } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { createWalletTransfer, getDashboardData } from "@/lib/api";
+import { formatMoney } from "@/lib/money";
+import type { WalletBalance } from "@/types";
+
+// 与台湾页一致: 操作人名字存 localStorage 跨刷新保留
+const OP_NAME_KEY = "taiwan-operator-name";
+
+function getStoredOperatorName(): string {
+  if (typeof window === "undefined") return "";
+  return localStorage.getItem(OP_NAME_KEY) ?? "";
+}
+
+function setStoredOperatorName(name: string) {
+  if (typeof window === "undefined") return;
+  if (name) localStorage.setItem(OP_NAME_KEY, name);
+}
+
+// 把 dashboard 树拍平成"叶子钱包列表"(非分组, 非已删除)
+function flattenLeaves(wallets: WalletBalance[]): WalletBalance[] {
+  const out: WalletBalance[] = [];
+  const walk = (nodes: WalletBalance[]) => {
+    for (const w of nodes) {
+      if (!w.isGroup && !w.deletedAt) {
+        out.push(w);
+      }
+      if (w.children && w.children.length > 0) {
+        walk(w.children);
+      }
+    }
+  };
+  walk(wallets);
+  return out;
+}
+
+// 汇率显示: 8 位小数, 自动 trim 尾 0; 但保留至少 1 位整数, 比如 "1" 而不是 "1."
+function formatRate(rate: string | number): string {
+  const n = typeof rate === "number" ? rate : Number(rate);
+  if (!Number.isFinite(n) || n <= 0) return "-";
+  const fixed = n.toFixed(8);
+  // 去尾 0; 如果点后全是 0, 连小数点一起去
+  return fixed.replace(/\.?0+$/, "") || "0";
+}
+
+function todayISO(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export type WalletTransferModalProps = {
+  open: boolean;
+  onClose: () => void;
+  defaultFromWalletId?: string;
+  onSuccess?: () => void;
+};
+
+export function WalletTransferModal({
+  open,
+  onClose,
+  defaultFromWalletId,
+  onSuccess
+}: WalletTransferModalProps) {
+  const queryClient = useQueryClient();
+
+  // 拉所有钱包(资产 + 台湾)
+  const { data: dashboard } = useQuery({
+    queryKey: ["dashboard"],
+    queryFn: getDashboardData,
+    enabled: open
+  });
+
+  const leafWallets = useMemo(
+    () => flattenLeaves(dashboard?.wallets ?? []),
+    [dashboard?.wallets]
+  );
+
+  const [fromWalletId, setFromWalletId] = useState<string>("");
+  const [toWalletId, setToWalletId] = useState<string>("");
+  const [fromAmount, setFromAmount] = useState<string>("");
+  const [toAmount, setToAmount] = useState<string>("");
+  const [operatorName, setOperatorName] = useState<string>("");
+  const [businessDate, setBusinessDate] = useState<string>(todayISO());
+  const [note, setNote] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+
+  // 打开时初始化表单
+  useEffect(() => {
+    if (!open) return;
+    setFromWalletId(defaultFromWalletId ?? "");
+    setToWalletId("");
+    setFromAmount("");
+    setToAmount("");
+    setNote("");
+    setError(null);
+    setBusinessDate(todayISO());
+    setOperatorName(getStoredOperatorName());
+  }, [open, defaultFromWalletId]);
+
+  const fromWallet = leafWallets.find((w) => w.id === fromWalletId);
+  const toWallet = leafWallets.find((w) => w.id === toWalletId);
+
+  // 实时算汇率 = to_amount / from_amount (前端只用于展示, 提交时后端会重算)
+  const rateDisplay = useMemo(() => {
+    const f = Number(fromAmount);
+    const t = Number(toAmount);
+    if (!Number.isFinite(f) || !Number.isFinite(t) || f <= 0 || t <= 0) return "-";
+    return formatRate(t / f);
+  }, [fromAmount, toAmount]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!fromWalletId) throw new Error("请选择出账钱包");
+      if (!toWalletId) throw new Error("请选择入账钱包");
+      if (fromWalletId === toWalletId) throw new Error("出账和入账不能是同一个钱包");
+      const f = Number(fromAmount);
+      const t = Number(toAmount);
+      if (!fromAmount.trim() || !Number.isFinite(f) || f <= 0) {
+        throw new Error("出账金额必须大于 0");
+      }
+      if (!toAmount.trim() || !Number.isFinite(t) || t <= 0) {
+        throw new Error("入账金额必须大于 0");
+      }
+      const opName = operatorName.trim();
+      if (opName) setStoredOperatorName(opName);
+      return createWalletTransfer({
+        fromWalletId,
+        toWalletId,
+        fromAmount: fromAmount.trim(),
+        toAmount: toAmount.trim(),
+        businessDate: businessDate || undefined,
+        operatorName: opName || undefined,
+        note: note.trim() || undefined
+      });
+    },
+    onSuccess: async () => {
+      // 刷各页缓存
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
+        queryClient.invalidateQueries({ queryKey: ["assets"] }),
+        queryClient.invalidateQueries({ queryKey: ["asset-transactions"] }),
+        queryClient.invalidateQueries({ queryKey: ["taiwan-wallets"] }),
+        queryClient.invalidateQueries({ queryKey: ["taiwan-summary"] }),
+        queryClient.invalidateQueries({ queryKey: ["taiwan-transactions"] }),
+        queryClient.invalidateQueries({ queryKey: ["wallet-transfers"] })
+      ]);
+      onSuccess?.();
+      onClose();
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "划转失败")
+  });
+
+  if (!open) return null;
+
+  // 入账钱包下拉应排除当前出账钱包
+  const toCandidates = leafWallets.filter((w) => w.id !== fromWalletId);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-lg">
+        <CardHeader>
+          <CardTitle className="text-base">钱包划转</CardTitle>
+          <div className="text-xs text-muted-foreground">
+            从一个钱包搬钱到另一个(支持跨币种), 系统按"入账/出账"自动算汇率
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* 出账钱包 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">出账钱包</div>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={fromWalletId}
+              onChange={(e) => setFromWalletId(e.target.value)}
+            >
+              <option value="">-- 选择 --</option>
+              {leafWallets.map((w) => (
+                <option key={w.id} value={w.id}>
+                  {w.name}({w.currency}, 余额 {formatMoney(w.balanceMinor, w.currency)})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 出账金额 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">
+              出账金额{fromWallet ? `(${fromWallet.currency})` : ""}
+            </div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={fromAmount}
+              onChange={(e) => setFromAmount(e.target.value)}
+              placeholder="例: 1000"
+              type="number"
+              min="0"
+              step="0.000001"
+              inputMode="decimal"
+            />
+          </div>
+
+          {/* 入账钱包 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">入账钱包</div>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={toWalletId}
+              onChange={(e) => setToWalletId(e.target.value)}
+            >
+              <option value="">-- 选择 --</option>
+              {toCandidates.map((w) => (
+                <option key={w.id} value={w.id}>
+                  {w.name}({w.currency}, 余额 {formatMoney(w.balanceMinor, w.currency)})
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* 入账金额 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">
+              入账金额{toWallet ? `(${toWallet.currency})` : ""}
+            </div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={toAmount}
+              onChange={(e) => setToAmount(e.target.value)}
+              placeholder="例: 30"
+              type="number"
+              min="0"
+              step="0.000001"
+              inputMode="decimal"
+            />
+          </div>
+
+          {/* 当前汇率(只读) */}
+          <div className="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs">
+            <div className="text-muted-foreground">当前汇率(入账 / 出账)</div>
+            <div className="mt-0.5 flex items-center gap-2 text-sm font-semibold tabular-nums">
+              {fromWallet ? <span>1 {fromWallet.currency}</span> : <span>1 ?</span>}
+              <ArrowRight className="h-3 w-3 text-muted-foreground" aria-hidden="true" />
+              <span>
+                {rateDisplay} {toWallet?.currency ?? "?"}
+              </span>
+            </div>
+          </div>
+
+          {/* 操作人 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">操作人</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={operatorName}
+              onChange={(e) => setOperatorName(e.target.value)}
+              placeholder="比如 黄呈煜 / 李睿旭"
+            />
+            <div className="text-[10px] text-muted-foreground">下次会自动填上次的名字</div>
+          </div>
+
+          {/* 业务日期 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">业务日期</div>
+            <input
+              type="date"
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={businessDate}
+              onChange={(e) => setBusinessDate(e.target.value)}
+            />
+          </div>
+
+          {/* 备注 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">备注(选填)</div>
+            <textarea
+              className="min-h-[60px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="例: 台币归集"
+            />
+          </div>
+
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-600">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button
+              onClick={() => mutation.mutate()}
+              disabled={mutation.isPending || !fromWalletId || !toWalletId}
+            >
+              {mutation.isPending ? "提交中..." : "确认划转"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -22,9 +22,11 @@ import {
   Plus,
   Receipt,
   RefreshCcw,
+  RotateCcw,
   Settings2,
   ShieldAlert,
   Trash2,
+  Undo2,
   Unlock,
   Users
 } from "lucide-react";
@@ -69,6 +71,8 @@ import {
   triggerXboxSync,
   updateXboxAccount
 } from "@/lib/api";
+import { XboxRefundList } from "@/components/xbox-refund-list";
+import { XboxRefundModal } from "@/components/xbox-refund-modal";
 import type { XboxRefreshJobStatus } from "@/lib/api";
 import { formatMoney, minorUnit } from "@/lib/money";
 import { cn } from "@/lib/utils";
@@ -2302,6 +2306,7 @@ function SaleRecordsTab({ highlightId }: { highlightId?: string | null }) {
   const [editTarget, setEditTarget] = useState<XboxSaleRecord | null>(null);
   const [expandTarget, setExpandTarget] = useState<XboxSaleRecord | null>(null);
   const [logsTarget, setLogsTarget] = useState<XboxSaleRecord | null>(null);
+  const [refundTarget, setRefundTarget] = useState<XboxSaleRecord | null>(null);
   const [dateRange, setDateRange] = useState(defaultDateRange);
 
   const { data: records = [], isFetching, refetch } = useQuery({
@@ -2408,15 +2413,30 @@ function SaleRecordsTab({ highlightId }: { highlightId?: string | null }) {
               {records.map((record) => {
                 const account = accounts.find((a) => a.id === record.accountId);
                 const isHighlighted = highlightId === record.id;
+                const isRefunded = record.status === "refunded";
                 return (
-                  <TableRow key={record.id} className={cn(isHighlighted && "bg-emerald-50")}>
+                  <TableRow key={record.id} className={cn(isHighlighted && "bg-emerald-50", isRefunded && "bg-red-50/40")}>
                     <TableCell className="text-xs tabular-nums">{formatDateTimeSeconds(record.saleDate)}</TableCell>
                     <TableCell className="text-xs text-muted-foreground">
                       {account?.accountNo ?? account?.name ?? "-"}
                     </TableCell>
-                    <TableCell className="truncate max-w-[200px]">{record.productName}</TableCell>
+                    <TableCell className="truncate max-w-[200px]">
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        <span className={cn(isRefunded && "line-through text-muted-foreground")}>
+                          {record.productName}
+                        </span>
+                        {isRefunded ? (
+                          <Badge tone="danger" className="text-[10px]">
+                            已退款{record.refundedAt ? ` · ${record.refundedAt.slice(0, 10)}` : ""}
+                          </Badge>
+                        ) : null}
+                      </div>
+                    </TableCell>
                     <TableCell className="text-xs text-muted-foreground">{record.operatorName}</TableCell>
-                    <TableCell className="text-right tabular-nums font-semibold text-emerald-600">
+                    <TableCell className={cn(
+                      "text-right tabular-nums font-semibold",
+                      isRefunded ? "text-muted-foreground line-through" : "text-emerald-600"
+                    )}>
                       {formatMoney(record.salePrice, record.saleCurrency as Currency)}
                     </TableCell>
                     <TableCell className="text-xs">{record.walletItemLabel}</TableCell>
@@ -2441,6 +2461,17 @@ function SaleRecordsTab({ highlightId }: { highlightId?: string | null }) {
                           <Pencil className="h-3.5 w-3.5" />
                           修改
                         </Button>
+                        {!isRefunded ? (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="text-red-600 border-red-300 hover:bg-red-50"
+                            onClick={() => setRefundTarget(record)}
+                          >
+                            <Undo2 className="h-3.5 w-3.5" />
+                            退款
+                          </Button>
+                        ) : null}
                         <Button size="sm" variant="ghost" onClick={() => setLogsTarget(record)}>
                           <History className="h-3.5 w-3.5" />
                           历史
@@ -2480,6 +2511,12 @@ function SaleRecordsTab({ highlightId }: { highlightId?: string | null }) {
           title={`销售 #${logsTarget.id} ${logsTarget.productName}`}
           fetchLogs={() => getXboxSaleRecordChangeLogs(logsTarget.id)}
           onClose={() => setLogsTarget(null)}
+        />
+      ) : null}
+      {refundTarget ? (
+        <XboxRefundModal
+          saleRecord={refundTarget}
+          onClose={() => setRefundTarget(null)}
         />
       ) : null}
     </div>
@@ -2906,12 +2943,13 @@ function WalletSettingsTab() {
 }
 
 
-type XboxTab = "accounts" | "orders" | "sale-records" | "wallet-settings" | "reconcile";
+type XboxTab = "accounts" | "orders" | "sale-records" | "refunds" | "wallet-settings" | "reconcile";
 
 const TAB_META: { id: XboxTab; label: string; icon: React.ReactNode }[] = [
   { id: "accounts", label: "账号管理", icon: <Users className="h-4 w-4" /> },
   { id: "orders", label: "订单", icon: <Receipt className="h-4 w-4" /> },
   { id: "sale-records", label: "销售记录", icon: <Layers className="h-4 w-4" /> },
+  { id: "refunds", label: "退款", icon: <Undo2 className="h-4 w-4" /> },
   { id: "wallet-settings", label: "钱包设置", icon: <Settings2 className="h-4 w-4" /> },
   { id: "reconcile", label: "对账", icon: <GitCompare className="h-4 w-4" /> }
 ];
@@ -3584,6 +3622,7 @@ export function XboxPage() {
       {tab === "accounts" ? <AccountsManagementTab /> : null}
       {tab === "orders" ? <OrdersTab onJumpToSaleRecord={jumpToSaleRecord} /> : null}
       {tab === "sale-records" ? <SaleRecordsTab highlightId={highlightSaleRecordId} /> : null}
+      {tab === "refunds" ? <XboxRefundList /> : null}
       {tab === "wallet-settings" ? <WalletSettingsTab /> : null}
       {tab === "reconcile" ? <ReconcileTab /> : null}
     </div>

--- a/frontend/components/xbox-page.tsx
+++ b/frontend/components/xbox-page.tsx
@@ -3012,7 +3012,8 @@ function ReconcileTab() {
         <CardHeader>
           <CardTitle className="text-base">{date} 对账</CardTitle>
           <div className="text-xs text-muted-foreground">
-            理论值（XBOX 销售归口）当日流入 vs 实际值钱包当日 IN 流水。差异 ≠ 0 表示客服可能填错出售渠道,
+            理论值（XBOX 销售归口）当日 vs 实际值钱包当日 IN/OUT 流水。
+            IN 差异 ≠ 0 表示客服可能填错出售渠道; OUT 差异 ≠ 0 表示退款时实际钱包选错。
             可在订单 tab 用「改字段」拆单纠错。
           </div>
         </CardHeader>
@@ -3022,9 +3023,12 @@ function ReconcileTab() {
               <TableRow>
                 <TableHead>理论值钱包</TableHead>
                 <TableHead>币种</TableHead>
-                <TableHead className="text-right">理论金额</TableHead>
-                <TableHead className="text-right">实际金额（合计）</TableHead>
-                <TableHead className="text-right">差异</TableHead>
+                <TableHead className="text-right text-emerald-700">理论 IN</TableHead>
+                <TableHead className="text-right text-emerald-700">实际 IN</TableHead>
+                <TableHead className="text-right text-emerald-700">IN 差异</TableHead>
+                <TableHead className="text-right text-red-700">理论 OUT</TableHead>
+                <TableHead className="text-right text-red-700">实际 OUT</TableHead>
+                <TableHead className="text-right text-red-700">OUT 差异</TableHead>
                 <TableHead>映射的实际钱包</TableHead>
               </TableRow>
             </TableHeader>
@@ -3033,6 +3037,10 @@ function ReconcileTab() {
                 const diff = Number(row.diff);
                 const diffColor =
                   diff === 0 ? "text-muted-foreground" : diff > 0 ? "text-blue-600" : "text-red-600";
+                const outDiff = Number(row.outDiff ?? "0");
+                const outDiffColor =
+                  outDiff === 0 ? "text-muted-foreground" : "text-amber-600";
+                const outDiffBg = outDiff !== 0 ? "bg-amber-50" : "";
                 return (
                   <TableRow key={row.theoreticalWallet.id}>
                     <TableCell className="font-medium">{row.theoreticalWallet.name}</TableCell>
@@ -3052,6 +3060,22 @@ function ReconcileTab() {
                     <TableCell className={cn("text-right tabular-nums font-semibold", diffColor)}>
                       {diff > 0 ? "+" : ""}
                       {Number(row.diff).toLocaleString("zh-CN", {
+                        minimumFractionDigits: 2, maximumFractionDigits: 2
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      {Number(row.theoreticalOutTotal ?? "0").toLocaleString("zh-CN", {
+                        minimumFractionDigits: 2, maximumFractionDigits: 2
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      {Number(row.actualOutTotal ?? "0").toLocaleString("zh-CN", {
+                        minimumFractionDigits: 2, maximumFractionDigits: 2
+                      })}
+                    </TableCell>
+                    <TableCell className={cn("text-right tabular-nums font-semibold", outDiffColor, outDiffBg)}>
+                      {outDiff > 0 ? "+" : ""}
+                      {Number(row.outDiff ?? "0").toLocaleString("zh-CN", {
                         minimumFractionDigits: 2, maximumFractionDigits: 2
                       })}
                     </TableCell>
@@ -3075,11 +3099,13 @@ function ReconcileTab() {
                                 m.theoreticalWalletId === String(row.theoreticalWallet.id) &&
                                 m.actualWalletId === String(aw.id)
                             );
+                            const hasOut = aw.outTotal !== undefined && Number(aw.outTotal) > 0;
                             return (
                               <Badge key={aw.id} tone="transfer">
                                 <span>{aw.name}</span>
                                 <span className="ml-1 tabular-nums">
-                                  ({aw.currency} {Number(aw.total).toLocaleString("zh-CN")})
+                                  ({aw.currency} IN {Number(aw.total).toLocaleString("zh-CN")}
+                                  {hasOut ? ` · OUT ${Number(aw.outTotal ?? "0").toLocaleString("zh-CN")}` : ""})
                                 </span>
                                 {mapping ? (
                                   <button
@@ -3117,7 +3143,7 @@ function ReconcileTab() {
               })}
               {report.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="py-8 text-center text-muted-foreground">
+                  <TableCell colSpan={9} className="py-8 text-center text-muted-foreground">
                     暂无对账数据
                   </TableCell>
                 </TableRow>

--- a/frontend/components/xbox-refund-list.tsx
+++ b/frontend/components/xbox-refund-list.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { RefreshCcw, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import {
+  cancelXboxRefund,
+  getXboxWalletPoolOptions,
+  listXboxRefunds
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type { XboxRefund } from "@/types";
+
+function formatAmountStr(amount: string, currency: string): string {
+  const n = Number(amount);
+  if (!Number.isFinite(n)) return amount;
+  const digits =
+    currency === "USDT" || currency === "BTC" || currency === "ETH" ? 6 : 2;
+  return n.toFixed(digits);
+}
+
+function formatDateOnly(value: string | null): string {
+  if (!value) return "-";
+  return value.length >= 10 ? value.slice(0, 10) : value;
+}
+
+export function XboxRefundList() {
+  const queryClient = useQueryClient();
+  const [fromDate, setFromDate] = useState<string>("");
+  const [toDate, setToDate] = useState<string>("");
+  const [actualWalletId, setActualWalletId] = useState<string>("");
+  const [operator, setOperator] = useState<string>("");
+
+  const { data: poolGroups = [] } = useQuery({
+    queryKey: ["xbox-pool-options-all-no-groups"],
+    queryFn: () => getXboxWalletPoolOptions({ xboxOnly: false, includeGroups: false })
+  });
+  const walletOptions = useMemo(
+    () => poolGroups.filter((g) => g.groupCode !== "XBOX_SALES_LEDGER"),
+    [poolGroups]
+  );
+
+  const queryKey = useMemo(
+    () => ["xbox-refunds", { fromDate, toDate, actualWalletId, operator }],
+    [fromDate, toDate, actualWalletId, operator]
+  );
+
+  const { data: refunds = [], isFetching, refetch } = useQuery({
+    queryKey,
+    queryFn: () =>
+      listXboxRefunds({
+        fromDate: fromDate || undefined,
+        toDate: toDate || undefined,
+        actualWalletId: actualWalletId || undefined,
+        operatorName: operator || undefined
+      })
+  });
+
+  const cancelMutation = useMutation({
+    mutationFn: (refundId: string) => cancelXboxRefund(refundId),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["xbox-refunds"] }),
+        queryClient.invalidateQueries({ queryKey: ["xbox-sale-records"] }),
+        queryClient.invalidateQueries({ queryKey: ["xbox-reconcile-report"] }),
+        queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
+        queryClient.invalidateQueries({ queryKey: ["assets"] })
+      ]);
+    },
+    onError: (err) => {
+      window.alert(err instanceof Error ? err.message : "撤销失败");
+    }
+  });
+
+  const handleCancel = (r: XboxRefund) => {
+    const desc = r.saleRecord
+      ? `销售记录 #${r.saleRecord.id} ${r.saleRecord.productName}`
+      : `退款 #${r.id}`;
+    if (
+      !confirm(
+        `确定撤销这笔退款?\n\n${desc}\n金额 ${formatAmountStr(r.refundAmount, r.refundCurrency)} ${r.refundCurrency}\n\n撤销会反向冲销两条流水, 销售记录回到「未退款」。`
+      )
+    ) {
+      return;
+    }
+    cancelMutation.mutate(r.id);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <CardTitle className="text-base">退款记录</CardTitle>
+          <Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+            <RefreshCcw className={cn("h-3.5 w-3.5", isFetching && "animate-spin")} aria-hidden="true" />
+            <span className="ml-1.5">刷新</span>
+          </Button>
+        </div>
+
+        {/* 筛选 */}
+        <div className="mt-3 grid grid-cols-1 gap-2 md:grid-cols-4">
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">起始日期</div>
+            <input
+              type="date"
+              className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={fromDate}
+              onChange={(e) => setFromDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">结束日期</div>
+            <input
+              type="date"
+              className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={toDate}
+              onChange={(e) => setToDate(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">实际退款钱包</div>
+            <select
+              className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary"
+              value={actualWalletId}
+              onChange={(e) => setActualWalletId(e.target.value)}
+            >
+              <option value="">全部</option>
+              {walletOptions.map((g) => (
+                <optgroup key={g.groupCode} label={`── ${g.groupLabel} ──`}>
+                  {g.wallets.map((w) => (
+                    <option key={w.id} value={w.id}>
+                      {w.name}({w.currency})
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <div className="text-[10px] font-medium text-muted-foreground">操作人</div>
+            <input
+              className="h-9 w-full rounded-md border border-border bg-card px-2 text-xs outline-none focus:ring-2 focus:ring-primary"
+              value={operator}
+              onChange={(e) => setOperator(e.target.value)}
+              placeholder="比如 黄呈煜"
+            />
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>日期</TableHead>
+              <TableHead>原销售记录</TableHead>
+              <TableHead className="text-right">原售价</TableHead>
+              <TableHead>实际退款钱包</TableHead>
+              <TableHead>操作人</TableHead>
+              <TableHead>备注</TableHead>
+              <TableHead className="text-right">操作</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {refunds.map((r) => (
+              <TableRow key={r.id}>
+                <TableCell className="tabular-nums text-xs">
+                  {formatDateOnly(r.businessDate ?? r.createdAt)}
+                </TableCell>
+                <TableCell className="text-xs">
+                  {r.saleRecord ? (
+                    <>
+                      <div className="text-muted-foreground">
+                        #{r.saleRecord.id}{" "}
+                        {r.saleRecord.accountNo ?? r.saleRecord.accountName ?? ""}
+                      </div>
+                      <div className="font-medium truncate max-w-[220px]">
+                        {r.saleRecord.productName}
+                      </div>
+                      <div className="text-[10px] text-muted-foreground">
+                        客服 {r.saleRecord.operatorName || "-"} · {r.saleRecord.walletItemLabel}
+                      </div>
+                    </>
+                  ) : (
+                    <span className="text-muted-foreground">
+                      销售 #{r.originalSaleRecordId}
+                    </span>
+                  )}
+                </TableCell>
+                <TableCell className="text-right tabular-nums text-xs font-semibold text-red-600">
+                  -{formatAmountStr(r.refundAmount, r.refundCurrency)} {r.refundCurrency}
+                </TableCell>
+                <TableCell className="text-xs">
+                  <div className="font-medium">{r.actualWalletName ?? r.actualWalletId}</div>
+                  {r.theoreticalWalletName ? (
+                    <div className="text-[10px] text-muted-foreground">
+                      理论 {r.theoreticalWalletName}
+                    </div>
+                  ) : null}
+                </TableCell>
+                <TableCell className="text-xs">{r.operatorName ?? "-"}</TableCell>
+                <TableCell className="text-xs text-muted-foreground">{r.note ?? "-"}</TableCell>
+                <TableCell className="text-right">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="h-7 text-red-600 border-red-300 hover:bg-red-50"
+                    onClick={() => handleCancel(r)}
+                    disabled={cancelMutation.isPending}
+                  >
+                    <Trash2 className="h-3 w-3" aria-hidden="true" />
+                    <span className="ml-1">撤销</span>
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+            {refunds.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={7} className="py-8 text-center text-muted-foreground">
+                  {isFetching ? "加载中..." : "暂无退款记录"}
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/xbox-refund-modal.tsx
+++ b/frontend/components/xbox-refund-modal.tsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  createXboxRefund,
+  getXboxAccounts,
+  getXboxWalletPoolOptions
+} from "@/lib/api";
+import { formatMoney } from "@/lib/money";
+import type { Currency, XboxSaleRecord } from "@/types";
+
+// 与划转弹窗一致, 操作人名字存 localStorage
+const OP_NAME_KEY = "taiwan-operator-name";
+
+function getStoredOperatorName(): string {
+  if (typeof window === "undefined") return "";
+  return localStorage.getItem(OP_NAME_KEY) ?? "";
+}
+
+function setStoredOperatorName(name: string) {
+  if (typeof window === "undefined") return;
+  if (name) localStorage.setItem(OP_NAME_KEY, name);
+}
+
+function todayISO(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export type XboxRefundModalProps = {
+  saleRecord: XboxSaleRecord;
+  onClose: () => void;
+  onSuccess?: () => void;
+};
+
+export function XboxRefundModal({ saleRecord, onClose, onSuccess }: XboxRefundModalProps) {
+  const queryClient = useQueryClient();
+
+  // 拉所有钱包(用 includeGroups=false 排除分组钱包) - 列出所有币种
+  const { data: poolGroups = [] } = useQuery({
+    queryKey: ["xbox-pool-options-all-no-groups"],
+    queryFn: () => getXboxWalletPoolOptions({ xboxOnly: false, includeGroups: false })
+  });
+
+  // 拉账号(显示账号编号)
+  const { data: accounts = [] } = useQuery({
+    queryKey: ["xbox-accounts"],
+    queryFn: () => getXboxAccounts()
+  });
+  const account = accounts.find((a) => a.id === saleRecord.accountId);
+
+  const [actualWalletId, setActualWalletId] = useState<string>("");
+  const [operatorName, setOperatorName] = useState<string>("");
+  const [businessDate, setBusinessDate] = useState<string>(todayISO());
+  const [note, setNote] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  // 默认按销售币种过滤, 可关闭"显示全部"
+  const [filterByCurrency, setFilterByCurrency] = useState<boolean>(true);
+
+  useEffect(() => {
+    setActualWalletId("");
+    setNote("");
+    setError(null);
+    setBusinessDate(todayISO());
+    setOperatorName(getStoredOperatorName());
+  }, [saleRecord.id]);
+
+  // 找原销售记录的理论钱包名 (从 pool 选项里找)
+  const theoreticalWallet = useMemo(() => {
+    for (const g of poolGroups) {
+      const w = g.wallets.find((x) => x.id === saleRecord.walletPoolId);
+      if (w) return w;
+    }
+    return null;
+  }, [poolGroups, saleRecord.walletPoolId]);
+
+  // 实际钱包候选: 排除 XBOX_SALES_LEDGER (那是理论钱包池), 按需按币种过滤
+  const candidateGroups = useMemo(() => {
+    const groups = poolGroups.filter((g) => g.groupCode !== "XBOX_SALES_LEDGER");
+    if (!filterByCurrency) return groups;
+    return groups
+      .map((g) => ({
+        ...g,
+        wallets: g.wallets.filter((w) => w.currency === saleRecord.saleCurrency)
+      }))
+      .filter((g) => g.wallets.length > 0);
+  }, [poolGroups, filterByCurrency, saleRecord.saleCurrency]);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!actualWalletId) throw new Error("请选择实际退款钱包");
+      const opName = operatorName.trim();
+      if (opName) setStoredOperatorName(opName);
+      return createXboxRefund({
+        saleRecordId: saleRecord.id,
+        actualWalletId,
+        businessDate: businessDate || undefined,
+        operatorName: opName || undefined,
+        note: note.trim() || undefined
+      });
+    },
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["xbox-sale-records"] }),
+        queryClient.invalidateQueries({ queryKey: ["xbox-refunds"] }),
+        queryClient.invalidateQueries({ queryKey: ["xbox-reconcile-report"] }),
+        queryClient.invalidateQueries({ queryKey: ["dashboard"] }),
+        queryClient.invalidateQueries({ queryKey: ["assets"] }),
+        queryClient.invalidateQueries({ queryKey: ["taiwan-wallets"] })
+      ]);
+      onSuccess?.();
+      onClose();
+    },
+    onError: (err) => setError(err instanceof Error ? err.message : "退款失败")
+  });
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <CardHeader>
+          <CardTitle className="text-base">XBOX 销售记录退款</CardTitle>
+          <div className="text-xs text-muted-foreground">
+            全额退款。提交后销售记录标「已退款」, 实际钱包与理论钱包同时 OUT 一笔。
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* 原销售记录摘要(只读) */}
+          <div className="rounded-md border border-border bg-muted/30 p-3 text-xs space-y-1">
+            <div className="font-semibold text-sm text-foreground">销售记录 #{saleRecord.id}</div>
+            <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-muted-foreground">
+              <div>
+                <span className="text-foreground/60">账号:</span>{" "}
+                <span className="font-medium text-foreground">
+                  {account?.accountNo ?? account?.name ?? "-"}
+                </span>
+              </div>
+              <div>
+                <span className="text-foreground/60">客服:</span>{" "}
+                <span className="font-medium text-foreground">{saleRecord.operatorName || "-"}</span>
+              </div>
+              <div className="col-span-2">
+                <span className="text-foreground/60">商品:</span>{" "}
+                <span className="font-medium text-foreground">{saleRecord.productName}</span>
+              </div>
+              <div>
+                <span className="text-foreground/60">原售价:</span>{" "}
+                <span className="font-semibold text-emerald-600">
+                  {formatMoney(saleRecord.salePrice, saleRecord.saleCurrency as Currency)}
+                </span>
+              </div>
+              <div>
+                <span className="text-foreground/60">理论钱包:</span>{" "}
+                <span className="font-medium text-foreground">
+                  {theoreticalWallet?.name ?? saleRecord.walletItemLabel}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* 退款金额(只读) */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">退款金额(全额, 不可改)</div>
+            <div className="h-10 flex items-center rounded-md border border-border bg-muted/30 px-3 text-sm font-semibold tabular-nums">
+              {formatMoney(saleRecord.salePrice, saleRecord.saleCurrency as Currency)}
+            </div>
+          </div>
+
+          {/* 实际退款钱包 */}
+          <div className="space-y-1">
+            <div className="flex items-center justify-between">
+              <div className="text-xs font-medium text-muted-foreground">实际退款钱包</div>
+              <label className="flex items-center gap-1 text-[10px] text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={!filterByCurrency}
+                  onChange={(e) => setFilterByCurrency(!e.target.checked)}
+                />
+                显示所有币种钱包
+              </label>
+            </div>
+            <select
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={actualWalletId}
+              onChange={(e) => setActualWalletId(e.target.value)}
+            >
+              <option value="">-- 选择实际钱包 --</option>
+              {candidateGroups.map((g) => (
+                <optgroup key={g.groupCode} label={`── ${g.groupLabel} ──`}>
+                  {g.wallets.map((w) => (
+                    <option key={w.id} value={w.id}>
+                      {w.fullPath}({w.currency})
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+            <div className="text-[10px] text-muted-foreground">
+              {filterByCurrency
+                ? `仅显示 ${saleRecord.saleCurrency} 钱包(取消勾选可看全部)`
+                : "显示全部币种钱包"}
+            </div>
+          </div>
+
+          {/* 业务日期 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">业务日期</div>
+            <input
+              type="date"
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary tabular-nums"
+              value={businessDate}
+              onChange={(e) => setBusinessDate(e.target.value)}
+            />
+          </div>
+
+          {/* 操作人 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">操作人</div>
+            <input
+              className="h-10 w-full rounded-md border border-border bg-card px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={operatorName}
+              onChange={(e) => setOperatorName(e.target.value)}
+              placeholder="比如 黄呈煜 / 李睿旭"
+            />
+            <div className="text-[10px] text-muted-foreground">下次会自动填上次的名字</div>
+          </div>
+
+          {/* 备注 */}
+          <div className="space-y-1">
+            <div className="text-xs font-medium text-muted-foreground">备注(选填)</div>
+            <textarea
+              className="min-h-[60px] w-full rounded-md border border-border bg-card px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="例: 客户太久没等到充值, 全额退"
+            />
+          </div>
+
+          {error ? (
+            <div className="rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-600">
+              {error}
+            </div>
+          ) : null}
+
+          <div className="flex justify-end gap-2 pt-1">
+            <Button variant="ghost" onClick={onClose} disabled={mutation.isPending}>
+              取消
+            </Button>
+            <Button
+              onClick={() => mutation.mutate()}
+              disabled={mutation.isPending || !actualWalletId}
+            >
+              {mutation.isPending ? "提交中..." : "确认退款"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -38,6 +38,8 @@ import type {
   Vendor,
   VendorTransaction,
   WalletBalance,
+  WalletTransfer,
+  WalletTransferTransactionRef,
   WalletType,
   XboxAccount,
   XboxAccountAuditLog,
@@ -1709,6 +1711,137 @@ export async function getTaiwanSummary(): Promise<TaiwanSummary> {
   } catch {
     return mockTaiwanSummary;
   }
+}
+
+// ---------------------------------------------------------------------------
+// 划转单 (Issue #129) - 钱包间转账 (POST/GET/GET-by-id/DELETE)
+// ---------------------------------------------------------------------------
+
+type WalletTransferTxResponse = {
+  id: string | number;
+  wallet_id?: string | number;
+  walletId?: string | number;
+  direction: "in" | "out";
+  amount: string | number;
+  remark?: string | null;
+};
+
+type WalletTransferResponse = {
+  id: string | number;
+  from_wallet_id?: string | number;
+  fromWalletId?: string | number;
+  to_wallet_id?: string | number;
+  toWalletId?: string | number;
+  from_wallet_name?: string | null;
+  fromWalletName?: string | null;
+  to_wallet_name?: string | null;
+  toWalletName?: string | null;
+  from_amount: string | number;
+  to_amount: string | number;
+  rate: string | number;
+  from_currency: string;
+  to_currency: string;
+  business_date?: string | null;
+  businessDate?: string | null;
+  operator_name?: string | null;
+  operatorName?: string | null;
+  note?: string | null;
+  created_at?: string;
+  createdAt?: string;
+  deleted_at?: string | null;
+  deletedAt?: string | null;
+  transactions?: WalletTransferTxResponse[];
+};
+
+function normalizeWalletTransferTx(tx: WalletTransferTxResponse): WalletTransferTransactionRef {
+  return {
+    id: String(tx.id),
+    walletId: String(tx.wallet_id ?? tx.walletId ?? ""),
+    direction: tx.direction,
+    amount: String(tx.amount),
+    remark: tx.remark ?? null
+  };
+}
+
+function normalizeWalletTransfer(t: WalletTransferResponse): WalletTransfer {
+  return {
+    id: String(t.id),
+    fromWalletId: String(t.from_wallet_id ?? t.fromWalletId ?? ""),
+    toWalletId: String(t.to_wallet_id ?? t.toWalletId ?? ""),
+    fromWalletName: t.from_wallet_name ?? t.fromWalletName ?? null,
+    toWalletName: t.to_wallet_name ?? t.toWalletName ?? null,
+    fromAmount: String(t.from_amount),
+    toAmount: String(t.to_amount),
+    rate: String(t.rate),
+    fromCurrency: t.from_currency,
+    toCurrency: t.to_currency,
+    businessDate: t.business_date ?? t.businessDate ?? null,
+    operatorName: t.operator_name ?? t.operatorName ?? null,
+    note: t.note ?? null,
+    createdAt: t.created_at ?? t.createdAt ?? "",
+    deletedAt: t.deleted_at ?? t.deletedAt ?? null,
+    transactions: (t.transactions ?? []).map(normalizeWalletTransferTx)
+  };
+}
+
+export async function createWalletTransfer(payload: {
+  fromWalletId: string;
+  toWalletId: string;
+  fromAmount: string;
+  toAmount: string;
+  businessDate?: string;
+  operatorName?: string;
+  note?: string;
+}): Promise<WalletTransfer> {
+  const body: Record<string, unknown> = {
+    from_wallet_id: Number(payload.fromWalletId),
+    to_wallet_id: Number(payload.toWalletId),
+    from_amount: payload.fromAmount,
+    to_amount: payload.toAmount
+  };
+  if (payload.businessDate) body.business_date = payload.businessDate;
+  if (payload.operatorName) body.operator_name = payload.operatorName;
+  if (payload.note) body.note = payload.note;
+  const data = (await postJson("/api/wallet-transfers", body)) as WalletTransferResponse;
+  return normalizeWalletTransfer(data);
+}
+
+export async function listWalletTransfers(filters?: {
+  fromWalletId?: string;
+  toWalletId?: string;
+  fromDate?: string;
+  toDate?: string;
+  operatorName?: string;
+  includeDeleted?: boolean;
+}): Promise<WalletTransfer[]> {
+  try {
+    const params = new URLSearchParams();
+    if (filters?.fromWalletId) params.set("from_wallet_id", filters.fromWalletId);
+    if (filters?.toWalletId) params.set("to_wallet_id", filters.toWalletId);
+    if (filters?.fromDate) params.set("from_date", filters.fromDate);
+    if (filters?.toDate) params.set("to_date", filters.toDate);
+    if (filters?.operatorName) params.set("operator_name", filters.operatorName);
+    if (filters?.includeDeleted) params.set("include_deleted", "true");
+    const qs = params.toString();
+    const path = qs ? `/api/wallet-transfers?${qs}` : "/api/wallet-transfers";
+    const data = await fetchJson<WalletTransferResponse[]>(path);
+    return data.map(normalizeWalletTransfer);
+  } catch {
+    return [];
+  }
+}
+
+export async function getWalletTransfer(transferId: string): Promise<WalletTransfer> {
+  const data = await fetchJson<WalletTransferResponse>(`/api/wallet-transfers/${transferId}`);
+  return normalizeWalletTransfer(data);
+}
+
+export async function cancelWalletTransfer(transferId: string): Promise<WalletTransfer> {
+  const data = (await sendJson(
+    `/api/wallet-transfers/${transferId}`,
+    "DELETE"
+  )) as WalletTransferResponse;
+  return normalizeWalletTransfer(data);
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -48,6 +48,7 @@ import type {
   XboxOrder,
   XboxOrderStatus,
   XboxPoolOptionGroup,
+  XboxRefund,
   XboxSaleCurrency,
   XboxSaleRecord,
   XboxSummary,
@@ -662,6 +663,12 @@ type XboxSaleRecordResponse = {
   created_at?: string;
   lastUpdatedAt?: string;
   last_updated_at?: string;
+  // Issue #130
+  status?: string;
+  refundedAt?: string | null;
+  refunded_at?: string | null;
+  refundId?: string | number | null;
+  refund_id?: string | number | null;
 };
 
 type XboxWalletMethodResponse = {
@@ -730,6 +737,9 @@ function _normalizeOrder(o: XboxOrderResponse): XboxOrder {
 
 function _normalizeSaleRecord(r: XboxSaleRecordResponse): XboxSaleRecord {
   const currency = (r.saleCurrency ?? r.sale_currency ?? "CNY") as XboxSaleCurrency;
+  const rawStatus = r.status ?? "active";
+  const status: "active" | "refunded" = rawStatus === "refunded" ? "refunded" : "active";
+  const refundIdRaw = r.refundId ?? r.refund_id ?? null;
   return {
     id: String(r.id),
     accountId: String(r.accountId ?? r.account_id ?? ""),
@@ -748,7 +758,10 @@ function _normalizeSaleRecord(r: XboxSaleRecordResponse): XboxSaleRecord {
         : String(r.bookkeepingTxId ?? r.bookkeeping_tx_id),
     orderIds: (r.orderIds ?? r.order_ids ?? []).map((x) => String(x)),
     createdAt: r.createdAt ?? r.created_at ?? "",
-    lastUpdatedAt: r.lastUpdatedAt ?? r.last_updated_at ?? ""
+    lastUpdatedAt: r.lastUpdatedAt ?? r.last_updated_at ?? "",
+    status,
+    refundedAt: r.refundedAt ?? r.refunded_at ?? null,
+    refundId: refundIdRaw == null ? null : String(refundIdRaw)
   };
 }
 
@@ -2145,4 +2158,147 @@ export async function returnClaim(
     body
   )) as OperatorClaimResponse;
   return _normalizeClaim(data);
+}
+
+// ---------------------------------------------------------------------------
+// XBOX 退款单 (Issue #130) — 全额退, 关联原销售记录, 实际钱包 + 理论钱包都 OUT
+// ---------------------------------------------------------------------------
+
+type XboxRefundSaleSummaryResponse = {
+  id: string | number;
+  accountId?: string | number;
+  account_id?: string | number;
+  accountNo?: string | null;
+  account_no?: string | null;
+  accountName?: string | null;
+  account_name?: string | null;
+  productName?: string;
+  product_name?: string;
+  operatorName?: string;
+  operator_name?: string;
+  salePrice?: string | number;
+  sale_price?: string | number;
+  saleCurrency?: string;
+  sale_currency?: string;
+  walletItemLabel?: string;
+  wallet_item_label?: string;
+};
+
+type XboxRefundResponse = {
+  id: string | number;
+  originalSaleRecordId?: string | number;
+  original_sale_record_id?: string | number;
+  refundAmount?: string | number;
+  refund_amount?: string | number;
+  refundCurrency?: string;
+  refund_currency?: string;
+  actualWalletId?: string | number;
+  actual_wallet_id?: string | number;
+  theoreticalWalletId?: string | number;
+  theoretical_wallet_id?: string | number;
+  businessDate?: string | null;
+  business_date?: string | null;
+  operatorName?: string | null;
+  operator_name?: string | null;
+  note?: string | null;
+  actualBookkeepingTxId?: string | number | null;
+  actual_bookkeeping_tx_id?: string | number | null;
+  theoreticalBookkeepingTxId?: string | number | null;
+  theoretical_bookkeeping_tx_id?: string | number | null;
+  createdAt?: string;
+  created_at?: string;
+  saleRecord?: XboxRefundSaleSummaryResponse | null;
+  sale_record?: XboxRefundSaleSummaryResponse | null;
+  actualWalletName?: string | null;
+  actual_wallet_name?: string | null;
+  theoreticalWalletName?: string | null;
+  theoretical_wallet_name?: string | null;
+};
+
+function _normalizeRefundSaleSummary(s: XboxRefundSaleSummaryResponse | null | undefined): XboxRefund["saleRecord"] {
+  if (!s) return null;
+  return {
+    id: String(s.id),
+    accountId: String(s.accountId ?? s.account_id ?? ""),
+    accountNo: s.accountNo ?? s.account_no ?? null,
+    accountName: s.accountName ?? s.account_name ?? null,
+    productName: s.productName ?? s.product_name ?? "",
+    operatorName: s.operatorName ?? s.operator_name ?? "",
+    salePrice: String(s.salePrice ?? s.sale_price ?? "0"),
+    saleCurrency: s.saleCurrency ?? s.sale_currency ?? "CNY",
+    walletItemLabel: s.walletItemLabel ?? s.wallet_item_label ?? ""
+  };
+}
+
+function _normalizeXboxRefund(r: XboxRefundResponse): XboxRefund {
+  return {
+    id: String(r.id),
+    originalSaleRecordId: String(r.originalSaleRecordId ?? r.original_sale_record_id ?? ""),
+    refundAmount: String(r.refundAmount ?? r.refund_amount ?? "0"),
+    refundCurrency: r.refundCurrency ?? r.refund_currency ?? "CNY",
+    actualWalletId: String(r.actualWalletId ?? r.actual_wallet_id ?? ""),
+    theoreticalWalletId: String(r.theoreticalWalletId ?? r.theoretical_wallet_id ?? ""),
+    businessDate: r.businessDate ?? r.business_date ?? null,
+    operatorName: r.operatorName ?? r.operator_name ?? null,
+    note: r.note ?? null,
+    actualBookkeepingTxId:
+      r.actualBookkeepingTxId == null && r.actual_bookkeeping_tx_id == null
+        ? null
+        : String(r.actualBookkeepingTxId ?? r.actual_bookkeeping_tx_id),
+    theoreticalBookkeepingTxId:
+      r.theoreticalBookkeepingTxId == null && r.theoretical_bookkeeping_tx_id == null
+        ? null
+        : String(r.theoreticalBookkeepingTxId ?? r.theoretical_bookkeeping_tx_id),
+    createdAt: r.createdAt ?? r.created_at ?? "",
+    saleRecord: _normalizeRefundSaleSummary(r.saleRecord ?? r.sale_record ?? null),
+    actualWalletName: r.actualWalletName ?? r.actual_wallet_name ?? null,
+    theoreticalWalletName: r.theoreticalWalletName ?? r.theoretical_wallet_name ?? null
+  };
+}
+
+export async function createXboxRefund(payload: {
+  saleRecordId: string;
+  actualWalletId: string;
+  businessDate?: string;
+  operatorName?: string;
+  note?: string;
+}): Promise<XboxRefund> {
+  const body: Record<string, unknown> = {
+    sale_record_id: payload.saleRecordId,
+    actual_wallet_id: payload.actualWalletId
+  };
+  if (payload.businessDate) body.business_date = payload.businessDate;
+  if (payload.operatorName) body.operator_name = payload.operatorName;
+  if (payload.note) body.note = payload.note;
+  const data = (await postJson("/api/xbox/refunds", body)) as XboxRefundResponse;
+  return _normalizeXboxRefund(data);
+}
+
+export async function listXboxRefunds(filters?: {
+  fromDate?: string;
+  toDate?: string;
+  actualWalletId?: string;
+  operatorName?: string;
+}): Promise<XboxRefund[]> {
+  const qs = new URLSearchParams();
+  if (filters?.fromDate) qs.set("from_date", filters.fromDate);
+  if (filters?.toDate) qs.set("to_date", filters.toDate);
+  if (filters?.actualWalletId) qs.set("actual_wallet_id", filters.actualWalletId);
+  if (filters?.operatorName) qs.set("operator_name", filters.operatorName);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+  try {
+    const data = await fetchJson<XboxRefundResponse[]>(`/api/xbox/refunds${suffix}`);
+    return data.map(_normalizeXboxRefund);
+  } catch {
+    return [];
+  }
+}
+
+export async function getXboxRefund(refundId: string): Promise<XboxRefund> {
+  const data = await fetchJson<XboxRefundResponse>(`/api/xbox/refunds/${refundId}`);
+  return _normalizeXboxRefund(data);
+}
+
+export async function cancelXboxRefund(refundId: string): Promise<void> {
+  await sendJson(`/api/xbox/refunds/${refundId}`, "DELETE");
 }

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -246,6 +246,37 @@ export type TaiwanSummary = {
 };
 
 // ---------------------------------------------------------------------------
+// 划转单 (Issue #129) - 钱包间转账, 一笔 transfer = 两条流水, 记录汇率
+// ---------------------------------------------------------------------------
+
+export type WalletTransferTransactionRef = {
+  id: string;
+  walletId: string;
+  direction: "in" | "out";
+  amount: string;
+  remark: string | null;
+};
+
+export type WalletTransfer = {
+  id: string;
+  fromWalletId: string;
+  toWalletId: string;
+  fromWalletName: string | null;
+  toWalletName: string | null;
+  fromAmount: string;
+  toAmount: string;
+  rate: string;
+  fromCurrency: string;
+  toCurrency: string;
+  businessDate: string | null;
+  operatorName: string | null;
+  note: string | null;
+  createdAt: string;
+  deletedAt: string | null;
+  transactions: WalletTransferTransactionRef[];
+};
+
+// ---------------------------------------------------------------------------
 // Taobao（PR #65/#67/#69/#73 后的新结构：3 店铺 × 5 钱包 + storeAlipayWallet 必填带 type）
 // ---------------------------------------------------------------------------
 

--- a/frontend/types.ts
+++ b/frontend/types.ts
@@ -122,6 +122,8 @@ export type XboxOrder = {
 };
 
 // 销售记录
+export type XboxSaleRecordStatus = "active" | "refunded";
+
 export type XboxSaleRecord = {
   id: string;
   accountId: string;
@@ -138,6 +140,40 @@ export type XboxSaleRecord = {
   orderIds: string[];
   createdAt: string;
   lastUpdatedAt: string;
+  // Issue #130 - 退款单
+  status: XboxSaleRecordStatus;
+  refundedAt: string | null;
+  refundId: string | null;
+};
+
+// 退款单 (Issue #130) — XBOX 销售记录全额退款
+export type XboxRefund = {
+  id: string;
+  originalSaleRecordId: string;
+  refundAmount: string; // 后端 Decimal 字符串
+  refundCurrency: string;
+  actualWalletId: string;
+  theoreticalWalletId: string;
+  businessDate: string | null;
+  operatorName: string | null;
+  note: string | null;
+  actualBookkeepingTxId: string | null;
+  theoreticalBookkeepingTxId: string | null;
+  createdAt: string;
+  // 列表 / 详情时后端附带的销售记录摘要 (可选)
+  saleRecord?: {
+    id: string;
+    accountId: string;
+    accountNo: string | null;
+    accountName: string | null;
+    productName: string;
+    operatorName: string;
+    salePrice: string;
+    saleCurrency: string;
+    walletItemLabel: string;
+  } | null;
+  actualWalletName?: string | null;
+  theoreticalWalletName?: string | null;
 };
 
 // 钱包设置 - 备注模板
@@ -192,12 +228,25 @@ export type XboxReconcileMapping = {
 };
 
 // 对账报告每行（一个理论值钱包 + 它配对的实际值钱包们）
+// Issue #130 - 新增 OUT 方向字段(退款), 后端在 actualWallets 每个项里也加了 outTotal
+export type XboxReconcileReportActualWallet = {
+  id: string;
+  name: string;
+  currency: string;
+  total: string;
+  outTotal?: string;
+};
+
 export type XboxReconcileReportRow = {
   theoreticalWallet: { id: string; name: string; currency: string };
-  actualWallets: { id: string; name: string; currency: string; total: string }[];
+  actualWallets: XboxReconcileReportActualWallet[];
   theoreticalTotal: string;
   actualTotal: string;
   diff: string;
+  // Issue #130 退款方向(OUT)对账, 后端可能未返回, 兜底为 "0"
+  theoreticalOutTotal?: string;
+  actualOutTotal?: string;
+  outDiff?: string;
 };
 
 export type XboxCountrySummary = {


### PR DESCRIPTION
## 关联 Issue

Closes #129
Closes #130

## 改动说明

### #129 划转单(钱包间转账)前端

- **API client**(`frontend/lib/api.ts`): `createWalletTransfer` / `listWalletTransfers` / `getWalletTransfer` / `cancelWalletTransfer`,带 snake_case → camelCase 转换 + 失败兜底
- **类型**(`frontend/types.ts`): `WalletTransfer` + `WalletTransferTransactionRef`
- **划转弹窗**(`frontend/components/wallet-transfer-modal.tsx`): 出账钱包/金额、入账钱包/金额、实时汇率(入账 / 出账)、业务日期、操作人(localStorage `taiwan-operator-name`)、备注;入账钱包下拉自动排除已选的出账钱包
- **划转记录列表**(`frontend/components/wallet-transfer-list.tsx`): 日期 / 出账 / 入账 / 汇率 / 操作人 / 备注 / 撤销;筛选钱包 + 日期 + 操作人 + 显示已撤销;撤销带 `confirm` 二次确认
- **集成**:
  - 台湾页(`taiwan-page.tsx`): 每个子钱包卡片加「划转」按钮;顶部加「划转记录」开关
  - 资产钱包页(`assets-page.tsx`): 每个非 group 钱包行加「划转」按钮;顶部加「划转记录」开关

### #130 退款单(XBOX 销售记录全额退款)前端

- **API client**(`frontend/lib/api.ts`): `createXboxRefund` / `listXboxRefunds` / `getXboxRefund` / `cancelXboxRefund`
- **类型**(`frontend/types.ts`): `XboxRefund` 新增;`XboxSaleRecord` 加 `status` / `refundedAt` / `refundId` 三字段;`XboxReconcileReportRow` 加 `theoreticalOutTotal` / `actualOutTotal` / `outDiff` 三字段,内嵌 `actualWallets` 项加可选 `outTotal`
- **退款弹窗**(`frontend/components/xbox-refund-modal.tsx`): 显示原销售记录摘要(账号/商品/客服/原售价/理论钱包);退款金额只读=原售价;实际钱包下拉默认按销售币种过滤,带「显示所有币种」开关;业务日期、操作人(同 localStorage)、备注
- **退款列表组件**(`frontend/components/xbox-refund-list.tsx`): 日期 / 原销售记录(账号 + 商品 + 客服) / 原售价 / 实际钱包(并显示理论钱包) / 操作人 / 备注 / 撤销;筛选日期范围 + 实际钱包 + 操作人
- **集成**:
  - XBOX 销售记录 Tab: `status === 'active'` 显示红色「退款」按钮(`Undo2` 图标);`status === 'refunded'` 显示红色徽章「已退款 · YYYY-MM-DD」,商品名和售价加删除线
  - XBOX 模块新增 Tab「退款」(`Undo2` 图标),挂载退款列表组件
  - XBOX 对账 Tab: 表格表头改为 9 列 — 理论值钱包 / 币种 / **理论 IN / 实际 IN / IN 差异** / **理论 OUT / 实际 OUT / OUT 差异** / 映射的实际钱包;OUT 差异 ≠ 0 行加 `bg-amber-50` 黄色高亮;实际钱包 Badge 同时显示 IN 和 OUT 金额

## 关键 UI 决定

- 划转记录在台湾页和资产钱包页都做了「头部按钮 + 切换显示」,**不占新 tab**(两个页都是平铺式,不希望再叠 tab 层)
- 退款列表在 XBOX 模块**新开一个独立 tab**(与销售记录、对账并列),因为 XBOX 已经是 tab 结构
- 对账页 OUT 三列**并入现有表格**(不另开 tab),便于一行一目了然看 IN 和 OUT 两套差异
- 实际钱包下拉默认按销售币种过滤,留「显示所有币种」开关兜底极端情况(满足任务约束 P2)
- 撤销操作统一用浏览器 `confirm` 弹窗(已在划转 list 用过这个范式)

## 自测

- [x] TypeScript 无错误 (`npm run typecheck` 通过)
- [x] Next.js production build 成功 (`npm run build` 通过, 10 个静态页面全部生成)
- [x] 验收标准已逐条满足
- [x] 不碰后端代码 (src/ 与 tests/ 未触碰)
- [x] 不破坏现有页面布局(增量加按钮 / 折叠区 / tab)

## 风险提示

- 后端 PR #131 / #132 已合并到 main,本 PR 假设后端 API 与文档描述一致;若后端 reconcile-report 返回结构未带 OUT 字段,前端兜底为 "0" 不会崩
- 撤销退款依赖后端校验实际钱包当前余额够不够加回(已实现兜底告警,但具体行为由后端定)

---
> 由 broky 实现,请 PM 审查